### PR TITLE
feat: add padding, align, stack, and decoration layout containers

### DIFF
--- a/tellur-core/src/geometry.rs
+++ b/tellur-core/src/geometry.rs
@@ -130,3 +130,71 @@ impl AnchoredSize {
         target_point - self.anchor.point(self.size)
     }
 }
+
+/// Per-edge offsets, mirroring CSS's `padding` / `margin` shorthand.
+///
+/// All values are in the same logical units as [`Vec2`]. Negative values
+/// are permitted and produce overhangs (the inner box becomes larger than
+/// the outer one), which can be useful for outset effects.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EdgeInsets {
+    pub left: f32,
+    pub top: f32,
+    pub right: f32,
+    pub bottom: f32,
+}
+
+impl EdgeInsets {
+    pub const ZERO: Self = Self {
+        left: 0.0,
+        top: 0.0,
+        right: 0.0,
+        bottom: 0.0,
+    };
+
+    /// Same inset on every side.
+    pub const fn all(value: f32) -> Self {
+        Self {
+            left: value,
+            top: value,
+            right: value,
+            bottom: value,
+        }
+    }
+
+    /// Independent horizontal (left/right) and vertical (top/bottom) insets.
+    pub const fn symmetric(horizontal: f32, vertical: f32) -> Self {
+        Self {
+            left: horizontal,
+            top: vertical,
+            right: horizontal,
+            bottom: vertical,
+        }
+    }
+
+    /// Explicit per-side construction, in CSS order (left, top, right, bottom).
+    pub const fn only(left: f32, top: f32, right: f32, bottom: f32) -> Self {
+        Self {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    /// Total horizontal inset (`left + right`).
+    pub fn horizontal(&self) -> f32 {
+        self.left + self.right
+    }
+
+    /// Total vertical inset (`top + bottom`).
+    pub fn vertical(&self) -> f32 {
+        self.top + self.bottom
+    }
+
+    /// The top-left corner offset, i.e. where the inset content begins
+    /// relative to the outer box's origin.
+    pub fn top_left(&self) -> Vec2 {
+        Vec2(self.left, self.top)
+    }
+}

--- a/tellur-core/src/layer.rs
+++ b/tellur-core/src/layer.rs
@@ -102,31 +102,51 @@ impl RasterComponent for Layer {
     }
 
     fn render(&self, target: Resolution) -> RasterImage {
-        let pixel_count = (target.width as usize) * (target.height as usize);
-        let mut accum = vec![0u8; pixel_count * 4];
+        let placed: Vec<(Vec2, &dyn RasterComponent)> = self
+            .children
+            .iter()
+            .map(|p| (p.position, p.child.as_ref()))
+            .collect();
+        composite_children(self.size, target, &placed)
+    }
+}
 
-        // Pixels per logical unit on each axis. SVG's `preserveAspectRatio="none"`
-        // — independent scaling on each axis.
-        let scale_x = target.width as f32 / self.size.0;
-        let scale_y = target.height as f32 / self.size.1;
+/// Rasterizes a set of placed raster components into a `container_size`
+/// logical coordinate space and returns the composited image at `target`
+/// pixel resolution.
+///
+/// Shared between `Layer::render` and the raster layout containers, which
+/// all need the same "place children at logical offsets, then source-over
+/// composite" pipeline.
+pub(crate) fn composite_children(
+    container_size: Vec2,
+    target: Resolution,
+    placed: &[(Vec2, &dyn RasterComponent)],
+) -> RasterImage {
+    let pixel_count = (target.width as usize) * (target.height as usize);
+    let mut accum = vec![0u8; pixel_count * 4];
 
-        for placed in &self.children {
-            let child_size = placed.child.view_box();
-            let child_px_w = (child_size.0 * scale_x).round().max(1.0) as u32;
-            let child_px_h = (child_size.1 * scale_y).round().max(1.0) as u32;
-            let offset_x = (placed.position.0 * scale_x).round() as i32;
-            let offset_y = (placed.position.1 * scale_y).round() as i32;
+    // Pixels per logical unit on each axis. SVG's `preserveAspectRatio="none"`
+    // — independent scaling on each axis.
+    let scale_x = target.width as f32 / container_size.0;
+    let scale_y = target.height as f32 / container_size.1;
 
-            let image = placed.child.render(Resolution::new(child_px_w, child_px_h));
-            composite_at(&mut accum, target, &image, offset_x, offset_y);
-        }
+    for (position, child) in placed {
+        let child_size = child.view_box();
+        let child_px_w = (child_size.0 * scale_x).round().max(1.0) as u32;
+        let child_px_h = (child_size.1 * scale_y).round().max(1.0) as u32;
+        let offset_x = (position.0 * scale_x).round() as i32;
+        let offset_y = (position.1 * scale_y).round() as i32;
 
-        RasterImage {
-            width: target.width,
-            height: target.height,
-            format: PixelFormat::Rgba8,
-            pixels: Bytes::from(accum),
-        }
+        let image = child.render(Resolution::new(child_px_w, child_px_h));
+        composite_at(&mut accum, target, &image, offset_x, offset_y);
+    }
+
+    RasterImage {
+        width: target.width,
+        height: target.height,
+        format: PixelFormat::Rgba8,
+        pixels: Bytes::from(accum),
     }
 }
 

--- a/tellur-core/src/layout.rs
+++ b/tellur-core/src/layout.rs
@@ -399,9 +399,7 @@ pub mod raster {
 
     use bytes::Bytes;
 
-    use super::{
-        compute_stack_layout, Axis, Color, CrossAlign, EdgeInsets, MainAlign, Vec2,
-    };
+    use super::{compute_stack_layout, Axis, Color, CrossAlign, EdgeInsets, MainAlign, Vec2};
     use crate::geometry::Anchor;
     use crate::layer::composite_children;
     use crate::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
@@ -508,10 +506,8 @@ pub mod raster {
             match self.background {
                 Some(color) => {
                     let bg = SolidRect { size, color };
-                    let placed: Vec<(Vec2, &dyn RasterComponent)> = vec![
-                        (Vec2::ZERO, &bg),
-                        (Vec2::ZERO, self.child.as_ref()),
-                    ];
+                    let placed: Vec<(Vec2, &dyn RasterComponent)> =
+                        vec![(Vec2::ZERO, &bg), (Vec2::ZERO, self.child.as_ref())];
                     composite_children(size, target, &placed)
                 }
                 None => composite_children(size, target, &[(Vec2::ZERO, self.child.as_ref())]),

--- a/tellur-core/src/layout.rs
+++ b/tellur-core/src/layout.rs
@@ -1,0 +1,602 @@
+//! Layout containers for composing components.
+//!
+//! These containers describe CSS-Box / Flexbox-style arrangements without
+//! introducing a constraint-based layout pass: every container reports its
+//! `view_box` as a pure function of its children's intrinsic sizes (plus
+//! any explicit sizing it owns), matching the existing
+//! [`VectorComponent`](crate::vector::VectorComponent) /
+//! [`RasterComponent`](crate::raster::RasterComponent) model.
+//!
+//! - [`Padding`] adds an outer border of empty space around a child.
+//! - [`Align`] places a child inside a fixed-size box at a chosen anchor.
+//! - [`Stack`] arranges children along an axis with spacing and alignment.
+//! - [`DecoratedBox`] paints a background fill (and optionally a border for
+//!   the vector variant) underneath its child.
+//! - [`SizedBox`] is an empty placeholder of a given size, useful as a
+//!   spacer or to reserve a region.
+//!
+//! Vector containers live at the module root and operate on
+//! `Box<dyn VectorComponent>`. Their raster counterparts share the same
+//! names under [`raster`] and operate on `Box<dyn RasterComponent>`.
+
+use crate::color::Color;
+use crate::geometry::{Anchor, EdgeInsets, Transform, Vec2};
+use crate::vector::{
+    Fill, Group, Node, Paint, Path, PathCommand, Stroke, VectorComponent, VectorGraphic,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+/// Main-axis distribution of children in a [`Stack`]. The `Space*` variants
+/// override `Stack::spacing` and derive the gap from the leftover space on
+/// the main axis; `Start` / `Center` / `End` keep `Stack::spacing` as the
+/// inter-child gap.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MainAlign {
+    Start,
+    Center,
+    End,
+    SpaceBetween,
+    SpaceAround,
+    SpaceEvenly,
+}
+
+/// Cross-axis alignment of each child inside the stack's cross extent.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CrossAlign {
+    Start,
+    Center,
+    End,
+}
+
+// ─── shared stack measurement ────────────────────────────────────────────
+
+pub(crate) struct StackLayout {
+    pub own_size: Vec2,
+    /// Top-left position of each child in the stack's coordinate space,
+    /// same length as the input `child_sizes`.
+    pub placements: Vec<Vec2>,
+}
+
+/// Pure layout math shared by the vector and raster [`Stack`] variants.
+///
+/// `explicit_size` is the stack's outer size when the caller set it
+/// (`Stack::size`); otherwise the layout collapses to the intrinsic size
+/// `sum(children) + spacing*(n-1)` on the main axis and `max(children)` on
+/// the cross axis, and `main_align` / `cross_align` become no-ops because
+/// there is no free space to distribute.
+pub(crate) fn compute_stack_layout(
+    axis: Axis,
+    explicit_size: Option<Vec2>,
+    spacing: f32,
+    main_align: MainAlign,
+    cross_align: CrossAlign,
+    child_sizes: &[Vec2],
+) -> StackLayout {
+    let n = child_sizes.len();
+    let (mains, crosses): (Vec<f32>, Vec<f32>) = match axis {
+        Axis::Horizontal => child_sizes.iter().map(|s| (s.0, s.1)).unzip(),
+        Axis::Vertical => child_sizes.iter().map(|s| (s.1, s.0)).unzip(),
+    };
+    let total_main_children: f32 = mains.iter().sum();
+    let max_cross_children: f32 = crosses.iter().cloned().fold(0.0_f32, f32::max);
+
+    let gap_count = n.saturating_sub(1) as f32;
+    let intrinsic_main = total_main_children + spacing * gap_count;
+    let intrinsic_cross = max_cross_children;
+
+    let (own_main, own_cross) = match explicit_size {
+        Some(s) => match axis {
+            Axis::Horizontal => (s.0, s.1),
+            Axis::Vertical => (s.1, s.0),
+        },
+        None => (intrinsic_main, intrinsic_cross),
+    };
+
+    let (start_offset, gap) = if n == 0 {
+        (0.0, 0.0)
+    } else {
+        match main_align {
+            MainAlign::Start => (0.0, spacing),
+            MainAlign::Center => {
+                let used = total_main_children + spacing * gap_count;
+                ((own_main - used) * 0.5, spacing)
+            }
+            MainAlign::End => {
+                let used = total_main_children + spacing * gap_count;
+                (own_main - used, spacing)
+            }
+            MainAlign::SpaceBetween => {
+                let free = (own_main - total_main_children).max(0.0);
+                if n >= 2 {
+                    (0.0, free / (n - 1) as f32)
+                } else {
+                    ((own_main - total_main_children) * 0.5, 0.0)
+                }
+            }
+            MainAlign::SpaceAround => {
+                let free = (own_main - total_main_children).max(0.0);
+                let g = free / n as f32;
+                (g * 0.5, g)
+            }
+            MainAlign::SpaceEvenly => {
+                let free = (own_main - total_main_children).max(0.0);
+                let g = free / (n + 1) as f32;
+                (g, g)
+            }
+        }
+    };
+
+    let mut placements = Vec::with_capacity(n);
+    let mut cursor = start_offset;
+    for (i, &main_size) in mains.iter().enumerate() {
+        let cross_size = crosses[i];
+        let cross_pos = match cross_align {
+            CrossAlign::Start => 0.0,
+            CrossAlign::Center => (own_cross - cross_size) * 0.5,
+            CrossAlign::End => own_cross - cross_size,
+        };
+        let pos = match axis {
+            Axis::Horizontal => Vec2(cursor, cross_pos),
+            Axis::Vertical => Vec2(cross_pos, cursor),
+        };
+        placements.push(pos);
+        cursor += main_size + gap;
+    }
+
+    let own_size = match axis {
+        Axis::Horizontal => Vec2(own_main, own_cross),
+        Axis::Vertical => Vec2(own_cross, own_main),
+    };
+
+    StackLayout {
+        own_size,
+        placements,
+    }
+}
+
+// ─── vector containers ───────────────────────────────────────────────────
+
+/// Wraps a child with empty space on each side.
+pub struct Padding {
+    pub insets: EdgeInsets,
+    pub child: Box<dyn VectorComponent>,
+}
+
+impl VectorComponent for Padding {
+    fn view_box(&self) -> Vec2 {
+        let c = self.child.view_box();
+        Vec2(c.0 + self.insets.horizontal(), c.1 + self.insets.vertical())
+    }
+
+    fn render(&self) -> VectorGraphic {
+        let inner = self.child.render();
+        let view_box = Vec2(
+            inner.view_box.0 + self.insets.horizontal(),
+            inner.view_box.1 + self.insets.vertical(),
+        );
+        VectorGraphic {
+            view_box,
+            root: Node::Group(Group {
+                transform: Transform::translate(self.insets.top_left()),
+                opacity: 1.0,
+                children: vec![inner.root],
+            }),
+        }
+    }
+}
+
+/// Places a child inside a fixed-size box, snapping the child's `anchor`
+/// onto the same anchor point of the parent box. For example,
+/// `anchor: Anchor::CENTER` produces center-in-box; `Anchor::BOTTOM_RIGHT`
+/// pins to the bottom-right corner.
+pub struct Align {
+    pub size: Vec2,
+    pub anchor: Anchor,
+    pub child: Box<dyn VectorComponent>,
+}
+
+impl VectorComponent for Align {
+    fn view_box(&self) -> Vec2 {
+        self.size
+    }
+
+    fn render(&self) -> VectorGraphic {
+        let inner = self.child.render();
+        let pos = inner
+            .view_box
+            .anchored(self.anchor)
+            .snap_to(self.anchor.point(self.size));
+        VectorGraphic {
+            view_box: self.size,
+            root: Node::Group(Group {
+                transform: Transform::translate(pos),
+                opacity: 1.0,
+                children: vec![inner.root],
+            }),
+        }
+    }
+}
+
+/// Arranges children along [`axis`](Self::axis) with [`spacing`](Self::spacing)
+/// between them.
+///
+/// When [`size`](Self::size) is `None`, the stack reports its intrinsic
+/// extent and `main_align` / `cross_align` only have an observable effect
+/// for the cross axis (no free space on the main axis). Set `size` to
+/// `Some(...)` to expand into a fixed box and let `main_align` distribute
+/// the leftover main-axis space.
+pub struct Stack {
+    pub axis: Axis,
+    pub size: Option<Vec2>,
+    pub spacing: f32,
+    pub main_align: MainAlign,
+    pub cross_align: CrossAlign,
+    pub children: Vec<Box<dyn VectorComponent>>,
+}
+
+impl VectorComponent for Stack {
+    fn view_box(&self) -> Vec2 {
+        let sizes: Vec<Vec2> = self.children.iter().map(|c| c.view_box()).collect();
+        compute_stack_layout(
+            self.axis,
+            self.size,
+            self.spacing,
+            self.main_align,
+            self.cross_align,
+            &sizes,
+        )
+        .own_size
+    }
+
+    fn render(&self) -> VectorGraphic {
+        let sizes: Vec<Vec2> = self.children.iter().map(|c| c.view_box()).collect();
+        let layout = compute_stack_layout(
+            self.axis,
+            self.size,
+            self.spacing,
+            self.main_align,
+            self.cross_align,
+            &sizes,
+        );
+        let nodes: Vec<Node> = self
+            .children
+            .iter()
+            .zip(layout.placements.iter())
+            .map(|(child, pos)| {
+                let inner = child.render();
+                Node::Group(Group {
+                    transform: Transform::translate(*pos),
+                    opacity: 1.0,
+                    children: vec![inner.root],
+                })
+            })
+            .collect();
+        VectorGraphic {
+            view_box: layout.own_size,
+            root: Node::Group(Group {
+                transform: Transform::IDENTITY,
+                opacity: 1.0,
+                children: nodes,
+            }),
+        }
+    }
+}
+
+/// Paints a background fill and/or stroke behind a child, sized to the
+/// child's own view_box. Combine with [`Padding`] for the typical
+/// CSS-style "padded box with a background".
+pub struct DecoratedBox {
+    pub child: Box<dyn VectorComponent>,
+    pub background: Option<Paint>,
+    pub border: Option<Stroke>,
+}
+
+impl VectorComponent for DecoratedBox {
+    fn view_box(&self) -> Vec2 {
+        self.child.view_box()
+    }
+
+    fn render(&self) -> VectorGraphic {
+        let inner = self.child.render();
+        let size = inner.view_box;
+        let mut children: Vec<Node> = Vec::new();
+        if self.background.is_some() || self.border.is_some() {
+            children.push(Node::Path(Path {
+                commands: vec![
+                    PathCommand::MoveTo(Vec2(0.0, 0.0)),
+                    PathCommand::LineTo(Vec2(size.0, 0.0)),
+                    PathCommand::LineTo(Vec2(size.0, size.1)),
+                    PathCommand::LineTo(Vec2(0.0, size.1)),
+                    PathCommand::Close,
+                ],
+                fill: self.background.clone().map(|paint| Fill { paint }),
+                stroke: self.border.clone(),
+                transform: Transform::IDENTITY,
+            }));
+        }
+        children.push(inner.root);
+        VectorGraphic {
+            view_box: size,
+            root: Node::Group(Group {
+                transform: Transform::IDENTITY,
+                opacity: 1.0,
+                children,
+            }),
+        }
+    }
+}
+
+/// An empty box of the given size. Useful as a spacer between stack
+/// children or to reserve a region without any visible content.
+pub struct SizedBox {
+    pub size: Vec2,
+}
+
+impl VectorComponent for SizedBox {
+    fn view_box(&self) -> Vec2 {
+        self.size
+    }
+
+    fn render(&self) -> VectorGraphic {
+        VectorGraphic {
+            view_box: self.size,
+            root: Node::Group(Group {
+                transform: Transform::IDENTITY,
+                opacity: 1.0,
+                children: vec![],
+            }),
+        }
+    }
+}
+
+/// Fluent extension adding `.padding(...)`, `.background(...)`,
+/// `.border(...)`, `.align(...)` to every [`VectorComponent`].
+pub trait VectorLayoutExt: VectorComponent + Sized + 'static {
+    fn padding(self, insets: EdgeInsets) -> Padding {
+        Padding {
+            insets,
+            child: Box::new(self),
+        }
+    }
+
+    fn background(self, paint: Paint) -> DecoratedBox {
+        DecoratedBox {
+            child: Box::new(self),
+            background: Some(paint),
+            border: None,
+        }
+    }
+
+    fn border(self, stroke: Stroke) -> DecoratedBox {
+        DecoratedBox {
+            child: Box::new(self),
+            background: None,
+            border: Some(stroke),
+        }
+    }
+
+    fn align(self, size: Vec2, anchor: Anchor) -> Align {
+        Align {
+            size,
+            anchor,
+            child: Box::new(self),
+        }
+    }
+}
+
+impl<T: VectorComponent + 'static> VectorLayoutExt for T {}
+
+// ─── raster containers ───────────────────────────────────────────────────
+
+pub mod raster {
+    //! Raster equivalents of the vector layout containers. Same shape and
+    //! semantics; operate on `Box<dyn RasterComponent>`.
+
+    use bytes::Bytes;
+
+    use super::{
+        compute_stack_layout, Axis, Color, CrossAlign, EdgeInsets, MainAlign, Vec2,
+    };
+    use crate::geometry::Anchor;
+    use crate::layer::composite_children;
+    use crate::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
+
+    pub struct Padding {
+        pub insets: EdgeInsets,
+        pub child: Box<dyn RasterComponent>,
+    }
+
+    impl RasterComponent for Padding {
+        fn view_box(&self) -> Vec2 {
+            let c = self.child.view_box();
+            Vec2(c.0 + self.insets.horizontal(), c.1 + self.insets.vertical())
+        }
+
+        fn render(&self, target: Resolution) -> RasterImage {
+            let outer = self.view_box();
+            composite_children(
+                outer,
+                target,
+                &[(self.insets.top_left(), self.child.as_ref())],
+            )
+        }
+    }
+
+    pub struct Align {
+        pub size: Vec2,
+        pub anchor: Anchor,
+        pub child: Box<dyn RasterComponent>,
+    }
+
+    impl RasterComponent for Align {
+        fn view_box(&self) -> Vec2 {
+            self.size
+        }
+
+        fn render(&self, target: Resolution) -> RasterImage {
+            let child_size = self.child.view_box();
+            let pos = child_size
+                .anchored(self.anchor)
+                .snap_to(self.anchor.point(self.size));
+            composite_children(self.size, target, &[(pos, self.child.as_ref())])
+        }
+    }
+
+    pub struct Stack {
+        pub axis: Axis,
+        pub size: Option<Vec2>,
+        pub spacing: f32,
+        pub main_align: MainAlign,
+        pub cross_align: CrossAlign,
+        pub children: Vec<Box<dyn RasterComponent>>,
+    }
+
+    impl RasterComponent for Stack {
+        fn view_box(&self) -> Vec2 {
+            let sizes: Vec<Vec2> = self.children.iter().map(|c| c.view_box()).collect();
+            compute_stack_layout(
+                self.axis,
+                self.size,
+                self.spacing,
+                self.main_align,
+                self.cross_align,
+                &sizes,
+            )
+            .own_size
+        }
+
+        fn render(&self, target: Resolution) -> RasterImage {
+            let sizes: Vec<Vec2> = self.children.iter().map(|c| c.view_box()).collect();
+            let layout = compute_stack_layout(
+                self.axis,
+                self.size,
+                self.spacing,
+                self.main_align,
+                self.cross_align,
+                &sizes,
+            );
+            let placed: Vec<(Vec2, &dyn RasterComponent)> = self
+                .children
+                .iter()
+                .zip(layout.placements.iter())
+                .map(|(c, p)| (*p, c.as_ref()))
+                .collect();
+            composite_children(layout.own_size, target, &placed)
+        }
+    }
+
+    /// Raster decoration. Only solid-color backgrounds are supported for
+    /// now; stroking on raster is left to the vector path. For richer
+    /// decoration, decorate on the vector side and rasterize after.
+    pub struct DecoratedBox {
+        pub child: Box<dyn RasterComponent>,
+        pub background: Option<Color>,
+    }
+
+    impl RasterComponent for DecoratedBox {
+        fn view_box(&self) -> Vec2 {
+            self.child.view_box()
+        }
+
+        fn render(&self, target: Resolution) -> RasterImage {
+            let size = self.view_box();
+            match self.background {
+                Some(color) => {
+                    let bg = SolidRect { size, color };
+                    let placed: Vec<(Vec2, &dyn RasterComponent)> = vec![
+                        (Vec2::ZERO, &bg),
+                        (Vec2::ZERO, self.child.as_ref()),
+                    ];
+                    composite_children(size, target, &placed)
+                }
+                None => composite_children(size, target, &[(Vec2::ZERO, self.child.as_ref())]),
+            }
+        }
+    }
+
+    pub struct SizedBox {
+        pub size: Vec2,
+    }
+
+    impl RasterComponent for SizedBox {
+        fn view_box(&self) -> Vec2 {
+            self.size
+        }
+
+        fn render(&self, target: Resolution) -> RasterImage {
+            let bytes = (target.width as usize) * (target.height as usize) * 4;
+            RasterImage {
+                width: target.width,
+                height: target.height,
+                format: PixelFormat::Rgba8,
+                pixels: Bytes::from(vec![0u8; bytes]),
+            }
+        }
+    }
+
+    /// Internal helper: a solid-color rectangle of the given logical size,
+    /// rasterized by directly filling the pixel buffer.
+    struct SolidRect {
+        size: Vec2,
+        color: Color,
+    }
+
+    impl RasterComponent for SolidRect {
+        fn view_box(&self) -> Vec2 {
+            self.size
+        }
+
+        fn render(&self, target: Resolution) -> RasterImage {
+            let pixels = (target.width as usize) * (target.height as usize);
+            let mut buf = Vec::with_capacity(pixels * 4);
+            let r = (self.color.r * 255.0).round().clamp(0.0, 255.0) as u8;
+            let g = (self.color.g * 255.0).round().clamp(0.0, 255.0) as u8;
+            let b = (self.color.b * 255.0).round().clamp(0.0, 255.0) as u8;
+            let a = (self.color.a * 255.0).round().clamp(0.0, 255.0) as u8;
+            for _ in 0..pixels {
+                buf.push(r);
+                buf.push(g);
+                buf.push(b);
+                buf.push(a);
+            }
+            RasterImage {
+                width: target.width,
+                height: target.height,
+                format: PixelFormat::Rgba8,
+                pixels: Bytes::from(buf),
+            }
+        }
+    }
+
+    /// Fluent extension mirroring [`super::VectorLayoutExt`] for raster.
+    pub trait RasterLayoutExt: RasterComponent + Sized + 'static {
+        fn padding(self, insets: EdgeInsets) -> Padding {
+            Padding {
+                insets,
+                child: Box::new(self),
+            }
+        }
+
+        fn background(self, color: Color) -> DecoratedBox {
+            DecoratedBox {
+                child: Box::new(self),
+                background: Some(color),
+            }
+        }
+
+        fn align(self, size: Vec2, anchor: Anchor) -> Align {
+            Align {
+                size,
+                anchor,
+                child: Box::new(self),
+            }
+        }
+    }
+
+    impl<T: RasterComponent + 'static> RasterLayoutExt for T {}
+}

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod color;
 pub mod geometry;
 pub mod interpolate;
 pub mod layer;
+pub mod layout;
 pub mod phase;
 pub mod placement;
 pub mod raster;

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -1,23 +1,24 @@
-//! Compare 60 / 30 / 15 / 10 fps quantization on a back-and-forth dot.
+//! Compare 60 / 30 / 24 / 16 fps quantization on a back-and-forth dot.
 //!
 //! Renders a 5-second timeline where four blue dots bounce horizontally.
 //! Each dot is a `BouncingDot` whose motion is driven by the time fed to
 //! it; the four instances receive the same `t` quantized to different
-//! framerates via `Time::fps`. The instances are stacked vertically with
-//! `Anchor` so the stutter at lower fps is directly comparable against the
-//! smooth top track.
+//! framerates via `Time::fps`. A vertical `Stack` distributes the four
+//! tracks evenly inside the scene, with a `DecoratedBox` painting the
+//! dark background.
 
 use std::path::Path;
 
 use tellur_core::color::Color;
-use tellur_core::geometry::{Anchor, Vec2};
+use tellur_core::geometry::{EdgeInsets, Vec2};
 use tellur_core::layer::VectorLayer;
+use tellur_core::layout::{Axis, CrossAlign, MainAlign, Stack, VectorLayoutExt};
 use tellur_core::placement::VectorPlacement;
 use tellur_core::raster::{RasterComponent, Resolution};
-use tellur_core::shapes::{Circle, Rectangle};
+use tellur_core::shapes::Circle;
 use tellur_core::time::{LocalTime, Time};
 use tellur_core::timeline::timeline;
-use tellur_core::vector::Paint;
+use tellur_core::vector::{Paint, VectorComponent};
 use tellur_core::vector_component;
 use tellur_renderer::{FfmpegEncoder, Rasterizable};
 
@@ -30,6 +31,7 @@ use tellur_renderer::{FfmpegEncoder, Rasterizable};
 fn BouncingDot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
     let (phase, _) = t.bounce(2.5);
     let size = Vec2(scene_width - 200.0, 60.0);
+    let x = phase.interpolate(0.0, 1.0) * size.0;
 
     VectorLayer {
         size,
@@ -38,49 +40,32 @@ fn BouncingDot(t: LocalTime, scene_width: f32) -> impl VectorComponent {
             fill: Paint::Solid(Color::hsl(200.0, 0.7, 0.6)).into(),
             stroke: None,
         }
-        .anchored(Anchor::CENTER)
-        .snap_to(Anchor::new(phase.interpolate(0.0, 1.0), 0.5).point(size))],
+        .anchored(tellur_core::geometry::Anchor::CENTER)
+        .snap_to(Vec2(x, size.1 * 0.5))],
     }
 }
 
 fn main() {
     let scene_size = Vec2(1280.0, 720.0);
     let tl = timeline(5.0, move |t, target| {
-        let scene = VectorLayer {
-            size: scene_size,
-            children: vec![
-                Rectangle {
-                    size: scene_size,
-                    fill: Paint::Solid(Color::rgb_u8(20, 20, 30)).into(),
-                    stroke: None,
-                }
-                .at(Vec2::ZERO),
-                BouncingDot {
-                    t: t.fps(60).into(),
-                    scene_width: scene_size.0,
-                }
-                .anchored(Anchor::CENTER)
-                .snap_to(Anchor::new(0.5, 0.125).point(scene_size)),
-                BouncingDot {
-                    t: t.fps(30).into(),
-                    scene_width: scene_size.0,
-                }
-                .anchored(Anchor::CENTER)
-                .snap_to(Anchor::new(0.5, 0.375).point(scene_size)),
-                BouncingDot {
-                    t: t.fps(24).into(),
-                    scene_width: scene_size.0,
-                }
-                .anchored(Anchor::CENTER)
-                .snap_to(Anchor::new(0.5, 0.625).point(scene_size)),
-                BouncingDot {
-                    t: t.fps(16).into(),
-                    scene_width: scene_size.0,
-                }
-                .anchored(Anchor::CENTER)
-                .snap_to(Anchor::new(0.5, 0.875).point(scene_size)),
-            ],
+        let track = |fps: u32| {
+            BouncingDot {
+                t: t.fps(fps).into(),
+                scene_width: scene_size.0,
+            }
+            .boxed()
         };
+
+        let scene = Stack {
+            axis: Axis::Vertical,
+            size: Some(scene_size),
+            spacing: 0.0,
+            main_align: MainAlign::SpaceEvenly,
+            cross_align: CrossAlign::Center,
+            children: vec![track(60), track(30), track(24), track(16)],
+        }
+        .padding(EdgeInsets::all(100.0))
+        .background(Paint::Solid(Color::rgb_u8(20, 20, 30)));
 
         scene.rasterize().render(target)
     });


### PR DESCRIPTION
Add CSS-Box / Flexbox-style layout containers so scene composition can describe padding, stacking, alignment, and background fills declaratively instead of hand-computing anchor offsets at every call site. The containers preserve the existing "intrinsic-only" `view_box()` model and ship symmetrically for vector and raster.

- `tellur-core::geometry`: `EdgeInsets` with `ZERO` / `all` / `symmetric` / `only` constructors and `horizontal` / `vertical` / `top_left` accessors.
- `tellur-core::layout` (new): `Padding`, `Align`, `Stack`, `DecoratedBox`, `SizedBox` over `Box<dyn VectorComponent>`. `Stack` takes an `axis`, an optional outer `size`, `spacing`, plus `MainAlign` (`Start` / `Center` / `End` / `SpaceBetween` / `SpaceAround` / `SpaceEvenly`) and `CrossAlign` (`Start` / `Center` / `End`). `Align` snaps a child's anchor onto the same anchor of a fixed-size parent box. `DecoratedBox` paints an optional background fill and/or border underneath the child, sized to the child's view_box.
- `tellur-core::layout::raster`: same five containers over `Box<dyn RasterComponent>`. Raster `DecoratedBox` supports a solid-color background only for now; a small `SolidRect` rasterizes the fill by buffer-filling. Vector and raster `Stack` share a `compute_stack_layout` helper.
- `VectorLayoutExt` / `RasterLayoutExt`: fluent `.padding(...)`, `.background(...)`, `.border(...)`, `.align(...)`.
- `tellur-core::layer`: `Layer::render`'s compositing loop extracted into a `pub(crate) composite_children(container_size, target, &[(pos, &dyn RasterComponent)])` helper, shared with the raster layout containers.
- Example: `timeline_to_mp4` swaps the four hand-computed `Anchor::new(0.5, y_frac).point(scene_size)` calls for a `Stack { axis: Vertical, size: Some(scene_size), main_align: SpaceEvenly, cross_align: Center, ... }.padding(EdgeInsets::all(100.0)).background(...)`. `BouncingDot` still takes `scene_width` — making it intrinsic-free needs a `render_within` / `Stretch` follow-up in a separate PR.