### PR TITLE
feat: add timeline-driven video rendering with ffmpeg export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "tellur-core",
+ "thiserror",
  "tiny-skia",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +51,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +70,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "fdeflate"
@@ -73,6 +97,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +168,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +191,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro2"
@@ -120,10 +217,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strict-num"
@@ -156,6 +265,7 @@ name = "tellur-renderer"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "indicatif",
  "tellur-core",
  "thiserror",
  "tiny-skia",
@@ -212,3 +322,85 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]

--- a/tellur-core/src/geometry.rs
+++ b/tellur-core/src/geometry.rs
@@ -122,11 +122,19 @@ pub struct AnchoredSize {
 }
 
 impl AnchoredSize {
-    /// Computes the offset for a box of `self.size` so that `self.anchor` on
-    /// it lands on `target_anchor` of a box of `target_size`. The returned
-    /// `Vec2` is the top-left position of the placed box in the target's
-    /// coordinate space.
-    pub fn snap_to(self, target_size: Vec2, target_anchor: Anchor) -> Vec2 {
-        target_anchor.point(target_size) - self.anchor.point(self.size)
+    /// Computes the offset for a box of `self.size` so that `self.anchor`
+    /// on it lands on `target_point` (already in the parent's coordinate
+    /// space). The returned `Vec2` is the top-left position of the placed
+    /// box in that coordinate space.
+    pub fn snap_to(self, target_point: Vec2) -> Vec2 {
+        target_point - self.anchor.point(self.size)
+    }
+
+    /// Snaps so that `self.anchor` lands on `target_anchor` of a parent box
+    /// of `target_size`. Convenience for the common case where the target
+    /// point is expressed as a fractional anchor on a known parent size:
+    /// equivalent to `self.snap_to(target_anchor.point(target_size))`.
+    pub fn snap_to_anchor(self, target_size: Vec2, target_anchor: Anchor) -> Vec2 {
+        self.snap_to(target_anchor.point(target_size))
     }
 }

--- a/tellur-core/src/interpolate.rs
+++ b/tellur-core/src/interpolate.rs
@@ -1,0 +1,95 @@
+//! [`Interpolate`] — linear interpolation parameterized by [`Phase`].
+//!
+//! The trait is the value-side counterpart of [`Phase::interpolate`]: the
+//! [`Phase`] holds the "where am I between 0 and 1", and the [`Interpolate`]
+//! implementation knows how to combine two values of its type given that
+//! fraction. Provide an impl for a new type to make `phase.interpolate(a, b)`
+//! work for it.
+
+use crate::geometry::{Anchor, Vec2};
+use crate::phase::Phase;
+
+/// Linear interpolation between two values of the same type, parameterized
+/// by a [`Phase`].
+pub trait Interpolate {
+    /// Returns the value at `p` between `self` (at `p == 0`) and `other`
+    /// (at `p == 1`).
+    fn interpolate(self, other: Self, p: Phase) -> Self;
+}
+
+impl Interpolate for f32 {
+    fn interpolate(self, other: Self, p: Phase) -> Self {
+        self + (other - self) * p.get()
+    }
+}
+
+impl Interpolate for Vec2 {
+    fn interpolate(self, other: Self, p: Phase) -> Self {
+        Vec2(
+            self.0.interpolate(other.0, p),
+            self.1.interpolate(other.1, p),
+        )
+    }
+}
+
+impl Interpolate for Anchor {
+    fn interpolate(self, other: Self, p: Phase) -> Self {
+        Anchor::new(
+            self.rx.interpolate(other.rx, p),
+            self.ry.interpolate(other.ry, p),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f32_endpoints() {
+        assert_eq!(2.0_f32.interpolate(5.0, Phase::ZERO), 2.0);
+        assert_eq!(2.0_f32.interpolate(5.0, Phase::ONE), 5.0);
+    }
+
+    #[test]
+    fn f32_half_is_midpoint() {
+        assert_eq!(2.0_f32.interpolate(5.0, Phase::HALF), 3.5);
+    }
+
+    #[test]
+    fn f32_handles_negative_direction() {
+        // from=5, to=2: at half should be 3.5.
+        assert_eq!(5.0_f32.interpolate(2.0, Phase::HALF), 3.5);
+    }
+
+    #[test]
+    fn vec2_endpoints() {
+        let a = Vec2(0.0, 10.0);
+        let b = Vec2(10.0, 0.0);
+        assert_eq!(a.interpolate(b, Phase::ZERO), a);
+        assert_eq!(a.interpolate(b, Phase::ONE), b);
+    }
+
+    #[test]
+    fn vec2_componentwise_midpoint() {
+        let a = Vec2(0.0, 10.0);
+        let b = Vec2(10.0, 0.0);
+        let mid = a.interpolate(b, Phase::HALF);
+        assert_eq!(mid, Vec2(5.0, 5.0));
+    }
+
+    #[test]
+    fn anchor_endpoints() {
+        let left = Anchor::CENTER_LEFT;
+        let right = Anchor::CENTER_RIGHT;
+        assert_eq!(left.interpolate(right, Phase::ZERO), left);
+        assert_eq!(left.interpolate(right, Phase::ONE), right);
+    }
+
+    #[test]
+    fn anchor_midpoint_is_center() {
+        // Halfway between left-center and right-center should be CENTER.
+        let mid = Anchor::CENTER_LEFT.interpolate(Anchor::CENTER_RIGHT, Phase::HALF);
+        assert_eq!(mid, Anchor::CENTER);
+    }
+}

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -3,4 +3,6 @@ pub mod geometry;
 pub mod layer;
 pub mod raster;
 pub mod shapes;
+pub mod time;
+pub mod timeline;
 pub mod vector;

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod color;
 pub mod geometry;
 pub mod layer;
+pub mod phase;
 pub mod raster;
 pub mod shapes;
 pub mod time;

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod color;
 pub mod geometry;
+pub mod interpolate;
 pub mod layer;
 pub mod phase;
 pub mod raster;

--- a/tellur-core/src/phase.rs
+++ b/tellur-core/src/phase.rs
@@ -118,7 +118,10 @@ mod tests {
     fn invert_is_one_minus() {
         assert_eq!(Phase::ZERO.invert(), Phase::ONE);
         assert_eq!(Phase::ONE.invert(), Phase::ZERO);
-        assert_eq!(Phase::new(0.25).unwrap().invert(), Phase::new(0.75).unwrap());
+        assert_eq!(
+            Phase::new(0.25).unwrap().invert(),
+            Phase::new(0.75).unwrap()
+        );
     }
 
     #[test]

--- a/tellur-core/src/phase.rs
+++ b/tellur-core/src/phase.rs
@@ -1,0 +1,134 @@
+//! [`Phase`] — a finite `f32` constrained to `[0.0, 1.0]`.
+//!
+//! Intended for normalized scalars such as animation progress, easing
+//! parameters, and similar "fraction of something" quantities. The type
+//! is a newtype wrapper that validates at construction so downstream code
+//! can rely on the invariant without re-checking.
+
+use std::fmt;
+
+use thiserror::Error;
+
+/// A finite `f32` constrained to the unit interval `[0.0, 1.0]` (both
+/// endpoints included).
+///
+/// Construct via [`Phase::new`] (validating) or [`Phase::saturating`]
+/// (clamping). The wrapped value is accessible through [`Phase::get`] and
+/// `Into<f32>`.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Phase(f32);
+
+impl Phase {
+    pub const ZERO: Self = Self(0.0);
+    pub const HALF: Self = Self(0.5);
+    pub const ONE: Self = Self(1.0);
+
+    /// Returns `Some(Self)` if `v` is finite and within `[0.0, 1.0]`.
+    /// `NaN`, `±inf`, or out-of-range values yield `None`.
+    pub fn new(v: f32) -> Option<Self> {
+        if v.is_finite() && (0.0..=1.0).contains(&v) {
+            Some(Self(v))
+        } else {
+            None
+        }
+    }
+
+    /// Clamps `v` to `[0.0, 1.0]`. `NaN` is treated as `0.0`.
+    pub fn saturating(v: f32) -> Self {
+        if v.is_nan() {
+            Self::ZERO
+        } else {
+            Self(v.clamp(0.0, 1.0))
+        }
+    }
+
+    /// Returns the inner value, guaranteed to be a finite `f32` in `[0.0, 1.0]`.
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+
+    /// Returns `1.0 - self`. The result is still a valid `Phase` (the
+    /// closed unit interval is closed under this reflection).
+    pub fn invert(self) -> Self {
+        Self(1.0 - self.0)
+    }
+}
+
+impl From<Phase> for f32 {
+    fn from(p: Phase) -> f32 {
+        p.0
+    }
+}
+
+impl TryFrom<f32> for Phase {
+    type Error = PhaseOutOfRange;
+    fn try_from(v: f32) -> Result<Self, Self::Error> {
+        Self::new(v).ok_or(PhaseOutOfRange(v))
+    }
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("phase value {0} is outside [0.0, 1.0] or non-finite")]
+pub struct PhaseOutOfRange(pub f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_in_range() {
+        assert_eq!(Phase::new(0.0).map(Phase::get), Some(0.0));
+        assert_eq!(Phase::new(0.5).map(Phase::get), Some(0.5));
+        assert_eq!(Phase::new(1.0).map(Phase::get), Some(1.0));
+    }
+
+    #[test]
+    fn new_rejects_out_of_range_and_non_finite() {
+        assert!(Phase::new(-0.0001).is_none());
+        assert!(Phase::new(1.0001).is_none());
+        assert!(Phase::new(f32::NAN).is_none());
+        assert!(Phase::new(f32::INFINITY).is_none());
+        assert!(Phase::new(f32::NEG_INFINITY).is_none());
+    }
+
+    #[test]
+    fn saturating_clamps_and_handles_nan() {
+        assert_eq!(Phase::saturating(-1.0).get(), 0.0);
+        assert_eq!(Phase::saturating(2.0).get(), 1.0);
+        assert_eq!(Phase::saturating(0.5).get(), 0.5);
+        assert_eq!(Phase::saturating(f32::NAN).get(), 0.0);
+    }
+
+    #[test]
+    fn invert_is_one_minus() {
+        assert_eq!(Phase::ZERO.invert(), Phase::ONE);
+        assert_eq!(Phase::ONE.invert(), Phase::ZERO);
+        assert_eq!(Phase::new(0.25).unwrap().invert(), Phase::new(0.75).unwrap());
+    }
+
+    #[test]
+    fn try_from_reports_offending_value() {
+        let err = Phase::try_from(2.5).unwrap_err();
+        assert_eq!(err.0, 2.5);
+    }
+
+    #[test]
+    fn into_f32_round_trips_via_get() {
+        let p = Phase::new(0.42).unwrap();
+        let v: f32 = p.into();
+        assert_eq!(v, p.get());
+    }
+
+    #[test]
+    fn consts_are_correct() {
+        assert_eq!(Phase::ZERO.get(), 0.0);
+        assert_eq!(Phase::HALF.get(), 0.5);
+        assert_eq!(Phase::ONE.get(), 1.0);
+    }
+}

--- a/tellur-core/src/phase.rs
+++ b/tellur-core/src/phase.rs
@@ -9,6 +9,8 @@ use std::fmt;
 
 use thiserror::Error;
 
+use crate::interpolate::Interpolate;
+
 /// A finite `f32` constrained to the unit interval `[0.0, 1.0]` (both
 /// endpoints included).
 ///
@@ -51,6 +53,13 @@ impl Phase {
     /// closed unit interval is closed under this reflection).
     pub fn invert(self) -> Self {
         Self(1.0 - self.0)
+    }
+
+    /// Linearly interpolates between `from` (at `self == 0`) and `to`
+    /// (at `self == 1`). Convenience wrapper for `from.interpolate(to, self)`
+    /// so the `Phase` reads as "the driver" in animation code.
+    pub fn interpolate<T: Interpolate>(self, from: T, to: T) -> T {
+        from.interpolate(to, self)
     }
 }
 
@@ -130,5 +139,12 @@ mod tests {
         assert_eq!(Phase::ZERO.get(), 0.0);
         assert_eq!(Phase::HALF.get(), 0.5);
         assert_eq!(Phase::ONE.get(), 1.0);
+    }
+
+    #[test]
+    fn interpolate_drives_f32_value() {
+        assert_eq!(Phase::HALF.interpolate(0.0, 10.0), 5.0);
+        assert_eq!(Phase::ZERO.interpolate(0.0, 10.0), 0.0);
+        assert_eq!(Phase::ONE.interpolate(0.0, 10.0), 10.0);
     }
 }

--- a/tellur-core/src/time.rs
+++ b/tellur-core/src/time.rs
@@ -1,91 +1,166 @@
 //! Time abstractions for timeline-driven rendering.
 //!
-//! [`Time`] represents a current playback time, measured in seconds. The
-//! combinators [`Time::during`] and [`Time::fps`] let scene code gate and
-//! quantize content along the time axis:
+//! Two concrete time types are distinguished by what coordinate space they
+//! live in:
+//!
+//! - [`TimelineTime`] — a point on the global timeline. This is what
+//!   [`crate::timeline::Timeline::build`] receives.
+//! - [`LocalTime`] — a remapped time, produced by [`Time::during_ripple`]
+//!   or [`Time::lerp`]. Its `seconds()` is no longer relative to the global
+//!   timeline origin but to whatever local frame the remap established.
+//!
+//! Both implement the [`Time`] trait, which provides the gating /
+//! remapping / quantization combinators. The trait methods are defaulted so
+//! the operations work identically on either type; the only difference is
+//! which type a method returns.
 //!
 //! ```ignore
-//! if let Some(t) = t.during(3.0, 5.0).fps(24) {
-//!     // Runs only when the outer time is in `[3.0, 5.0)`,
-//!     // with `t.seconds()` in `[0.0, 2.0)` quantized to 1/24s steps.
+//! // `t: TimelineTime` from Timeline::build.
+//! if let Some(t) = t.during(3.0, 5.0) {
+//!     // Pure gate: `t` is still `TimelineTime`, `t.seconds()` ∈ [3.0, 5.0).
 //! }
+//!
+//! if let Some(t) = t.during_ripple(3.0, 5.0) {
+//!     // Gate + rebase: `t` is `LocalTime`, `t.seconds()` ∈ [0.0, 2.0).
+//! }
+//!
+//! let warped = t.lerp((3.0, 5.0), (0.0, 4.0));
+//! // `warped: LocalTime`, 2x speed of the [3, 5) source range.
 //! ```
-//!
-//! `during` rebases time to start at zero inside the gated block, so child
-//! animations can be authored in their own local timeline. `fps` floors
-//! `seconds` to multiples of `1/fps`, useful for stop-motion or stutter
-//! effects.
-//!
-//! [`TimeOptionExt`] extends `Option<T: Time>` with the same combinators so
-//! they can be chained across a `during` that may return `None`.
 
-/// A point in time on a timeline, measured in seconds from the start.
-pub trait Time: Copy {
-    /// Current time in seconds.
+/// A point in time, measured in seconds.
+///
+/// All combinators (`during`, `during_ripple`, `lerp`, `fps`) are provided
+/// as default methods so implementors only need to express their own
+/// representation via [`Self::seconds`] and [`Self::from_seconds`].
+pub trait Time: Copy + Sized {
     fn seconds(&self) -> f32;
+    fn from_seconds(seconds: f32) -> Self;
 
-    /// Returns `Some(t)` when the current time is within `[start, end)`,
-    /// where `t.seconds()` is rebased to start at zero (relative time).
-    /// Returns `None` otherwise.
-    fn during(&self, start: f32, end: f32) -> Option<TimeView>;
-
-    /// Returns a time floored to the nearest `1/fps` second boundary.
-    /// Causes the rendered output to advance in `fps`-Hz steps regardless
-    /// of the encoder's frame rate.
-    fn fps(&self, fps: u32) -> TimeView;
-}
-
-/// A concrete [`Time`] value. Returned by [`Time::during`] and [`Time::fps`]
-/// so the combinators can be chained without forcing a particular root type.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TimeView {
-    seconds: f32,
-}
-
-impl TimeView {
-    pub const fn new(seconds: f32) -> Self {
-        Self { seconds }
-    }
-}
-
-impl Time for TimeView {
-    fn seconds(&self) -> f32 {
-        self.seconds
-    }
-
-    fn during(&self, start: f32, end: f32) -> Option<TimeView> {
-        if self.seconds >= start && self.seconds < end {
-            Some(TimeView::new(self.seconds - start))
+    /// Gate-only combinator: returns `Some(self)` (unchanged time, same type)
+    /// when `seconds()` is within `[start, end)`, otherwise `None`. Useful
+    /// when you want to keep operating in the original coordinate system.
+    fn during(&self, start: f32, end: f32) -> Option<Self> {
+        let s = self.seconds();
+        if s >= start && s < end {
+            Some(*self)
         } else {
             None
         }
     }
 
-    fn fps(&self, fps: u32) -> TimeView {
-        // `fps == 0` would divide by zero; treat it as "no quantization".
+    /// Gate + rebase to zero: returns `Some(LocalTime)` whose `seconds()`
+    /// starts at zero when `self` is within `[start, end)`. Outside the
+    /// range, returns `None`. Use this to open a fresh local timeline for
+    /// the gated block.
+    fn during_ripple(&self, start: f32, end: f32) -> Option<LocalTime> {
+        let s = self.seconds();
+        if s >= start && s < end {
+            Some(LocalTime::from_seconds(s - start))
+        } else {
+            None
+        }
+    }
+
+    /// Affine remap from `src` to `dst`. Outside `src`, the mapping is
+    /// extrapolated linearly (no clamping, no gating). The output is always
+    /// a [`LocalTime`] because the warp invalidates any prior coordinate
+    /// system.
+    fn lerp(&self, src: (f32, f32), dst: (f32, f32)) -> LocalTime {
+        let u = (self.seconds() - src.0) / (src.1 - src.0);
+        LocalTime::from_seconds(dst.0 + u * (dst.1 - dst.0))
+    }
+
+    /// Floors `seconds()` to a `1/fps`-second grid. Type is preserved, so
+    /// quantizing a [`TimelineTime`] yields a [`TimelineTime`] (and likewise
+    /// for [`LocalTime`]). `fps == 0` is treated as "no quantization".
+    fn fps(&self, fps: u32) -> Self {
         if fps == 0 {
             return *self;
         }
         let step = 1.0 / fps as f32;
-        let quantized = (self.seconds / step).floor() * step;
-        TimeView::new(quantized)
+        Self::from_seconds((self.seconds() / step).floor() * step)
     }
 }
 
-/// Extension trait that mirrors [`Time`] on `Option<T: Time>` so chains like
-/// `t.during(3.0, 5.0).fps(24)` type-check: a `during` that yields `None`
-/// propagates through the chain instead of forcing the caller to unwrap.
-pub trait TimeOptionExt {
-    fn during(self, start: f32, end: f32) -> Option<TimeView>;
-    fn fps(self, fps: u32) -> Option<TimeView>;
+/// A point on the global timeline that a [`crate::timeline::Timeline`] is
+/// being sampled at. Produced by the renderer; users typically don't
+/// construct it directly.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TimelineTime {
+    seconds: f32,
 }
 
-impl<T: Time> TimeOptionExt for Option<T> {
-    fn during(self, start: f32, end: f32) -> Option<TimeView> {
+impl TimelineTime {
+    pub const fn new(seconds: f32) -> Self {
+        Self { seconds }
+    }
+}
+
+impl Time for TimelineTime {
+    fn seconds(&self) -> f32 {
+        self.seconds
+    }
+    fn from_seconds(seconds: f32) -> Self {
+        Self { seconds }
+    }
+}
+
+/// A remapped time, no longer relative to the global timeline origin.
+/// Produced by [`Time::during_ripple`] and [`Time::lerp`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LocalTime {
+    seconds: f32,
+}
+
+impl LocalTime {
+    pub const fn new(seconds: f32) -> Self {
+        Self { seconds }
+    }
+}
+
+impl Time for LocalTime {
+    fn seconds(&self) -> f32 {
+        self.seconds
+    }
+    fn from_seconds(seconds: f32) -> Self {
+        Self { seconds }
+    }
+}
+
+/// `TimelineTime` converts into `LocalTime` by treating the timeline
+/// position as the local-frame value. This lets components that only
+/// care about "some clock value, in seconds" accept either type via a
+/// single `.into()` at the call site instead of being generic over
+/// [`Time`].
+impl From<TimelineTime> for LocalTime {
+    fn from(t: TimelineTime) -> Self {
+        Self {
+            seconds: t.seconds,
+        }
+    }
+}
+
+/// Mirrors [`Time`] on `Option<T: Time>` so combinators can be chained
+/// across operations that may yield `None` (e.g., `during`/`during_ripple`).
+pub trait TimeOptionExt<T: Time> {
+    fn during(self, start: f32, end: f32) -> Option<T>;
+    fn during_ripple(self, start: f32, end: f32) -> Option<LocalTime>;
+    fn lerp(self, src: (f32, f32), dst: (f32, f32)) -> Option<LocalTime>;
+    fn fps(self, fps: u32) -> Option<T>;
+}
+
+impl<T: Time> TimeOptionExt<T> for Option<T> {
+    fn during(self, start: f32, end: f32) -> Option<T> {
         self.and_then(|t| t.during(start, end))
     }
-
-    fn fps(self, fps: u32) -> Option<TimeView> {
+    fn during_ripple(self, start: f32, end: f32) -> Option<LocalTime> {
+        self.and_then(|t| t.during_ripple(start, end))
+    }
+    fn lerp(self, src: (f32, f32), dst: (f32, f32)) -> Option<LocalTime> {
+        self.map(|t| t.lerp(src, dst))
+    }
+    fn fps(self, fps: u32) -> Option<T> {
         self.map(|t| t.fps(fps))
     }
 }
@@ -95,54 +170,99 @@ mod tests {
     use super::*;
 
     #[test]
-    fn during_outside_range_returns_none() {
-        let t = TimeView::new(2.0);
+    fn during_gates_without_rebase_and_preserves_type() {
+        let t = TimelineTime::new(4.2);
+        let gated = t.during(3.0, 5.0).expect("in range");
+        // Type preserved (TimelineTime → TimelineTime) and seconds unchanged.
+        assert_eq!(gated, TimelineTime::new(4.2));
+    }
+
+    #[test]
+    fn during_out_of_range_is_none() {
+        let t = TimelineTime::new(2.0);
         assert!(t.during(3.0, 5.0).is_none());
-
-        let t = TimeView::new(5.0);
-        assert!(t.during(3.0, 5.0).is_none(), "end is exclusive");
-
-        let t = TimeView::new(6.0);
+        // End is exclusive.
+        let t = TimelineTime::new(5.0);
         assert!(t.during(3.0, 5.0).is_none());
     }
 
     #[test]
-    fn during_inside_range_rebases_to_zero() {
-        let t = TimeView::new(3.0);
-        assert_eq!(t.during(3.0, 5.0), Some(TimeView::new(0.0)));
-
-        let t = TimeView::new(4.2);
-        let inner = t.during(3.0, 5.0).expect("in range");
-        assert!((inner.seconds() - 1.2).abs() < 1e-6);
+    fn during_ripple_rebases_to_local_time() {
+        let t = TimelineTime::new(4.2);
+        let local = t.during_ripple(3.0, 5.0).expect("in range");
+        assert!((local.seconds() - 1.2).abs() < 1e-6);
     }
 
     #[test]
-    fn fps_floors_to_step() {
-        let t = TimeView::new(1.234);
-        // 24fps step = ~0.04167s; floor(1.234 / 0.04167) = 29 -> 29 * 0.04167 ≈ 1.2083
+    fn during_ripple_out_of_range_is_none() {
+        let t = TimelineTime::new(6.0);
+        assert!(t.during_ripple(3.0, 5.0).is_none());
+    }
+
+    #[test]
+    fn lerp_inside_src_maps_linearly() {
+        let t = TimelineTime::new(4.0);
+        // (3, 5) → (0, 4): width-doubling, t=4 is halfway → output 2.0.
+        let out = t.lerp((3.0, 5.0), (0.0, 4.0));
+        assert!((out.seconds() - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn lerp_outside_src_extrapolates() {
+        let t = TimelineTime::new(2.0);
+        // (3, 5) → (0, 4): t=2 is one unit before src start, so u = -0.5,
+        // output = 0 + (-0.5) * 4 = -2.0.
+        let out = t.lerp((3.0, 5.0), (0.0, 4.0));
+        assert!((out.seconds() - (-2.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fps_floors_and_preserves_type() {
+        let t = TimelineTime::new(1.234);
         let q = t.fps(24);
         let expected = (29.0_f32) / 24.0;
         assert!((q.seconds() - expected).abs() < 1e-5);
+        // Type preserved.
+        let _is_timeline_time: TimelineTime = q;
     }
 
     #[test]
-    fn fps_zero_passes_through() {
-        let t = TimeView::new(1.234);
+    fn fps_zero_is_identity() {
+        let t = TimelineTime::new(1.234);
         assert_eq!(t.fps(0), t);
     }
 
     #[test]
-    fn option_chain_during_then_fps() {
-        let t = TimeView::new(4.5);
-        let chained = t.during(3.0, 5.0).fps(24);
-        // Inner relative time = 1.5; 24fps step = 1/24; floor(1.5 / (1/24)) = 36 -> 1.5
+    fn local_time_supports_same_ops() {
+        let t = LocalTime::new(0.8);
+        // during preserves LocalTime → LocalTime.
+        let gated: LocalTime = t.during(0.0, 1.0).expect("in range");
+        assert_eq!(gated, LocalTime::new(0.8));
+        // during_ripple yields LocalTime regardless.
+        let rerebased = t.during_ripple(0.5, 1.0).expect("in range");
+        assert!((rerebased.seconds() - 0.3).abs() < 1e-6);
+    }
+
+    #[test]
+    fn option_chain_during_then_during_ripple() {
+        let t = TimelineTime::new(4.5);
+        let chained = t.during(3.0, 5.0).during_ripple(3.0, 5.0);
         let inner = chained.expect("in range");
-        assert!((inner.seconds() - 1.5).abs() < 1e-5);
+        assert!((inner.seconds() - 1.5).abs() < 1e-6);
     }
 
     #[test]
     fn option_chain_propagates_none() {
-        let t = TimeView::new(10.0);
-        assert!(t.during(3.0, 5.0).fps(24).is_none());
+        let t = TimelineTime::new(10.0);
+        assert!(t.during(3.0, 5.0).during_ripple(3.0, 5.0).is_none());
+        assert!(t.during_ripple(3.0, 5.0).fps(24).is_none());
+    }
+
+    #[test]
+    fn option_chain_lerp_is_always_some() {
+        let t = TimelineTime::new(4.0);
+        let warped = t.during(3.0, 5.0).lerp((3.0, 5.0), (0.0, 4.0));
+        // 4.0 maps to 2.0 (halfway of dst).
+        assert!((warped.expect("in range").seconds() - 2.0).abs() < 1e-6);
     }
 }

--- a/tellur-core/src/time.rs
+++ b/tellur-core/src/time.rs
@@ -1,0 +1,148 @@
+//! Time abstractions for timeline-driven rendering.
+//!
+//! [`Time`] represents a current playback time, measured in seconds. The
+//! combinators [`Time::during`] and [`Time::fps`] let scene code gate and
+//! quantize content along the time axis:
+//!
+//! ```ignore
+//! if let Some(t) = t.during(3.0, 5.0).fps(24) {
+//!     // Runs only when the outer time is in `[3.0, 5.0)`,
+//!     // with `t.seconds()` in `[0.0, 2.0)` quantized to 1/24s steps.
+//! }
+//! ```
+//!
+//! `during` rebases time to start at zero inside the gated block, so child
+//! animations can be authored in their own local timeline. `fps` floors
+//! `seconds` to multiples of `1/fps`, useful for stop-motion or stutter
+//! effects.
+//!
+//! [`TimeOptionExt`] extends `Option<T: Time>` with the same combinators so
+//! they can be chained across a `during` that may return `None`.
+
+/// A point in time on a timeline, measured in seconds from the start.
+pub trait Time: Copy {
+    /// Current time in seconds.
+    fn seconds(&self) -> f32;
+
+    /// Returns `Some(t)` when the current time is within `[start, end)`,
+    /// where `t.seconds()` is rebased to start at zero (relative time).
+    /// Returns `None` otherwise.
+    fn during(&self, start: f32, end: f32) -> Option<TimeView>;
+
+    /// Returns a time floored to the nearest `1/fps` second boundary.
+    /// Causes the rendered output to advance in `fps`-Hz steps regardless
+    /// of the encoder's frame rate.
+    fn fps(&self, fps: u32) -> TimeView;
+}
+
+/// A concrete [`Time`] value. Returned by [`Time::during`] and [`Time::fps`]
+/// so the combinators can be chained without forcing a particular root type.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TimeView {
+    seconds: f32,
+}
+
+impl TimeView {
+    pub const fn new(seconds: f32) -> Self {
+        Self { seconds }
+    }
+}
+
+impl Time for TimeView {
+    fn seconds(&self) -> f32 {
+        self.seconds
+    }
+
+    fn during(&self, start: f32, end: f32) -> Option<TimeView> {
+        if self.seconds >= start && self.seconds < end {
+            Some(TimeView::new(self.seconds - start))
+        } else {
+            None
+        }
+    }
+
+    fn fps(&self, fps: u32) -> TimeView {
+        // `fps == 0` would divide by zero; treat it as "no quantization".
+        if fps == 0 {
+            return *self;
+        }
+        let step = 1.0 / fps as f32;
+        let quantized = (self.seconds / step).floor() * step;
+        TimeView::new(quantized)
+    }
+}
+
+/// Extension trait that mirrors [`Time`] on `Option<T: Time>` so chains like
+/// `t.during(3.0, 5.0).fps(24)` type-check: a `during` that yields `None`
+/// propagates through the chain instead of forcing the caller to unwrap.
+pub trait TimeOptionExt {
+    fn during(self, start: f32, end: f32) -> Option<TimeView>;
+    fn fps(self, fps: u32) -> Option<TimeView>;
+}
+
+impl<T: Time> TimeOptionExt for Option<T> {
+    fn during(self, start: f32, end: f32) -> Option<TimeView> {
+        self.and_then(|t| t.during(start, end))
+    }
+
+    fn fps(self, fps: u32) -> Option<TimeView> {
+        self.map(|t| t.fps(fps))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn during_outside_range_returns_none() {
+        let t = TimeView::new(2.0);
+        assert!(t.during(3.0, 5.0).is_none());
+
+        let t = TimeView::new(5.0);
+        assert!(t.during(3.0, 5.0).is_none(), "end is exclusive");
+
+        let t = TimeView::new(6.0);
+        assert!(t.during(3.0, 5.0).is_none());
+    }
+
+    #[test]
+    fn during_inside_range_rebases_to_zero() {
+        let t = TimeView::new(3.0);
+        assert_eq!(t.during(3.0, 5.0), Some(TimeView::new(0.0)));
+
+        let t = TimeView::new(4.2);
+        let inner = t.during(3.0, 5.0).expect("in range");
+        assert!((inner.seconds() - 1.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fps_floors_to_step() {
+        let t = TimeView::new(1.234);
+        // 24fps step = ~0.04167s; floor(1.234 / 0.04167) = 29 -> 29 * 0.04167 ≈ 1.2083
+        let q = t.fps(24);
+        let expected = (29.0_f32) / 24.0;
+        assert!((q.seconds() - expected).abs() < 1e-5);
+    }
+
+    #[test]
+    fn fps_zero_passes_through() {
+        let t = TimeView::new(1.234);
+        assert_eq!(t.fps(0), t);
+    }
+
+    #[test]
+    fn option_chain_during_then_fps() {
+        let t = TimeView::new(4.5);
+        let chained = t.during(3.0, 5.0).fps(24);
+        // Inner relative time = 1.5; 24fps step = 1/24; floor(1.5 / (1/24)) = 36 -> 1.5
+        let inner = chained.expect("in range");
+        assert!((inner.seconds() - 1.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn option_chain_propagates_none() {
+        let t = TimeView::new(10.0);
+        assert!(t.during(3.0, 5.0).fps(24).is_none());
+    }
+}

--- a/tellur-core/src/time.rs
+++ b/tellur-core/src/time.rs
@@ -10,8 +10,10 @@
 //!   timeline origin but to whatever local frame the remap established.
 //!
 //! Both implement the [`Time`] trait, which provides the gating /
-//! remapping / quantization combinators. The trait methods are defaulted so
-//! the operations work identically on either type; the only difference is
+//! remapping / quantization combinators, plus periodic decompositions
+//! ([`Time::cycle`], [`Time::bounce`]) and range mapping ([`Time::phase`])
+//! that return a [`Phase`]. The trait methods are defaulted so the
+//! operations work identically on either type; the only difference is
 //! which type a method returns.
 //!
 //! ```ignore
@@ -28,11 +30,14 @@
 //! // `warped: LocalTime`, 2x speed of the [3, 5) source range.
 //! ```
 
+use crate::phase::Phase;
+
 /// A point in time, measured in seconds.
 ///
-/// All combinators (`during`, `during_ripple`, `lerp`, `fps`) are provided
-/// as default methods so implementors only need to express their own
-/// representation via [`Self::seconds`] and [`Self::from_seconds`].
+/// All combinators (`during`, `during_ripple`, `lerp`, `fps`, `cycle`,
+/// `bounce`, `phase`) are provided as default methods so implementors only
+/// need to express their own representation via [`Self::seconds`] and
+/// [`Self::from_seconds`].
 pub trait Time: Copy + Sized {
     fn seconds(&self) -> f32;
     fn from_seconds(seconds: f32) -> Self;
@@ -80,6 +85,47 @@ pub trait Time: Copy + Sized {
         }
         let step = 1.0 / fps as f32;
         Self::from_seconds((self.seconds() / step).floor() * step)
+    }
+
+    /// Decomposes time into `(phase within the current cycle, cycle index)`,
+    /// where one cycle spans `period` seconds starting at `seconds() == 0`.
+    /// The phase rises linearly from 0 to 1 across each cycle; the cycle
+    /// index is the floor of `seconds() / period` and can be negative when
+    /// time precedes the zero point.
+    fn cycle(&self, period: f32) -> (Phase, i32) {
+        self.cycle_with_zero(period, 0.0)
+    }
+
+    /// Like [`Self::cycle`] but treats `zero` as the start of cycle 0 — i.e.,
+    /// the cycle boundary nearest the start of the animation can be shifted
+    /// to an arbitrary timeline position.
+    fn cycle_with_zero(&self, period: f32, zero: f32) -> (Phase, i32) {
+        let s = self.seconds() - zero;
+        let cycle = (s / period).floor() as i32;
+        let p = s.rem_euclid(period) / period;
+        (Phase::saturating(p), cycle)
+    }
+
+    /// Triangle-wave decomposition: `phase` rises from 0 → 1 across the first
+    /// half of each `period`-second cycle and falls 1 → 0 across the second
+    /// half. Cycle index increments at every full period boundary.
+    fn bounce(&self, period: f32) -> (Phase, i32) {
+        self.bounce_with_zero(period, 0.0)
+    }
+
+    /// Like [`Self::bounce`] but with `zero` as the start of cycle 0.
+    fn bounce_with_zero(&self, period: f32, zero: f32) -> (Phase, i32) {
+        let (p, c) = self.cycle_with_zero(period, zero);
+        let triangle = 1.0 - (2.0 * p.get() - 1.0).abs();
+        (Phase::saturating(triangle), c)
+    }
+
+    /// Maps `[start, end]` to `[0.0, 1.0]` linearly, clamping outside.
+    /// Useful for driving an easing or interpolation whose input is a
+    /// [`Phase`] rather than a raw time value.
+    fn phase(&self, start: f32, end: f32) -> Phase {
+        let u = (self.seconds() - start) / (end - start);
+        Phase::saturating(u)
     }
 }
 
@@ -148,6 +194,11 @@ pub trait TimeOptionExt<T: Time> {
     fn during_ripple(self, start: f32, end: f32) -> Option<LocalTime>;
     fn lerp(self, src: (f32, f32), dst: (f32, f32)) -> Option<LocalTime>;
     fn fps(self, fps: u32) -> Option<T>;
+    fn cycle(self, period: f32) -> Option<(Phase, i32)>;
+    fn cycle_with_zero(self, period: f32, zero: f32) -> Option<(Phase, i32)>;
+    fn bounce(self, period: f32) -> Option<(Phase, i32)>;
+    fn bounce_with_zero(self, period: f32, zero: f32) -> Option<(Phase, i32)>;
+    fn phase(self, start: f32, end: f32) -> Option<Phase>;
 }
 
 impl<T: Time> TimeOptionExt<T> for Option<T> {
@@ -162,6 +213,21 @@ impl<T: Time> TimeOptionExt<T> for Option<T> {
     }
     fn fps(self, fps: u32) -> Option<T> {
         self.map(|t| t.fps(fps))
+    }
+    fn cycle(self, period: f32) -> Option<(Phase, i32)> {
+        self.map(|t| t.cycle(period))
+    }
+    fn cycle_with_zero(self, period: f32, zero: f32) -> Option<(Phase, i32)> {
+        self.map(|t| t.cycle_with_zero(period, zero))
+    }
+    fn bounce(self, period: f32) -> Option<(Phase, i32)> {
+        self.map(|t| t.bounce(period))
+    }
+    fn bounce_with_zero(self, period: f32, zero: f32) -> Option<(Phase, i32)> {
+        self.map(|t| t.bounce_with_zero(period, zero))
+    }
+    fn phase(self, start: f32, end: f32) -> Option<Phase> {
+        self.map(|t| t.phase(start, end))
     }
 }
 
@@ -264,5 +330,95 @@ mod tests {
         let warped = t.during(3.0, 5.0).lerp((3.0, 5.0), (0.0, 4.0));
         // 4.0 maps to 2.0 (halfway of dst).
         assert!((warped.expect("in range").seconds() - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cycle_decomposes_into_phase_and_index() {
+        let t = TimelineTime::new(2.5);
+        let (p, c) = t.cycle(1.0);
+        assert_eq!(c, 2);
+        assert!((p.get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cycle_at_period_boundary_advances_to_next_cycle() {
+        let t = TimelineTime::new(1.0);
+        let (p, c) = t.cycle(1.0);
+        assert_eq!(c, 1);
+        assert_eq!(p.get(), 0.0);
+    }
+
+    #[test]
+    fn cycle_handles_negative_time() {
+        let t = LocalTime::new(-0.3);
+        let (p, c) = t.cycle(1.0);
+        assert_eq!(c, -1);
+        assert!((p.get() - 0.7).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cycle_with_zero_shifts_origin() {
+        let t = TimelineTime::new(3.0);
+        // zero at 2.5, period 1.0 → effective offset of 0.5 into cycle 0.
+        let (p, c) = t.cycle_with_zero(1.0, 2.5);
+        assert_eq!(c, 0);
+        assert!((p.get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bounce_peaks_at_half_period() {
+        let t = TimelineTime::new(0.5);
+        let (p, c) = t.bounce(1.0);
+        assert_eq!(c, 0);
+        assert!((p.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bounce_is_zero_at_period_boundaries() {
+        let (p0, _) = TimelineTime::new(0.0).bounce(1.0);
+        assert_eq!(p0.get(), 0.0);
+        let (p1, c1) = TimelineTime::new(1.0).bounce(1.0);
+        assert_eq!(p1.get(), 0.0);
+        assert_eq!(c1, 1);
+        let (p2, c2) = TimelineTime::new(2.0).bounce(1.0);
+        assert_eq!(p2.get(), 0.0);
+        assert_eq!(c2, 2);
+    }
+
+    #[test]
+    fn bounce_with_zero_offsets_phase() {
+        // zero at 0.5, period 1.0 → at t=1.0, effective t' = 0.5, bounce peak.
+        let t = TimelineTime::new(1.0);
+        let (p, c) = t.bounce_with_zero(1.0, 0.5);
+        assert_eq!(c, 0);
+        assert!((p.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn phase_maps_range_to_unit_interval() {
+        let t = TimelineTime::new(4.0);
+        // (4 - 3) / (5 - 3) = 0.5
+        assert_eq!(t.phase(3.0, 5.0).get(), 0.5);
+    }
+
+    #[test]
+    fn phase_clamps_outside_range() {
+        let before = TimelineTime::new(2.0);
+        assert_eq!(before.phase(3.0, 5.0), Phase::ZERO);
+        let after = TimelineTime::new(6.0);
+        assert_eq!(after.phase(3.0, 5.0), Phase::ONE);
+    }
+
+    #[test]
+    fn option_chain_phase_propagates_some() {
+        let t = TimelineTime::new(4.0);
+        let p = t.during(3.0, 5.0).phase(3.0, 5.0);
+        assert_eq!(p.map(Phase::get), Some(0.5));
+    }
+
+    #[test]
+    fn option_chain_cycle_propagates_none() {
+        let t = TimelineTime::new(10.0);
+        assert!(t.during(3.0, 5.0).cycle(1.0).is_none());
     }
 }

--- a/tellur-core/src/time.rs
+++ b/tellur-core/src/time.rs
@@ -181,9 +181,7 @@ impl Time for LocalTime {
 /// [`Time`].
 impl From<TimelineTime> for LocalTime {
     fn from(t: TimelineTime) -> Self {
-        Self {
-            seconds: t.seconds,
-        }
+        Self { seconds: t.seconds }
     }
 }
 

--- a/tellur-core/src/timeline.rs
+++ b/tellur-core/src/timeline.rs
@@ -1,12 +1,12 @@
 //! Time-driven scene description.
 //!
-//! A [`Timeline`] produces a [`RasterImage`] for any given [`TimeView`] within
+//! A [`Timeline`] produces a [`RasterImage`] for any given [`TimelineTime`] within
 //! its `duration`. Renderers walk the timeline frame by frame to produce a
 //! video. The shape of `build` mirrors [`crate::raster::RasterComponent`] so
 //! the same `target: Resolution` flow works.
 
 use crate::raster::{RasterImage, Resolution};
-use crate::time::TimeView;
+use crate::time::TimelineTime;
 
 /// A scene defined over a finite time interval.
 pub trait Timeline {
@@ -14,14 +14,14 @@ pub trait Timeline {
     fn duration(&self) -> f32;
 
     /// Produces the frame for `t` at the requested `target` resolution.
-    fn build(&self, t: TimeView, target: Resolution) -> RasterImage;
+    fn build(&self, t: TimelineTime, target: Resolution) -> RasterImage;
 }
 
 /// Builds a [`Timeline`] from a closure. The closure receives the current
 /// time and the target resolution, and returns the rasterized frame.
 pub fn timeline<F>(duration: f32, build: F) -> impl Timeline
 where
-    F: Fn(TimeView, Resolution) -> RasterImage,
+    F: Fn(TimelineTime, Resolution) -> RasterImage,
 {
     FnTimeline { duration, build }
 }
@@ -33,13 +33,13 @@ struct FnTimeline<F> {
 
 impl<F> Timeline for FnTimeline<F>
 where
-    F: Fn(TimeView, Resolution) -> RasterImage,
+    F: Fn(TimelineTime, Resolution) -> RasterImage,
 {
     fn duration(&self) -> f32 {
         self.duration
     }
 
-    fn build(&self, t: TimeView, target: Resolution) -> RasterImage {
+    fn build(&self, t: TimelineTime, target: Resolution) -> RasterImage {
         (self.build)(t, target)
     }
 }

--- a/tellur-core/src/timeline.rs
+++ b/tellur-core/src/timeline.rs
@@ -1,0 +1,48 @@
+//! Time-driven scene description.
+//!
+//! A [`Timeline`] produces a [`RasterImage`] for any given [`TimeView`] within
+//! its `duration`. Renderers walk the timeline frame by frame to produce a
+//! video. The shape of `build` mirrors [`crate::raster::RasterComponent`] so
+//! the same `target: Resolution` flow works.
+
+use crate::raster::{RasterImage, Resolution};
+use crate::time::TimeView;
+
+/// A scene defined over a finite time interval.
+pub trait Timeline {
+    /// Total length of the timeline, in seconds.
+    fn duration(&self) -> f32;
+
+    /// Produces the frame for `t` at the requested `target` resolution.
+    fn build(&self, t: TimeView, target: Resolution) -> RasterImage;
+}
+
+/// Builds a [`Timeline`] from a closure. The closure receives the current
+/// time and the target resolution, and returns the rasterized frame.
+pub fn timeline<F>(duration: f32, build: F) -> impl Timeline
+where
+    F: Fn(TimeView, Resolution) -> RasterImage,
+{
+    FnTimeline { duration, build }
+}
+
+struct FnTimeline<F> {
+    duration: f32,
+    build: F,
+}
+
+impl<F> Timeline for FnTimeline<F>
+where
+    F: Fn(TimeView, Resolution) -> RasterImage,
+{
+    fn duration(&self) -> f32 {
+        self.duration
+    }
+
+    fn build(&self, t: TimeView, target: Resolution) -> RasterImage {
+        (self.build)(t, target)
+    }
+}
+
+// Compile-time guarantee that `Timeline` is dyn-safe.
+const _: Option<&dyn Timeline> = None;

--- a/tellur-renderer/Cargo.toml
+++ b/tellur-renderer/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 bytes = "1.11.1"
 tellur-core = { path = "../tellur-core" }
+thiserror = "2.0.18"
 tiny-skia = "0.12.0"

--- a/tellur-renderer/Cargo.toml
+++ b/tellur-renderer/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.11.1"
+indicatif = "0.18.4"
 tellur-core = { path = "../tellur-core" }
 thiserror = "2.0.18"
 tiny-skia = "0.12.0"

--- a/tellur-renderer/examples/raster_layer_to_png.rs
+++ b/tellur-renderer/examples/raster_layer_to_png.rs
@@ -55,7 +55,7 @@ fn main() {
     scene.add(
         red.view_box()
             .anchor(Anchor::CENTER)
-            .snap_to(scene.size, Anchor::new(0.4, 0.4)),
+            .snap_to_anchor(scene.size, Anchor::new(0.4, 0.4)),
         red,
     );
 
@@ -68,7 +68,7 @@ fn main() {
         green
             .view_box()
             .anchor(Anchor::CENTER)
-            .snap_to(scene.size, Anchor::new(0.6, 0.4)),
+            .snap_to_anchor(scene.size, Anchor::new(0.6, 0.4)),
         green,
     );
 
@@ -80,7 +80,7 @@ fn main() {
     scene.add(
         blue.view_box()
             .anchor(Anchor::CENTER)
-            .snap_to(scene.size, Anchor::new(0.5, 0.65)),
+            .snap_to_anchor(scene.size, Anchor::new(0.5, 0.65)),
         blue,
     );
 

--- a/tellur-renderer/examples/scene_to_png.rs
+++ b/tellur-renderer/examples/scene_to_png.rs
@@ -29,7 +29,7 @@ fn main() {
         square
             .view_box()
             .anchor(Anchor::TOP_LEFT)
-            .snap_to(scene.size, Anchor::TOP_LEFT),
+            .snap_to_anchor(scene.size, Anchor::TOP_LEFT),
         square,
     );
 
@@ -42,7 +42,7 @@ fn main() {
         circle
             .view_box()
             .anchor(Anchor::BOTTOM_RIGHT)
-            .snap_to(scene.size, Anchor::BOTTOM_RIGHT),
+            .snap_to_anchor(scene.size, Anchor::BOTTOM_RIGHT),
         circle,
     );
 

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -42,21 +42,24 @@ impl VectorComponent for BouncingDot {
     }
 
     fn render(&self) -> VectorGraphic {
-        // phase ∈ [0, 1) over one period.
-        let phase = self.t.seconds().rem_euclid(Self::PERIOD) / Self::PERIOD;
-        // Triangle wave: 0 → 1 → 0 over one period.
-        let normalized = 1.0 - (2.0 * phase - 1.0).abs();
-        let travel = self.scene_width - 2.0 * (Self::SIDE_PADDING + Self::RADIUS);
-        let center_x = Self::SIDE_PADDING + Self::RADIUS + normalized * travel;
+        let (phase, _) = self.t.bounce(Self::PERIOD);
+        // The dot bounces between two points, vertically centered in the track.
+        let center_y = self.view_box().1 * 0.5;
+        let target = phase.interpolate(
+            Vec2(Self::SIDE_PADDING + Self::RADIUS, center_y),
+            Vec2(self.scene_width - Self::SIDE_PADDING - Self::RADIUS, center_y),
+        );
+
+        let circle = Circle {
+            radius: Self::RADIUS,
+            fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
+            stroke: None,
+        };
 
         let mut layer = VectorLayer::new(self.view_box());
         layer.add(
-            Vec2(center_x - Self::RADIUS, 0.0),
-            Circle {
-                radius: Self::RADIUS,
-                fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
-                stroke: None,
-            },
+            circle.view_box().anchor(Anchor::CENTER).snap_to(target),
+            circle,
         );
         layer.render()
     }
@@ -87,7 +90,7 @@ fn main() {
             let position = dot
                 .view_box()
                 .anchor(Anchor::CENTER_LEFT)
-                .snap_to(scene_size, stripe_anchor);
+                .snap_to_anchor(scene_size, stripe_anchor);
             scene.add(position, dot);
         }
 

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -95,7 +95,7 @@ fn main() {
     });
 
     let out = Path::new("/tmp/timeline.mp4");
-    FfmpegEncoder::new(Resolution::new(1280, 720), 60)
+    FfmpegEncoder::new(Resolution::new(1920, 1080), 60)
         .args(["-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "20"])
         .encode(&tl, out)
         .expect("encode mp4");

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -47,7 +47,10 @@ impl VectorComponent for BouncingDot {
         let center_y = self.view_box().1 * 0.5;
         let target = phase.interpolate(
             Vec2(Self::SIDE_PADDING + Self::RADIUS, center_y),
-            Vec2(self.scene_width - Self::SIDE_PADDING - Self::RADIUS, center_y),
+            Vec2(
+                self.scene_width - Self::SIDE_PADDING - Self::RADIUS,
+                center_y,
+            ),
         );
 
         let circle = Circle {

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -1,0 +1,103 @@
+//! Compare 60 / 30 / 15 / 10 fps quantization on a back-and-forth dot.
+//!
+//! Renders a 5-second timeline where four blue dots bounce horizontally.
+//! Each dot is a `BouncingDot` whose motion is driven by the time fed to
+//! it; the four instances receive the same `t` quantized to different
+//! framerates via `Time::fps`. The instances are stacked vertically with
+//! `Anchor` so the stutter at lower fps is directly comparable against the
+//! smooth top track.
+
+use std::path::Path;
+
+use tellur_core::color::Color;
+use tellur_core::geometry::{Anchor, Vec2};
+use tellur_core::layer::VectorLayer;
+use tellur_core::raster::{RasterComponent, Resolution};
+use tellur_core::shapes::{Circle, Rectangle};
+use tellur_core::time::{Time, TimeView};
+use tellur_core::timeline::timeline;
+use tellur_core::vector::{Paint, VectorComponent, VectorGraphic};
+use tellur_renderer::{FfmpegEncoder, Rasterizable};
+
+/// A circle that triangle-wave scrubs left-to-right-to-left across a track
+/// of `scene_width`, with one full round trip per `Self::PERIOD` seconds.
+/// The motion is driven entirely by `t`, so callers can quantize or gate
+/// the time independently per instance.
+struct BouncingDot {
+    t: TimeView,
+    scene_width: f32,
+}
+
+impl BouncingDot {
+    const PERIOD: f32 = 2.5;
+    const RADIUS: f32 = 30.0;
+    const SIDE_PADDING: f32 = 40.0;
+}
+
+impl VectorComponent for BouncingDot {
+    fn view_box(&self) -> Vec2 {
+        // Track footprint: full track width, just tall enough to bound the dot.
+        Vec2(self.scene_width, Self::RADIUS * 2.0)
+    }
+
+    fn render(&self) -> VectorGraphic {
+        // phase ∈ [0, 1) over one period.
+        let phase = self.t.seconds().rem_euclid(Self::PERIOD) / Self::PERIOD;
+        // Triangle wave: 0 → 1 → 0 over one period.
+        let normalized = 1.0 - (2.0 * phase - 1.0).abs();
+        let travel = self.scene_width - 2.0 * (Self::SIDE_PADDING + Self::RADIUS);
+        let center_x = Self::SIDE_PADDING + Self::RADIUS + normalized * travel;
+
+        let mut layer = VectorLayer::new(self.view_box());
+        layer.add(
+            Vec2(center_x - Self::RADIUS, 0.0),
+            Circle {
+                radius: Self::RADIUS,
+                fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
+                stroke: None,
+            },
+        );
+        layer.render()
+    }
+}
+
+fn main() {
+    let scene_size = Vec2(1280.0, 720.0);
+    let tl = timeline(5.0, move |t, target| {
+        let mut scene = VectorLayer::new(scene_size);
+
+        scene.add(
+            Vec2::ZERO,
+            Rectangle {
+                size: scene_size,
+                fill: Paint::Solid(Color::rgb_u8(20, 20, 30)).into(),
+                stroke: None,
+            },
+        );
+
+        // Distribute four dots evenly along the Y axis by snapping each one's
+        // CENTER_LEFT onto a fractional anchor at (0, (i + 0.5) / N) of the scene.
+        for (i, &fps) in [60u32, 30, 24, 16].iter().enumerate() {
+            let dot = BouncingDot {
+                t: t.fps(fps),
+                scene_width: scene_size.0,
+            };
+            let stripe_anchor = Anchor::new(0.0, (i as f32 + 0.5) / 4f32);
+            let position = dot
+                .view_box()
+                .anchor(Anchor::CENTER_LEFT)
+                .snap_to(scene_size, stripe_anchor);
+            scene.add(position, dot);
+        }
+
+        scene.rasterize().render(target)
+    });
+
+    let out = Path::new("/tmp/timeline.mp4");
+    FfmpegEncoder::new(Resolution::new(1280, 720), 60)
+        .args(["-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "20"])
+        .encode(&tl, out)
+        .expect("encode mp4");
+
+    println!("Wrote {}", out.display());
+}

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -14,17 +14,18 @@ use tellur_core::geometry::{Anchor, Vec2};
 use tellur_core::layer::VectorLayer;
 use tellur_core::raster::{RasterComponent, Resolution};
 use tellur_core::shapes::{Circle, Rectangle};
-use tellur_core::time::{Time, TimeView};
+use tellur_core::time::{LocalTime, Time};
 use tellur_core::timeline::timeline;
 use tellur_core::vector::{Paint, VectorComponent, VectorGraphic};
 use tellur_renderer::{FfmpegEncoder, Rasterizable};
 
 /// A circle that triangle-wave scrubs left-to-right-to-left across a track
 /// of `scene_width`, with one full round trip per `Self::PERIOD` seconds.
-/// The motion is driven entirely by `t`, so callers can quantize or gate
-/// the time independently per instance.
+/// The motion is driven entirely by `t` — a `LocalTime` clock that the
+/// component reads independently of the global timeline. Callers can pass
+/// `TimelineTime` directly via `.into()` since it converts to `LocalTime`.
 struct BouncingDot {
-    t: TimeView,
+    t: LocalTime,
     scene_width: f32,
 }
 
@@ -79,7 +80,7 @@ fn main() {
         // CENTER_LEFT onto a fractional anchor at (0, (i + 0.5) / N) of the scene.
         for (i, &fps) in [60u32, 30, 24, 16].iter().enumerate() {
             let dot = BouncingDot {
-                t: t.fps(fps),
+                t: t.fps(fps).into(),
                 scene_width: scene_size.0,
             };
             let stripe_anchor = Anchor::new(0.0, (i as f32 + 0.5) / 4f32);

--- a/tellur-renderer/src/lib.rs
+++ b/tellur-renderer/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod rasterize;
+pub mod video;
 
 pub use rasterize::{Rasterizable, Rasterize};
+pub use video::{FfmpegEncoder, FfmpegError};

--- a/tellur-renderer/src/video.rs
+++ b/tellur-renderer/src/video.rs
@@ -1,0 +1,178 @@
+//! Video encoding via an `ffmpeg` subprocess.
+//!
+//! [`FfmpegEncoder`] streams frames of a [`Timeline`] into `ffmpeg`'s stdin
+//! as raw RGBA. The output codec, container, pixel format, and any filters
+//! are controlled entirely through caller-supplied `args` — the encoder
+//! itself only fixes the input side (raw RGBA at a known size/framerate),
+//! so any container/codec `ffmpeg` knows about is reachable (mp4, mov +
+//! ProRes, webm, image sequences, ...).
+//!
+//! Frames are produced by repeatedly calling `Timeline::build(t, resolution)`
+//! with `t = frame_idx / fps` for `frame_idx` in `0..ceil(duration * fps)`.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tellur_core::raster::{PixelFormat, Resolution};
+use tellur_core::time::TimeView;
+use tellur_core::timeline::Timeline;
+use thiserror::Error;
+
+/// Builder that spawns `ffmpeg` and drives a [`Timeline`] through it.
+///
+/// The frame size is fixed at construction (`resolution`) and frames are
+/// emitted at `fps` Hz. Output-side `ffmpeg` arguments (codec, container,
+/// filters, ...) are supplied via [`Self::arg`] / [`Self::args`] and inserted
+/// verbatim between the raw-video input and the output path.
+pub struct FfmpegEncoder {
+    fps: u32,
+    resolution: Resolution,
+    args: Vec<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum FfmpegError {
+    #[error("failed to spawn ffmpeg (is it on PATH?): {0}")]
+    Spawn(std::io::Error),
+    #[error("failed to write frame {frame} to ffmpeg stdin: {source}")]
+    Write { frame: u64, source: std::io::Error },
+    #[error("failed to read ffmpeg stderr: {0}")]
+    ReadStderr(std::io::Error),
+    #[error("failed to wait for ffmpeg: {0}")]
+    Wait(std::io::Error),
+    #[error("ffmpeg exited with status {status}:\n{stderr}")]
+    NonZeroExit { status: String, stderr: String },
+    #[error(
+        "frame {frame} produced {actual} bytes, expected {expected} ({width}x{height} RGBA)"
+    )]
+    FrameSizeMismatch {
+        frame: u64,
+        expected: usize,
+        actual: usize,
+        width: u32,
+        height: u32,
+    },
+    #[error("frame {frame} pixel format is {format:?}, only Rgba8 is supported")]
+    UnsupportedFormat { frame: u64, format: PixelFormat },
+    #[error("fps must be greater than zero")]
+    ZeroFps,
+    #[error("duration must be finite and non-negative, got {0}")]
+    InvalidDuration(f32),
+}
+
+impl FfmpegEncoder {
+    pub fn new(resolution: Resolution, fps: u32) -> Self {
+        Self {
+            fps,
+            resolution,
+            args: Vec::new(),
+        }
+    }
+
+    pub fn arg(mut self, a: impl Into<String>) -> Self {
+        self.args.push(a.into());
+        self
+    }
+
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn encode<T: Timeline>(&self, tl: &T, out: &Path) -> Result<(), FfmpegError> {
+        if self.fps == 0 {
+            return Err(FfmpegError::ZeroFps);
+        }
+        let duration = tl.duration();
+        if !duration.is_finite() || duration < 0.0 {
+            return Err(FfmpegError::InvalidDuration(duration));
+        }
+
+        let w = self.resolution.width;
+        let h = self.resolution.height;
+        let expected_bytes = (w as usize) * (h as usize) * 4;
+        // ceil(duration * fps), saturating to u64.
+        let total_frames = (duration * self.fps as f32).ceil().max(0.0) as u64;
+
+        let size_arg = format!("{w}x{h}");
+        let fps_arg = self.fps.to_string();
+
+        let mut cmd = Command::new("ffmpeg");
+        cmd.arg("-y")
+            .args(["-f", "rawvideo"])
+            .args(["-pix_fmt", "rgba"])
+            .args(["-s", &size_arg])
+            .args(["-r", &fps_arg])
+            .args(["-i", "-"])
+            .args(&self.args)
+            .arg(out)
+            .stdin(Stdio::piped())
+            // Capture stderr so we can surface ffmpeg's error message on failure.
+            // ffmpeg is chatty on stderr even on success, but we only read it
+            // when something goes wrong.
+            .stderr(Stdio::piped())
+            .stdout(Stdio::null());
+
+        let mut child = cmd.spawn().map_err(FfmpegError::Spawn)?;
+        let mut stdin = child.stdin.take().expect("stdin piped");
+
+        let write_result = (|| -> Result<(), FfmpegError> {
+            for frame_idx in 0..total_frames {
+                let t = TimeView::new(frame_idx as f32 / self.fps as f32);
+                let image = tl.build(t, self.resolution);
+
+                if image.format != PixelFormat::Rgba8 {
+                    return Err(FfmpegError::UnsupportedFormat {
+                        frame: frame_idx,
+                        format: image.format,
+                    });
+                }
+                if image.pixels.len() != expected_bytes {
+                    return Err(FfmpegError::FrameSizeMismatch {
+                        frame: frame_idx,
+                        expected: expected_bytes,
+                        actual: image.pixels.len(),
+                        width: w,
+                        height: h,
+                    });
+                }
+
+                stdin
+                    .write_all(&image.pixels)
+                    .map_err(|source| FfmpegError::Write {
+                        frame: frame_idx,
+                        source,
+                    })?;
+            }
+            Ok(())
+        })();
+
+        // Close stdin so ffmpeg can finalize the file, even if frame
+        // production errored partway through — that lets ffmpeg shut down
+        // cleanly so we can collect its stderr.
+        drop(stdin);
+
+        let mut stderr_buf = String::new();
+        if let Some(mut stderr) = child.stderr.take() {
+            stderr
+                .read_to_string(&mut stderr_buf)
+                .map_err(FfmpegError::ReadStderr)?;
+        }
+        let status = child.wait().map_err(FfmpegError::Wait)?;
+
+        write_result?;
+
+        if !status.success() {
+            return Err(FfmpegError::NonZeroExit {
+                status: status.to_string(),
+                stderr: stderr_buf,
+            });
+        }
+        Ok(())
+    }
+}

--- a/tellur-renderer/src/video.rs
+++ b/tellur-renderer/src/video.rs
@@ -52,9 +52,7 @@ pub enum FfmpegError {
     Wait(std::io::Error),
     #[error("ffmpeg exited with status {status}:\n{stderr}")]
     NonZeroExit { status: String, stderr: String },
-    #[error(
-        "frame {frame} produced {actual} bytes, expected {expected} ({width}x{height} RGBA)"
-    )]
+    #[error("frame {frame} produced {actual} bytes, expected {expected} ({width}x{height} RGBA)")]
     FrameSizeMismatch {
         frame: u64,
         expected: usize,
@@ -165,7 +163,10 @@ impl FfmpegEncoder {
             encode_bar.set_style(style);
             encode_bar.set_message("Encode");
 
-            let stdout = child.stdout.take().expect("stdout piped when progress=true");
+            let stdout = child
+                .stdout
+                .take()
+                .expect("stdout piped when progress=true");
             let encode_bar_for_thread = encode_bar.clone();
             let handle = thread::spawn(move || {
                 let reader = BufReader::new(stdout);

--- a/tellur-renderer/src/video.rs
+++ b/tellur-renderer/src/video.rs
@@ -9,11 +9,19 @@
 //!
 //! Frames are produced by repeatedly calling `Timeline::build(t, resolution)`
 //! with `t = frame_idx / fps` for `frame_idx` in `0..ceil(duration * fps)`.
+//!
+//! Progress: a two-row progress display (`Render` / `Encode`) is shown by
+//! default, driven by [`indicatif`]. The Render row counts frames as we
+//! produce them; the Encode row is updated by parsing `frame=N` lines that
+//! `ffmpeg` writes to stdout via `-progress pipe:1`. Disable via
+//! [`FfmpegEncoder::progress`].
 
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::thread;
 
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use tellur_core::raster::{PixelFormat, Resolution};
 use tellur_core::time::TimelineTime;
 use tellur_core::timeline::Timeline;
@@ -29,6 +37,7 @@ pub struct FfmpegEncoder {
     fps: u32,
     resolution: Resolution,
     args: Vec<String>,
+    progress: bool,
 }
 
 #[derive(Debug, Error)]
@@ -67,6 +76,7 @@ impl FfmpegEncoder {
             fps,
             resolution,
             args: Vec::new(),
+            progress: true,
         }
     }
 
@@ -81,6 +91,14 @@ impl FfmpegEncoder {
         S: Into<String>,
     {
         self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Toggle the two-row progress display. Default is on. When the output
+    /// is not a TTY, `indicatif` automatically renders nothing, so leaving
+    /// this on is safe for piped/redirected runs.
+    pub fn progress(mut self, enabled: bool) -> Self {
+        self.progress = enabled;
         self
     }
 
@@ -108,18 +126,67 @@ impl FfmpegEncoder {
             .args(["-pix_fmt", "rgba"])
             .args(["-s", &size_arg])
             .args(["-r", &fps_arg])
-            .args(["-i", "-"])
-            .args(&self.args)
+            .args(["-i", "-"]);
+
+        // -progress pipe:1 makes ffmpeg emit machine-readable key=value lines
+        // to stdout; we parse `frame=N` off the stream to drive the Encode bar.
+        // Without progress, we just discard stdout.
+        if self.progress {
+            cmd.args(["-progress", "pipe:1"]).stdout(Stdio::piped());
+        } else {
+            cmd.stdout(Stdio::null());
+        }
+
+        cmd.args(&self.args)
             .arg(out)
             .stdin(Stdio::piped())
-            // Capture stderr so we can surface ffmpeg's error message on failure.
-            // ffmpeg is chatty on stderr even on success, but we only read it
-            // when something goes wrong.
-            .stderr(Stdio::piped())
-            .stdout(Stdio::null());
+            .stderr(Stdio::piped());
 
         let mut child = cmd.spawn().map_err(FfmpegError::Spawn)?;
         let mut stdin = child.stdin.take().expect("stdin piped");
+
+        // Set up the two-row progress display and a thread that drains
+        // ffmpeg's progress output. The `_multi` guard keeps the multi-bar
+        // alive for the duration of the encode; dropping it after both bars
+        // finish lets indicatif clear/finalize the lines cleanly.
+        let (_multi, render_bar, encode_bar, progress_thread) = if self.progress {
+            let multi = MultiProgress::new();
+            let style = ProgressStyle::with_template(
+                "{msg:7} {bar:40.cyan/blue} {pos:>5}/{len} ({percent:>3}%) {elapsed_precise}",
+            )
+            .expect("static template parses")
+            .progress_chars("##-");
+
+            let render_bar = multi.add(ProgressBar::new(total_frames));
+            render_bar.set_style(style.clone());
+            render_bar.set_message("Render");
+
+            let encode_bar = multi.add(ProgressBar::new(total_frames));
+            encode_bar.set_style(style);
+            encode_bar.set_message("Encode");
+
+            let stdout = child.stdout.take().expect("stdout piped when progress=true");
+            let encode_bar_for_thread = encode_bar.clone();
+            let handle = thread::spawn(move || {
+                let reader = BufReader::new(stdout);
+                for line in reader.lines().map_while(Result::ok) {
+                    if let Some(rest) = line.strip_prefix("frame=") {
+                        if let Ok(n) = rest.trim().parse::<u64>() {
+                            encode_bar_for_thread.set_position(n);
+                        }
+                    }
+                }
+            });
+
+            (
+                Some(multi),
+                Some(render_bar),
+                Some(encode_bar),
+                Some(handle),
+            )
+        } else {
+            (None, None, None, None)
+        };
 
         let write_result = (|| -> Result<(), FfmpegError> {
             for frame_idx in 0..total_frames {
@@ -148,6 +215,10 @@ impl FfmpegEncoder {
                         frame: frame_idx,
                         source,
                     })?;
+
+                if let Some(bar) = &render_bar {
+                    bar.inc(1);
+                }
             }
             Ok(())
         })();
@@ -157,6 +228,18 @@ impl FfmpegEncoder {
         // cleanly so we can collect its stderr.
         drop(stdin);
 
+        // Render side is done; the encoder thread continues until ffmpeg
+        // closes stdout (which it does on exit).
+        if let Some(bar) = &render_bar {
+            bar.finish();
+        }
+
+        if let Some(handle) = progress_thread {
+            // Join is best-effort: a panic in the parsing thread should not
+            // shadow the actual ffmpeg outcome below.
+            let _ = handle.join();
+        }
+
         let mut stderr_buf = String::new();
         if let Some(mut stderr) = child.stderr.take() {
             stderr
@@ -164,6 +247,15 @@ impl FfmpegEncoder {
                 .map_err(FfmpegError::ReadStderr)?;
         }
         let status = child.wait().map_err(FfmpegError::Wait)?;
+
+        if let Some(bar) = &encode_bar {
+            // ffmpeg's last `frame=` might lag the actual final count; snap to
+            // total so the bar reads 100% on completion when it really finished.
+            if status.success() {
+                bar.set_position(total_frames);
+            }
+            bar.finish();
+        }
 
         write_result?;
 

--- a/tellur-renderer/src/video.rs
+++ b/tellur-renderer/src/video.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use tellur_core::raster::{PixelFormat, Resolution};
-use tellur_core::time::TimeView;
+use tellur_core::time::TimelineTime;
 use tellur_core::timeline::Timeline;
 use thiserror::Error;
 
@@ -123,7 +123,7 @@ impl FfmpegEncoder {
 
         let write_result = (|| -> Result<(), FfmpegError> {
             for frame_idx in 0..total_frames {
-                let t = TimeView::new(frame_idx as f32 / self.fps as f32);
+                let t = TimelineTime::new(frame_idx as f32 / self.fps as f32);
                 let image = tl.build(t, self.resolution);
 
                 if image.format != PixelFormat::Rgba8 {


### PR DESCRIPTION
Time-driven scene composition that's rendered into a video via ffmpeg, plus the supporting type machinery for animation work.

- `tellur-core::time`: `Time` trait abstracting over `TimelineTime` (received from the renderer) and `LocalTime` (produced by remaps). Default combinators include `during` (gate, type-preserving), `during_ripple` (gate + rebase), `lerp` (affine warp with extrapolation), `fps` (floor quantization), and `cycle` / `bounce` / `phase` (periodic and range decompositions). A `TimeOptionExt` mirrors them on `Option<T>` for chaining.
- `tellur-core::phase`: `Phase` newtype enforcing `[0.0, 1.0]` at construction. Useful for easing, progress, and other normalized scalars.
- `tellur-core::interpolate`: `Interpolate` trait with impls for `f32`, `Vec2`, and `Anchor`. `Phase::interpolate(from, to)` reads naturally in animation code.
- `tellur-core::timeline`: `Timeline` trait (`build(t, target) -> RasterImage`) plus a `timeline()` closure helper.
- `tellur-core::geometry`: `AnchoredSize::snap_to(target_point)` for absolute positions (Vec2-interpolation-friendly); `snap_to_anchor(target_size, target_anchor)` kept as the convenience for static layouts.
- `tellur-renderer::video`: `FfmpegEncoder` that streams raw RGBA frames into an `ffmpeg` subprocess. Input side (size, fps) is fixed; codec / container / filters are caller-controlled raw args, so mp4/mov/ProRes/etc. are all reachable. Two-row `indicatif` progress bars (Render / Encode) show by default; `-progress pipe:1` drives the Encode bar.
- Example: `timeline_to_mp4` — four `BouncingDot` instances stacked vertically, each fed the same `t` quantized to 60/30/24/16 fps, so the lower-fps stutter is directly visible against the smooth top track.