### PR TITLE
feat: wrap layer children in Placed for inline placement

### DIFF
--- a/tellur-core/src/geometry.rs
+++ b/tellur-core/src/geometry.rs
@@ -12,8 +12,8 @@ impl Vec2 {
     pub const ZERO: Self = Self(0.0, 0.0);
 
     /// Treats `self` as a size and pairs it with an anchor point on that box,
-    /// ready to be snapped to another anchored size via [`AnchoredSize::snap_to`].
-    pub fn anchor(self, anchor: Anchor) -> AnchoredSize {
+    /// ready to be snapped onto a target point via [`AnchoredSize::snap_to`].
+    pub fn anchored(self, anchor: Anchor) -> AnchoredSize {
         AnchoredSize { size: self, anchor }
     }
 }
@@ -114,7 +114,7 @@ impl Anchor {
     }
 }
 
-/// A size paired with an anchor on that size, produced by [`Vec2::anchor`].
+/// A size paired with an anchor on that size, produced by [`Vec2::anchored`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AnchoredSize {
     pub size: Vec2,
@@ -128,13 +128,5 @@ impl AnchoredSize {
     /// box in that coordinate space.
     pub fn snap_to(self, target_point: Vec2) -> Vec2 {
         target_point - self.anchor.point(self.size)
-    }
-
-    /// Snaps so that `self.anchor` lands on `target_anchor` of a parent box
-    /// of `target_size`. Convenience for the common case where the target
-    /// point is expressed as a fractional anchor on a known parent size:
-    /// equivalent to `self.snap_to(target_anchor.point(target_size))`.
-    pub fn snap_to_anchor(self, target_size: Vec2, target_anchor: Anchor) -> Vec2 {
-        self.snap_to(target_anchor.point(target_size))
     }
 }

--- a/tellur-core/src/layer.rs
+++ b/tellur-core/src/layer.rs
@@ -4,6 +4,14 @@
 //! logical `size` defining its coordinate space (top-left at `(0, 0)`),
 //! and children are placed at logical positions within it.
 //!
+//! Children are stored as [`Placed<dyn _>`](Placed) — the position lives on
+//! a wrapper around the component rather than as a field of the component
+//! itself, keeping the component types focused on intrinsic shape. Use the
+//! placement extension traits in [`crate::placement`]
+//! ([`VectorPlacement`](crate::placement::VectorPlacement) /
+//! [`RasterPlacement`](crate::placement::RasterPlacement)) to construct
+//! placed children with `at`, `anchor(...).snap_to(...)`, etc.
+//!
 //! `VectorLayer` composes `VectorComponent` children into a single
 //! `VectorGraphic`. Each child is placed by wrapping it in a translating
 //! `Group` so the composed result remains pure vector data.
@@ -17,12 +25,13 @@
 use bytes::Bytes;
 
 use crate::geometry::{Transform, Vec2};
+use crate::placement::Placed;
 use crate::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
 use crate::vector::{Group, Node, VectorComponent, VectorGraphic};
 
 pub struct VectorLayer {
     pub size: Vec2,
-    pub children: Vec<(Vec2, Box<dyn VectorComponent>)>,
+    pub children: Vec<Placed<dyn VectorComponent>>,
 }
 
 impl VectorLayer {
@@ -33,8 +42,8 @@ impl VectorLayer {
         }
     }
 
-    pub fn add<C: VectorComponent + 'static>(&mut self, position: Vec2, child: C) -> &mut Self {
-        self.children.push((position, Box::new(child)));
+    pub fn add(&mut self, child: Placed<dyn VectorComponent>) -> &mut Self {
+        self.children.push(child);
         self
     }
 }
@@ -48,10 +57,10 @@ impl VectorComponent for VectorLayer {
         let children = self
             .children
             .iter()
-            .map(|(pos, c)| {
-                let child = c.render();
+            .map(|placed| {
+                let child = placed.child.render();
                 Node::Group(Group {
-                    transform: Transform::translate(*pos),
+                    transform: Transform::translate(placed.position),
                     opacity: 1.0,
                     children: vec![child.root],
                 })
@@ -70,7 +79,7 @@ impl VectorComponent for VectorLayer {
 
 pub struct Layer {
     pub size: Vec2,
-    pub children: Vec<(Vec2, Box<dyn RasterComponent>)>,
+    pub children: Vec<Placed<dyn RasterComponent>>,
 }
 
 impl Layer {
@@ -81,8 +90,8 @@ impl Layer {
         }
     }
 
-    pub fn add<C: RasterComponent + 'static>(&mut self, position: Vec2, child: C) -> &mut Self {
-        self.children.push((position, Box::new(child)));
+    pub fn add(&mut self, child: Placed<dyn RasterComponent>) -> &mut Self {
+        self.children.push(child);
         self
     }
 }
@@ -101,14 +110,14 @@ impl RasterComponent for Layer {
         let scale_x = target.width as f32 / self.size.0;
         let scale_y = target.height as f32 / self.size.1;
 
-        for (pos, child) in &self.children {
-            let child_size = child.view_box();
+        for placed in &self.children {
+            let child_size = placed.child.view_box();
             let child_px_w = (child_size.0 * scale_x).round().max(1.0) as u32;
             let child_px_h = (child_size.1 * scale_y).round().max(1.0) as u32;
-            let offset_x = (pos.0 * scale_x).round() as i32;
-            let offset_y = (pos.1 * scale_y).round() as i32;
+            let offset_x = (placed.position.0 * scale_x).round() as i32;
+            let offset_y = (placed.position.1 * scale_y).round() as i32;
 
-            let image = child.render(Resolution::new(child_px_w, child_px_h));
+            let image = placed.child.render(Resolution::new(child_px_w, child_px_h));
             composite_at(&mut accum, target, &image, offset_x, offset_y);
         }
 

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod geometry;
 pub mod interpolate;
 pub mod layer;
 pub mod phase;
+pub mod placement;
 pub mod raster;
 pub mod shapes;
 pub mod time;

--- a/tellur-core/src/placement.rs
+++ b/tellur-core/src/placement.rs
@@ -1,0 +1,139 @@
+//! Placement primitives for positioning components inside a parent layout.
+//!
+//! [`Placed`] is a `(position, component)` pair stored by layer-like
+//! containers (e.g. [`VectorLayer::children`](crate::layer::VectorLayer)).
+//! It deliberately lives *outside* the component traits so that a
+//! [`VectorComponent`] or [`RasterComponent`] describes only its intrinsic
+//! shape, while its placement in a parent is expressed by wrapping it.
+//!
+//! The [`VectorPlacement`] and [`RasterPlacement`] extension traits give
+//! every component fluent methods to produce a `Placed`:
+//!
+//! ```ignore
+//! use tellur_core::placement::VectorPlacement;
+//!
+//! scene.add(background.at(Vec2::ZERO));
+//! scene.add(circle.anchored(Anchor::CENTER).snap_to(target_point));
+//! scene.add(dot.anchored(Anchor::CENTER_LEFT).snap_to(stripe_anchor.point(scene_size)));
+//! ```
+//!
+//! The anchor-based methods mirror [`Vec2::anchored`] →
+//! [`AnchoredSize::snap_to`](crate::geometry::AnchoredSize::snap_to) so the
+//! geometry vocabulary carries over directly to component placement.
+
+use crate::geometry::{Anchor, Vec2};
+use crate::raster::RasterComponent;
+use crate::vector::VectorComponent;
+
+/// A component paired with its top-left position in the parent's
+/// coordinate space.
+///
+/// `C` is typically `dyn VectorComponent` or `dyn RasterComponent`, so the
+/// concrete struct stored is `Placed<dyn VectorComponent>` etc. The
+/// `?Sized` bound allows the dyn case.
+pub struct Placed<C: ?Sized> {
+    pub position: Vec2,
+    pub child: Box<C>,
+}
+
+/// Extension trait that adds placement methods to every [`VectorComponent`].
+///
+/// Brought into scope alongside `use tellur_core::vector::VectorComponent`,
+/// it lets callers write `circle.at(pos)` or
+/// `circle.anchored(Anchor::CENTER).snap_to(target)` instead of manually
+/// computing the offset and boxing the component.
+pub trait VectorPlacement: VectorComponent + Sized + 'static {
+    /// Places the component so its local origin `(0, 0)` lands at `position`
+    /// in the parent's coordinate space.
+    fn at(self, position: Vec2) -> Placed<dyn VectorComponent> {
+        Placed {
+            position,
+            child: Box::new(self),
+        }
+    }
+
+    /// Begins an anchor-based placement: `anchor` picks a point on the
+    /// component's own [`view_box`](VectorComponent::view_box), which a
+    /// follow-up `snap_to` then aligns onto a point in the parent.
+    fn anchored(self, anchor: Anchor) -> AnchoredVectorComponent<Self> {
+        AnchoredVectorComponent {
+            component: self,
+            anchor,
+        }
+    }
+}
+
+impl<T: VectorComponent + 'static> VectorPlacement for T {}
+
+/// Intermediate produced by [`VectorPlacement::anchored`]. Holds the
+/// component and the anchor point on its `view_box` until a snap target is
+/// provided.
+pub struct AnchoredVectorComponent<C: VectorComponent> {
+    component: C,
+    anchor: Anchor,
+}
+
+impl<C: VectorComponent + 'static> AnchoredVectorComponent<C> {
+    /// Places the component so the chosen anchor on its `view_box` lands on
+    /// `target_point` in the parent's coordinate space.
+    pub fn snap_to(self, target_point: Vec2) -> Placed<dyn VectorComponent> {
+        let position = self
+            .component
+            .view_box()
+            .anchored(self.anchor)
+            .snap_to(target_point);
+        Placed {
+            position,
+            child: Box::new(self.component),
+        }
+    }
+}
+
+/// Extension trait that adds placement methods to every [`RasterComponent`].
+///
+/// Mirrors [`VectorPlacement`] one-to-one; the produced `Placed` wraps a
+/// `dyn RasterComponent` instead.
+pub trait RasterPlacement: RasterComponent + Sized + 'static {
+    /// Places the component so its local origin `(0, 0)` lands at `position`
+    /// in the parent's coordinate space.
+    fn at(self, position: Vec2) -> Placed<dyn RasterComponent> {
+        Placed {
+            position,
+            child: Box::new(self),
+        }
+    }
+
+    /// Begins an anchor-based placement; see
+    /// [`VectorPlacement::anchored`] for the same idea on the vector side.
+    fn anchored(self, anchor: Anchor) -> AnchoredRasterComponent<Self> {
+        AnchoredRasterComponent {
+            component: self,
+            anchor,
+        }
+    }
+}
+
+impl<T: RasterComponent + 'static> RasterPlacement for T {}
+
+/// Intermediate produced by [`RasterPlacement::anchored`]; counterpart of
+/// [`AnchoredVectorComponent`].
+pub struct AnchoredRasterComponent<C: RasterComponent> {
+    component: C,
+    anchor: Anchor,
+}
+
+impl<C: RasterComponent + 'static> AnchoredRasterComponent<C> {
+    /// Places the component so the chosen anchor on its `view_box` lands on
+    /// `target_point` in the parent's coordinate space.
+    pub fn snap_to(self, target_point: Vec2) -> Placed<dyn RasterComponent> {
+        let position = self
+            .component
+            .view_box()
+            .anchored(self.anchor)
+            .snap_to(target_point);
+        Placed {
+            position,
+            child: Box::new(self.component),
+        }
+    }
+}

--- a/tellur-renderer/examples/raster_layer_to_png.rs
+++ b/tellur-renderer/examples/raster_layer_to_png.rs
@@ -9,6 +9,7 @@ use std::fs::File;
 use tellur_core::color::Color;
 use tellur_core::geometry::{Anchor, Vec2};
 use tellur_core::layer::Layer;
+use tellur_core::placement::RasterPlacement;
 use tellur_core::raster::{RasterComponent, Resolution};
 use tellur_core::shapes::{Circle, Rectangle};
 use tellur_core::vector::Paint;
@@ -27,52 +28,40 @@ fn blob(radius: f32, hue: f32) -> impl VectorComponent {
 }
 
 fn main() {
-    let mut scene = Layer::new(Vec2(1280.0, 720.0));
-
-    let background = Rectangle {
-        size: scene.size,
-        fill: Paint::Solid(Color::rgb_u8(245, 240, 230)).into(),
-        stroke: None,
-    }
-    .rasterize();
-    scene.add(Vec2::ZERO, background);
-
-    let red = Blob {
-        radius: 200.0,
-        hue: 0.0,
-    }
-    .rasterize();
-    scene.add(
-        red.view_box()
-            .anchor(Anchor::CENTER)
-            .snap_to_anchor(scene.size, Anchor::new(0.4, 0.4)),
-        red,
-    );
-
-    let green = Blob {
-        radius: 200.0,
-        hue: 120.0,
-    }
-    .rasterize();
-    scene.add(
-        green
-            .view_box()
-            .anchor(Anchor::CENTER)
-            .snap_to_anchor(scene.size, Anchor::new(0.6, 0.4)),
-        green,
-    );
-
-    let blue = Blob {
-        radius: 200.0,
-        hue: 240.0,
-    }
-    .rasterize();
-    scene.add(
-        blue.view_box()
-            .anchor(Anchor::CENTER)
-            .snap_to_anchor(scene.size, Anchor::new(0.5, 0.65)),
-        blue,
-    );
+    let scene_size = Vec2(1280.0, 720.0);
+    let scene = Layer {
+        size: scene_size,
+        children: vec![
+            Rectangle {
+                size: scene_size,
+                fill: Paint::Solid(Color::rgb_u8(245, 240, 230)).into(),
+                stroke: None,
+            }
+            .rasterize()
+            .at(Vec2::ZERO),
+            Blob {
+                radius: 200.0,
+                hue: 0.0,
+            }
+            .rasterize()
+            .anchored(Anchor::CENTER)
+            .snap_to(Anchor::new(0.4, 0.4).point(scene_size)),
+            Blob {
+                radius: 200.0,
+                hue: 120.0,
+            }
+            .rasterize()
+            .anchored(Anchor::CENTER)
+            .snap_to(Anchor::new(0.6, 0.4).point(scene_size)),
+            Blob {
+                radius: 200.0,
+                hue: 240.0,
+            }
+            .rasterize()
+            .anchored(Anchor::CENTER)
+            .snap_to(Anchor::new(0.5, 0.65).point(scene_size)),
+        ],
+    };
 
     let image = scene.render(Resolution::new(1280, 720));
 

--- a/tellur-renderer/examples/scene_to_png.rs
+++ b/tellur-renderer/examples/scene_to_png.rs
@@ -5,46 +5,39 @@ use std::fs::File;
 use tellur_core::color::Color;
 use tellur_core::geometry::{Anchor, Vec2};
 use tellur_core::layer::VectorLayer;
+use tellur_core::placement::VectorPlacement;
 use tellur_core::raster::{RasterComponent, Resolution};
 use tellur_core::shapes::{Circle, Rectangle};
-use tellur_core::vector::{Paint, VectorComponent};
+use tellur_core::vector::Paint;
 use tellur_renderer::Rasterizable;
 
 fn main() {
-    let mut scene = VectorLayer::new(Vec2(1280.0, 720.0));
-
-    let background = Rectangle {
-        size: scene.size,
-        fill: Paint::Solid(Color::rgb_u8(255, 255, 255)).into(),
-        stroke: None,
+    let scene_size = Vec2(1280.0, 720.0);
+    let scene = VectorLayer {
+        size: scene_size,
+        children: vec![
+            Rectangle {
+                size: scene_size,
+                fill: Paint::Solid(Color::rgb_u8(255, 255, 255)).into(),
+                stroke: None,
+            }
+            .at(Vec2::ZERO),
+            Rectangle {
+                size: Vec2(240.0, 240.0),
+                fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.55)).into(),
+                stroke: None,
+            }
+            .anchored(Anchor::TOP_LEFT)
+            .snap_to(Anchor::TOP_LEFT.point(scene_size)),
+            Circle {
+                radius: 120.0,
+                fill: Paint::Solid(Color::hsl(20.0, 0.7, 0.55)).into(),
+                stroke: None,
+            }
+            .anchored(Anchor::BOTTOM_RIGHT)
+            .snap_to(Anchor::BOTTOM_RIGHT.point(scene_size)),
+        ],
     };
-    scene.add(Vec2::ZERO, background);
-
-    let square = Rectangle {
-        size: Vec2(240.0, 240.0),
-        fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.55)).into(),
-        stroke: None,
-    };
-    scene.add(
-        square
-            .view_box()
-            .anchor(Anchor::TOP_LEFT)
-            .snap_to_anchor(scene.size, Anchor::TOP_LEFT),
-        square,
-    );
-
-    let circle = Circle {
-        radius: 120.0,
-        fill: Paint::Solid(Color::hsl(20.0, 0.7, 0.55)).into(),
-        stroke: None,
-    };
-    scene.add(
-        circle
-            .view_box()
-            .anchor(Anchor::BOTTOM_RIGHT)
-            .snap_to_anchor(scene.size, Anchor::BOTTOM_RIGHT),
-        circle,
-    );
 
     let image = scene.rasterize().render(Resolution::new(1280, 720));
 

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -12,11 +12,12 @@ use std::path::Path;
 use tellur_core::color::Color;
 use tellur_core::geometry::{Anchor, Vec2};
 use tellur_core::layer::VectorLayer;
+use tellur_core::placement::VectorPlacement;
 use tellur_core::raster::{RasterComponent, Resolution};
 use tellur_core::shapes::{Circle, Rectangle};
 use tellur_core::time::{LocalTime, Time};
 use tellur_core::timeline::timeline;
-use tellur_core::vector::{Paint, VectorComponent};
+use tellur_core::vector::Paint;
 use tellur_core::vector_component;
 use tellur_renderer::{FfmpegEncoder, Rasterizable};
 
@@ -27,62 +28,58 @@ use tellur_renderer::{FfmpegEncoder, Rasterizable};
 /// `TimelineTime` directly via `.into()` since it converts to `LocalTime`.
 #[vector_component]
 fn BouncingDot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
-    const PERIOD: f32 = 2.5;
-    const RADIUS: f32 = 30.0;
-    const SIDE_PADDING: f32 = 40.0;
-
-    let (phase, _) = t.bounce(PERIOD);
-    let view = Vec2(scene_width, RADIUS * 2.0);
-    let center_y = view.1 * 0.5;
-    let target = phase.interpolate(
-        Vec2(SIDE_PADDING + RADIUS, center_y),
-        Vec2(scene_width - SIDE_PADDING - RADIUS, center_y),
-    );
-
-    let circle = Circle {
-        radius: RADIUS,
-        fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
-        stroke: None,
-    };
+    let (phase, _) = t.bounce(2.5);
+    let size = Vec2(scene_width - 200.0, 60.0);
 
     VectorLayer {
-        size: view,
-        children: vec![(
-            circle.view_box().anchor(Anchor::CENTER).snap_to(target),
-            circle.boxed(),
-        )],
+        size,
+        children: vec![Circle {
+            radius: 30.0,
+            fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
+            stroke: None,
+        }
+        .anchored(Anchor::CENTER)
+        .snap_to(Anchor::new(phase.interpolate(0.0, 1.0), 0.5).point(size))],
     }
 }
 
 fn main() {
     let scene_size = Vec2(1280.0, 720.0);
     let tl = timeline(5.0, move |t, target| {
-        let background = Rectangle {
-            size: scene_size,
-            fill: Paint::Solid(Color::rgb_u8(20, 20, 30)).into(),
-            stroke: None,
-        };
-
-        // Distribute four dots evenly along the Y axis by snapping each one's
-        // CENTER_LEFT onto a fractional anchor at (0, (i + 0.5) / N) of the scene.
-        let dots = [60u32, 30, 24, 16].iter().enumerate().map(|(i, &fps)| {
-            let dot = BouncingDot {
-                t: t.fps(fps).into(),
-                scene_width: scene_size.0,
-            };
-            let stripe_anchor = Anchor::new(0.0, (i as f32 + 0.5) / 4f32);
-            let position = dot
-                .view_box()
-                .anchor(Anchor::CENTER_LEFT)
-                .snap_to_anchor(scene_size, stripe_anchor);
-            (position, dot.boxed())
-        });
-
         let scene = VectorLayer {
             size: scene_size,
-            children: std::iter::once((Vec2::ZERO, background.boxed()))
-                .chain(dots)
-                .collect(),
+            children: vec![
+                Rectangle {
+                    size: scene_size,
+                    fill: Paint::Solid(Color::rgb_u8(20, 20, 30)).into(),
+                    stroke: None,
+                }
+                .at(Vec2::ZERO),
+                BouncingDot {
+                    t: t.fps(60).into(),
+                    scene_width: scene_size.0,
+                }
+                .anchored(Anchor::CENTER)
+                .snap_to(Anchor::new(0.5, 0.125).point(scene_size)),
+                BouncingDot {
+                    t: t.fps(30).into(),
+                    scene_width: scene_size.0,
+                }
+                .anchored(Anchor::CENTER)
+                .snap_to(Anchor::new(0.5, 0.375).point(scene_size)),
+                BouncingDot {
+                    t: t.fps(24).into(),
+                    scene_width: scene_size.0,
+                }
+                .anchored(Anchor::CENTER)
+                .snap_to(Anchor::new(0.5, 0.625).point(scene_size)),
+                BouncingDot {
+                    t: t.fps(16).into(),
+                    scene_width: scene_size.0,
+                }
+                .anchored(Anchor::CENTER)
+                .snap_to(Anchor::new(0.5, 0.875).point(scene_size)),
+            ],
         };
 
         scene.rasterize().render(target)


### PR DESCRIPTION
Replace the `(Vec2, Box<dyn _>)` tuple in layer children with a `Placed<C>` wrapper, and add ext traits so positioning becomes a method chain on the component itself. Layer construction can now be a single struct-literal expression with all children placed inline.

- `tellur-core::placement` (new): `Placed<C: ?Sized> { position, child }`, plus `VectorPlacement` / `RasterPlacement` ext traits providing `at(pos)` and `anchored(self_anchor).snap_to(target_point)`. The anchored form mirrors `Vec2::anchored(...).snap_to(...)` so the geometry vocabulary carries over to component placement.
- `tellur-core::layer`: `VectorLayer.children` / `Layer.children` now hold `Vec<Placed<dyn _>>`; `add` takes a single `Placed<dyn _>` argument.
- `tellur-core::geometry`: rename `Vec2::anchor` → `anchored` (past-participle reads better at call sites). Drop `AnchoredSize::snap_to_anchor` — callers use `snap_to(target_anchor.point(target_size))`.
- Examples: all three reshaped to construct the layer as a single struct-literal with inline placement; `timeline_to_mp4` also unrolls the fps loop into four direct entries. The `(view_box().anchor().snap_to_anchor(...), boxed())` tuple form is gone.