### PR TITLE
feat: add component body abstraction with proc macros

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [tellur-core, tellur-renderer]
+        package: [tellur-core, tellur-macros, tellur-renderer]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: sudo mkdir -p /nix && sudo chown "$(id -u):$(id -g)" /nix
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [tellur-core, tellur-renderer]
+        package: [tellur-core, tellur-macros, tellur-renderer]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: sudo mkdir -p /nix && sudo chown "$(id -u):$(id -g)" /nix
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [tellur-core, tellur-renderer]
+        package: [tellur-core, tellur-macros, tellur-renderer]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: sudo mkdir -p /nix && sudo chown "$(id -u):$(id -g)" /nix
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [tellur-core, tellur-renderer]
+        package: [tellur-core, tellur-macros, tellur-renderer]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: sudo mkdir -p /nix && sudo chown "$(id -u):$(id -g)" /nix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,17 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "png",
+ "tellur-macros",
  "thiserror",
+]
+
+[[package]]
+name = "tellur-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["tellur-core", "tellur-renderer"]
+members = ["tellur-core", "tellur-macros", "tellur-renderer"]
 resolver = "2"

--- a/tellur-core/Cargo.toml
+++ b/tellur-core/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 bytes = "1.11.1"
 png = "0.18.1"
+tellur-macros = { path = "../tellur-macros", version = "0.1.0" }
 thiserror = "2.0.18"

--- a/tellur-core/src/layer.rs
+++ b/tellur-core/src/layer.rs
@@ -22,7 +22,7 @@ use crate::vector::{Group, Node, VectorComponent, VectorGraphic};
 
 pub struct VectorLayer {
     pub size: Vec2,
-    children: Vec<(Vec2, Box<dyn VectorComponent>)>,
+    pub children: Vec<(Vec2, Box<dyn VectorComponent>)>,
 }
 
 impl VectorLayer {
@@ -70,7 +70,7 @@ impl VectorComponent for VectorLayer {
 
 pub struct Layer {
     pub size: Vec2,
-    children: Vec<(Vec2, Box<dyn RasterComponent>)>,
+    pub children: Vec<(Vec2, Box<dyn RasterComponent>)>,
 }
 
 impl Layer {

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -8,3 +8,10 @@ pub mod shapes;
 pub mod time;
 pub mod timeline;
 pub mod vector;
+
+// Re-export the component macros so users only need to depend on `tellur-core`.
+// The macros emit fully-qualified `::tellur_core::...` paths, so this self-name
+// must be reachable inside this crate too if someone uses them internally.
+extern crate self as tellur_core;
+
+pub use tellur_macros::{raster_component, vector_component};

--- a/tellur-core/src/raster.rs
+++ b/tellur-core/src/raster.rs
@@ -42,12 +42,47 @@ impl Resolution {
 /// own children so that the final image is produced with the minimum work
 /// needed to fill `target`.
 ///
+/// Two roles share this trait, mirroring `VectorComponent`. **Element
+/// components** are leaves that own a concrete `render()` implementation
+/// (e.g. `Layer`, `Rasterize<V>`); they keep the default `body()` returning
+/// `RasterBody::Element` and override `render()` themselves. **Composite
+/// components** delegate to another component by overriding `body()` to
+/// return `RasterBody::Of(...)`; the default `render()` then forwards
+/// `target` through the chain until it reaches an element.
+///
 /// Implementors must keep `view_box()` consistent with the logical size
 /// they occupy in a parent's coordinate space, so layers can lay them out
 /// without forcing a render.
 pub trait RasterComponent {
     fn view_box(&self) -> Vec2;
-    fn render(&self, target: Resolution) -> RasterImage;
+
+    /// Identifies whether this component is a render-owning element or a
+    /// delegate to another component. Default is `Element` so that leaf types
+    /// only need to override `render()`.
+    fn body(&self) -> RasterBody {
+        RasterBody::Element
+    }
+
+    /// Produces the rasterized output. The default walks `body()` until it
+    /// reaches an `Element`, threading `target` through unchanged; elements
+    /// must override this with their own implementation.
+    fn render(&self, target: Resolution) -> RasterImage {
+        match self.body() {
+            RasterBody::Element => unimplemented!(
+                "RasterComponent with body() == RasterBody::Element must override render()"
+            ),
+            RasterBody::Of(c) => c.render(target),
+        }
+    }
+}
+
+/// Discriminates element components (own their `render`) from composite
+/// components (delegate to another component).
+pub enum RasterBody {
+    /// This component owns a concrete `render()` implementation.
+    Element,
+    /// Delegate to another component — `render()` forwards `target` through it.
+    Of(Box<dyn RasterComponent>),
 }
 
 // Compile-time guarantee that `RasterComponent` is dyn-safe.

--- a/tellur-core/src/raster.rs
+++ b/tellur-core/src/raster.rs
@@ -74,6 +74,16 @@ pub trait RasterComponent {
             RasterBody::Of(c) => c.render(target),
         }
     }
+
+    /// Type-erases `self` into a heap-allocated trait object. Useful for
+    /// constructing heterogeneous containers like `Layer.children` in
+    /// struct-literal form.
+    fn boxed(self) -> Box<dyn RasterComponent>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
 }
 
 /// Discriminates element components (own their `render`) from composite

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -47,6 +47,16 @@ pub trait VectorComponent {
             VectorBody::Of(c) => c.render(),
         }
     }
+
+    /// Type-erases `self` into a heap-allocated trait object. Useful for
+    /// constructing heterogeneous containers like `VectorLayer.children`
+    /// in struct-literal form.
+    fn boxed(self) -> Box<dyn VectorComponent>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
 }
 
 /// Discriminates element components (own their `render`) from composite

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -16,11 +16,46 @@ pub struct VectorGraphic {
 
 /// A component that can produce a `VectorGraphic`.
 ///
+/// Two roles share this trait. **Element components** are leaves that own a
+/// concrete `render()` implementation (e.g. `Rectangle`, `VectorLayer`); they
+/// keep the default `body()` returning `VectorBody::Element` and override
+/// `render()` themselves. **Composite components** are usually user-defined
+/// and delegate to another component by overriding `body()` to return
+/// `VectorBody::Of(...)`; the default `render()` then walks the chain until
+/// it reaches an element.
+///
 /// Implementors must keep `view_box()` consistent with `render().view_box`,
 /// so callers can query the intrinsic size without paying for a full render.
 pub trait VectorComponent {
     fn view_box(&self) -> Vec2;
-    fn render(&self) -> VectorGraphic;
+
+    /// Identifies whether this component is a render-owning element or a
+    /// delegate to another component. Default is `Element` so that leaf types
+    /// only need to override `render()`.
+    fn body(&self) -> VectorBody {
+        VectorBody::Element
+    }
+
+    /// Produces the flattened graphic. The default walks `body()` until it
+    /// reaches an `Element`; elements must override this with their own
+    /// implementation.
+    fn render(&self) -> VectorGraphic {
+        match self.body() {
+            VectorBody::Element => unimplemented!(
+                "VectorComponent with body() == VectorBody::Element must override render()"
+            ),
+            VectorBody::Of(c) => c.render(),
+        }
+    }
+}
+
+/// Discriminates element components (own their `render`) from composite
+/// components (delegate to another component).
+pub enum VectorBody {
+    /// This component owns a concrete `render()` implementation.
+    Element,
+    /// Delegate to another component — `render()` walks through it.
+    Of(Box<dyn VectorComponent>),
 }
 
 // Compile-time guarantee that `VectorComponent` is dyn-safe.

--- a/tellur-macros/Cargo.toml
+++ b/tellur-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tellur-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/tellur-macros/src/lib.rs
+++ b/tellur-macros/src/lib.rs
@@ -1,0 +1,156 @@
+//! Attribute macros that turn a function-style component definition into a
+//! struct + `VectorComponent` / `RasterComponent` impl.
+//!
+//! ```ignore
+//! #[vector_component]
+//! fn bouncing_dot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
+//!     // ...returns any VectorComponent...
+//! }
+//! ```
+//!
+//! Expands to a `BouncingDot` struct (PascalCase of the fn name) whose fields
+//! are the function arguments. The function body becomes the component's
+//! `body()` implementation, wrapped in `VectorBody::Of(Box::new(...))`.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{parse_macro_input, FnArg, ItemFn, Pat, PatType};
+
+/// Attribute macro for vector components. See crate-level docs.
+#[proc_macro_attribute]
+pub fn vector_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    expand_entry(item, Kind::Vector)
+}
+
+/// Attribute macro for raster components. The runtime `target: Resolution`
+/// argument is *not* surfaced in the function signature — it threads through
+/// the generated default `render()` via `RasterBody::Of`.
+#[proc_macro_attribute]
+pub fn raster_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    expand_entry(item, Kind::Raster)
+}
+
+#[derive(Clone, Copy)]
+enum Kind {
+    Vector,
+    Raster,
+}
+
+fn expand_entry(item: TokenStream, kind: Kind) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+    match expand(input, kind) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand(func: ItemFn, kind: Kind) -> syn::Result<TokenStream2> {
+    if let Some(constness) = func.sig.constness {
+        return Err(syn::Error::new_spanned(
+            constness,
+            "component fn cannot be const",
+        ));
+    }
+    if let Some(asyncness) = func.sig.asyncness {
+        return Err(syn::Error::new_spanned(
+            asyncness,
+            "component fn cannot be async",
+        ));
+    }
+    if !func.sig.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &func.sig.generics,
+            "component fn cannot have generic parameters (use concrete types as fields)",
+        ));
+    }
+
+    let vis = &func.vis;
+    let fn_ident = &func.sig.ident;
+    let struct_ident = snake_to_pascal_ident(fn_ident);
+
+    let mut field_idents: Vec<&syn::Ident> = Vec::new();
+    let mut field_types: Vec<&syn::Type> = Vec::new();
+    for arg in &func.sig.inputs {
+        match arg {
+            FnArg::Receiver(r) => {
+                return Err(syn::Error::new_spanned(
+                    r,
+                    "component fn must not take a self receiver",
+                ));
+            }
+            FnArg::Typed(PatType { pat, ty, .. }) => {
+                let Pat::Ident(pi) = pat.as_ref() else {
+                    return Err(syn::Error::new_spanned(
+                        pat,
+                        "component fn argument must be a plain identifier",
+                    ));
+                };
+                field_idents.push(&pi.ident);
+                field_types.push(ty.as_ref());
+            }
+        }
+    }
+
+    let body = &func.block;
+
+    let (trait_path, body_path, body_of_variant, vec2_path) = match kind {
+        Kind::Vector => (
+            quote!(::tellur_core::vector::VectorComponent),
+            quote!(::tellur_core::vector::VectorBody),
+            quote!(::tellur_core::vector::VectorBody::Of),
+            quote!(::tellur_core::geometry::Vec2),
+        ),
+        Kind::Raster => (
+            quote!(::tellur_core::raster::RasterComponent),
+            quote!(::tellur_core::raster::RasterBody),
+            quote!(::tellur_core::raster::RasterBody::Of),
+            quote!(::tellur_core::geometry::Vec2),
+        ),
+    };
+
+    let build_method = syn::Ident::new("__tellur_build", fn_ident.span());
+
+    let output = quote! {
+        #[derive(::core::clone::Clone)]
+        #vis struct #struct_ident {
+            #( pub #field_idents: #field_types, )*
+        }
+
+        impl #struct_ident {
+            #[doc(hidden)]
+            fn #build_method(&self) -> impl #trait_path + 'static {
+                let Self { #( #field_idents ),* } = ::core::clone::Clone::clone(self);
+                #body
+            }
+        }
+
+        impl #trait_path for #struct_ident {
+            fn view_box(&self) -> #vec2_path {
+                #trait_path::view_box(&self.#build_method())
+            }
+            fn body(&self) -> #body_path {
+                #body_of_variant(::std::boxed::Box::new(self.#build_method()))
+            }
+        }
+    };
+
+    Ok(output)
+}
+
+fn snake_to_pascal_ident(ident: &syn::Ident) -> syn::Ident {
+    let s = ident.to_string();
+    let mut out = String::with_capacity(s.len());
+    let mut capitalize = true;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize = true;
+        } else if capitalize {
+            out.extend(c.to_uppercase());
+            capitalize = false;
+        } else {
+            out.push(c);
+        }
+    }
+    syn::Ident::new(&out, ident.span())
+}

--- a/tellur-renderer/examples/raster_layer_to_png.rs
+++ b/tellur-renderer/examples/raster_layer_to_png.rs
@@ -11,28 +11,18 @@ use tellur_core::geometry::{Anchor, Vec2};
 use tellur_core::layer::Layer;
 use tellur_core::raster::{RasterComponent, Resolution};
 use tellur_core::shapes::{Circle, Rectangle};
-use tellur_core::vector::{Paint, VectorComponent, VectorGraphic};
+use tellur_core::vector::Paint;
+use tellur_core::vector_component;
 use tellur_renderer::Rasterizable;
 
 /// A translucent colored circle. The whole shape is parameterised by hue
 /// and radius; saturation, lightness and alpha are baked in.
-struct Blob {
-    radius: f32,
-    hue: f32,
-}
-
-impl VectorComponent for Blob {
-    fn view_box(&self) -> Vec2 {
-        Vec2(self.radius * 2.0, self.radius * 2.0)
-    }
-
-    fn render(&self) -> VectorGraphic {
-        Circle {
-            radius: self.radius,
-            fill: Paint::Solid(Color::hsla(self.hue, 0.7, 0.55, 0.65)).into(),
-            stroke: None,
-        }
-        .render()
+#[vector_component]
+fn blob(radius: f32, hue: f32) -> impl VectorComponent {
+    Circle {
+        radius,
+        fill: Paint::Solid(Color::hsla(hue, 0.7, 0.55, 0.65)).into(),
+        stroke: None,
     }
 }
 

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -26,7 +26,7 @@ use tellur_renderer::{FfmpegEncoder, Rasterizable};
 /// component reads independently of the global timeline. Callers can pass
 /// `TimelineTime` directly via `.into()` since it converts to `LocalTime`.
 #[vector_component]
-fn bouncing_dot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
+fn BouncingDot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
     const PERIOD: f32 = 2.5;
     const RADIUS: f32 = 30.0;
     const SIDE_PADDING: f32 = 40.0;
@@ -45,31 +45,27 @@ fn bouncing_dot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
         stroke: None,
     };
 
-    let mut layer = VectorLayer::new(view);
-    layer.add(
-        circle.view_box().anchor(Anchor::CENTER).snap_to(target),
-        circle,
-    );
-    layer
+    VectorLayer {
+        size: view,
+        children: vec![(
+            circle.view_box().anchor(Anchor::CENTER).snap_to(target),
+            circle.boxed(),
+        )],
+    }
 }
 
 fn main() {
     let scene_size = Vec2(1280.0, 720.0);
     let tl = timeline(5.0, move |t, target| {
-        let mut scene = VectorLayer::new(scene_size);
-
-        scene.add(
-            Vec2::ZERO,
-            Rectangle {
-                size: scene_size,
-                fill: Paint::Solid(Color::rgb_u8(20, 20, 30)).into(),
-                stroke: None,
-            },
-        );
+        let background = Rectangle {
+            size: scene_size,
+            fill: Paint::Solid(Color::rgb_u8(20, 20, 30)).into(),
+            stroke: None,
+        };
 
         // Distribute four dots evenly along the Y axis by snapping each one's
         // CENTER_LEFT onto a fractional anchor at (0, (i + 0.5) / N) of the scene.
-        for (i, &fps) in [60u32, 30, 24, 16].iter().enumerate() {
+        let dots = [60u32, 30, 24, 16].iter().enumerate().map(|(i, &fps)| {
             let dot = BouncingDot {
                 t: t.fps(fps).into(),
                 scene_width: scene_size.0,
@@ -79,8 +75,15 @@ fn main() {
                 .view_box()
                 .anchor(Anchor::CENTER_LEFT)
                 .snap_to_anchor(scene_size, stripe_anchor);
-            scene.add(position, dot);
-        }
+            (position, dot.boxed())
+        });
+
+        let scene = VectorLayer {
+            size: scene_size,
+            children: std::iter::once((Vec2::ZERO, background.boxed()))
+                .chain(dots)
+                .collect(),
+        };
 
         scene.rasterize().render(target)
     });

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -16,56 +16,41 @@ use tellur_core::raster::{RasterComponent, Resolution};
 use tellur_core::shapes::{Circle, Rectangle};
 use tellur_core::time::{LocalTime, Time};
 use tellur_core::timeline::timeline;
-use tellur_core::vector::{Paint, VectorComponent, VectorGraphic};
+use tellur_core::vector::{Paint, VectorComponent};
+use tellur_core::vector_component;
 use tellur_renderer::{FfmpegEncoder, Rasterizable};
 
 /// A circle that triangle-wave scrubs left-to-right-to-left across a track
-/// of `scene_width`, with one full round trip per `Self::PERIOD` seconds.
-/// The motion is driven entirely by `t` — a `LocalTime` clock that the
+/// of `scene_width`, with one full round trip per `PERIOD` seconds. The
+/// motion is driven entirely by `t` — a `LocalTime` clock that the
 /// component reads independently of the global timeline. Callers can pass
 /// `TimelineTime` directly via `.into()` since it converts to `LocalTime`.
-struct BouncingDot {
-    t: LocalTime,
-    scene_width: f32,
-}
-
-impl BouncingDot {
+#[vector_component]
+fn bouncing_dot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
     const PERIOD: f32 = 2.5;
     const RADIUS: f32 = 30.0;
     const SIDE_PADDING: f32 = 40.0;
-}
 
-impl VectorComponent for BouncingDot {
-    fn view_box(&self) -> Vec2 {
-        // Track footprint: full track width, just tall enough to bound the dot.
-        Vec2(self.scene_width, Self::RADIUS * 2.0)
-    }
+    let (phase, _) = t.bounce(PERIOD);
+    let view = Vec2(scene_width, RADIUS * 2.0);
+    let center_y = view.1 * 0.5;
+    let target = phase.interpolate(
+        Vec2(SIDE_PADDING + RADIUS, center_y),
+        Vec2(scene_width - SIDE_PADDING - RADIUS, center_y),
+    );
 
-    fn render(&self) -> VectorGraphic {
-        let (phase, _) = self.t.bounce(Self::PERIOD);
-        // The dot bounces between two points, vertically centered in the track.
-        let center_y = self.view_box().1 * 0.5;
-        let target = phase.interpolate(
-            Vec2(Self::SIDE_PADDING + Self::RADIUS, center_y),
-            Vec2(
-                self.scene_width - Self::SIDE_PADDING - Self::RADIUS,
-                center_y,
-            ),
-        );
+    let circle = Circle {
+        radius: RADIUS,
+        fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
+        stroke: None,
+    };
 
-        let circle = Circle {
-            radius: Self::RADIUS,
-            fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
-            stroke: None,
-        };
-
-        let mut layer = VectorLayer::new(self.view_box());
-        layer.add(
-            circle.view_box().anchor(Anchor::CENTER).snap_to(target),
-            circle,
-        );
-        layer.render()
-    }
+    let mut layer = VectorLayer::new(view);
+    layer.add(
+        circle.view_box().anchor(Anchor::CENTER).snap_to(target),
+        circle,
+    );
+    layer
 }
 
 fn main() {


### PR DESCRIPTION
React/SwiftUI-style component composition. User-defined composites can now return another component instead of constructing a `VectorGraphic` themselves, and `#[vector_component]` / `#[raster_component]` proc macros collapse the struct + impl boilerplate into a single function.

- `tellur-core::vector::VectorBody` and `tellur-core::raster::RasterBody`: new enums distinguishing **element** components (own a `render()` implementation — `Rectangle`, `Circle`, `Ellipse`, `VectorLayer`, `Layer`, `Rasterize<V>`) from **composite** components that delegate via `Body::Of(Box<dyn ...>)`.
- `VectorComponent` / `RasterComponent` traits gain default `body()` returning `Body::Element` and default `render()` that walks the body chain. `target: Resolution` threads through `RasterBody::Of` automatically — composites never see it in their signature.
- `tellur-macros`: new proc-macro crate exposing `#[vector_component]` and `#[raster_component]`. Each turns a function-style component definition into a PascalCase struct (fields = function args, `#[derive(Clone)]`) plus the trait impl. Re-exported from `tellur-core`.
- Examples migrated: `BouncingDot` (in `timeline_to_mp4`) and `Blob` (in `raster_layer_to_png`) are now written as plain functions; `BouncingDot` drops ~16 lines of boilerplate, `Blob` shrinks to 7 lines from 20.
- CI: `tellur-macros` added to the per-crate fmt / clippy / build / test matrix.