### PR TITLE
feat: add Text component with per-span styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -119,6 +137,38 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fontconfig"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854f6a6479193c392bd820abcd2123b116f01eba7775b6bcfc26494be3285229"
+dependencies = [
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "futures-core"
@@ -187,6 +237,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +272,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -237,6 +312,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -276,10 +357,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -292,6 +397,21 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strict-num"
@@ -328,7 +448,10 @@ name = "tellur-core"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "fontconfig",
+ "fontdb",
  "png",
+ "rustybuzz",
  "tellur-macros",
  "thiserror",
 ]
@@ -403,10 +526,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-width"
@@ -419,6 +590,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"
@@ -628,3 +805,14 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
           ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             pkgs.pkg-config
             pkgs.mold
+            pkgs.fontconfig
           ];
         };
       }

--- a/tellur-core/Cargo.toml
+++ b/tellur-core/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.11.1"
+fontconfig = "0.10"
+fontdb = "0.23"
 png = "0.18.1"
+rustybuzz = "0.20"
 tellur-macros = { path = "../tellur-macros", version = "0.1.0" }
 thiserror = "2.0.18"

--- a/tellur-core/src/layer.rs
+++ b/tellur-core/src/layer.rs
@@ -30,14 +30,27 @@ use crate::vector::{Group, Node, VectorComponent, VectorGraphic};
 
 #[derive(PartialEq, Hash)]
 pub struct VectorLayer {
-    pub size: Vec2,
+    /// `Some(size)` for a fixed extent; `None` to auto-fit the
+    /// bounding box of the children's placed paint bounds (the layer's
+    /// `view_box.origin` then matches that bounding rect's origin, so
+    /// children with negative positions are not clipped).
+    pub size: Option<Vec2>,
     pub children: Vec<Placed<dyn VectorComponent>>,
 }
 
 impl VectorLayer {
+    /// Fixed-size layer of the given extent.
     pub fn new(size: Vec2) -> Self {
         Self {
-            size,
+            size: Some(size),
+            children: Vec::new(),
+        }
+    }
+
+    /// Auto-fit layer that shrinks to the children's bounding box.
+    pub fn fit() -> Self {
+        Self {
+            size: None,
             children: Vec::new(),
         }
     }
@@ -46,14 +59,43 @@ impl VectorLayer {
         self.children.push(child);
         self
     }
+
+    /// Bounding rect of all children's placed paint bounds, computed
+    /// with each child laid out under `Constraints::UNBOUNDED`. Returns
+    /// a zero rect when there are no children.
+    fn children_bounds(&self) -> Rect {
+        let mut iter = self.children.iter().map(|placed| {
+            let child_size = placed.child.layout(Constraints::UNBOUNDED);
+            let child_paint = placed.child.paint_bounds(child_size);
+            translate_rect(child_paint, placed.position)
+        });
+        let Some(first) = iter.next() else {
+            return Rect {
+                origin: Vec2::ZERO,
+                size: Vec2::ZERO,
+            };
+        };
+        iter.fold(first, union_rect)
+    }
 }
 
 impl VectorComponent for VectorLayer {
     fn layout(&self, constraints: Constraints) -> Vec2 {
-        constraints.constrain(self.size)
+        let intrinsic = match self.size {
+            Some(s) => s,
+            None => self.children_bounds().size,
+        };
+        constraints.constrain(intrinsic)
     }
 
     fn render(&self, size: Vec2) -> VectorGraphic {
+        // For auto-fit, the view_box origin tracks the children's
+        // bounding rect so children that paint at negative positions
+        // are inside the box rather than clipped.
+        let view_origin = match self.size {
+            Some(_) => Vec2::ZERO,
+            None => self.children_bounds().origin,
+        };
         let child_constraints = Constraints::loose(size);
         let children: Vec<Node> = self
             .children
@@ -70,7 +112,7 @@ impl VectorComponent for VectorLayer {
             .collect();
         VectorGraphic {
             view_box: Rect {
-                origin: Vec2::ZERO,
+                origin: view_origin,
                 size,
             },
             root: Node::Group(Group {
@@ -84,14 +126,25 @@ impl VectorComponent for VectorLayer {
 
 #[derive(PartialEq, Hash)]
 pub struct Layer {
-    pub size: Vec2,
+    /// `Some(size)` for a fixed extent; `None` to auto-fit the
+    /// bounding box of the children's placed paint bounds.
+    pub size: Option<Vec2>,
     pub children: Vec<Placed<dyn RasterComponent>>,
 }
 
 impl Layer {
+    /// Fixed-size layer of the given extent.
     pub fn new(size: Vec2) -> Self {
         Self {
-            size,
+            size: Some(size),
+            children: Vec::new(),
+        }
+    }
+
+    /// Auto-fit layer that shrinks to the children's bounding box.
+    pub fn fit() -> Self {
+        Self {
+            size: None,
             children: Vec::new(),
         }
     }
@@ -100,14 +153,42 @@ impl Layer {
         self.children.push(child);
         self
     }
+
+    /// Bounding rect of all children's placed paint bounds, computed
+    /// with each child laid out under `Constraints::UNBOUNDED`.
+    fn children_bounds(&self) -> Rect {
+        let mut iter = self.children.iter().map(|placed| {
+            let child_size = placed.child.layout(Constraints::UNBOUNDED);
+            let child_paint = placed.child.paint_bounds(child_size);
+            translate_rect(child_paint, placed.position)
+        });
+        let Some(first) = iter.next() else {
+            return Rect {
+                origin: Vec2::ZERO,
+                size: Vec2::ZERO,
+            };
+        };
+        iter.fold(first, union_rect)
+    }
 }
 
 impl RasterComponent for Layer {
     fn layout(&self, constraints: Constraints) -> Vec2 {
-        constraints.constrain(self.size)
+        let intrinsic = match self.size {
+            Some(s) => s,
+            None => self.children_bounds().size,
+        };
+        constraints.constrain(intrinsic)
     }
 
     fn paint_bounds(&self, size: Vec2) -> Rect {
+        // For auto-fit, the children's bounding rect *is* the paint
+        // region (the layout `size` was derived from it). For fixed
+        // size, start from the `(0,0)..size` rect and grow it to
+        // include any children that overflow the box.
+        if self.size.is_none() {
+            return self.children_bounds();
+        }
         let child_constraints = Constraints::loose(size);
         let mut bounds = Rect {
             origin: Vec2::ZERO,
@@ -212,5 +293,75 @@ pub(crate) fn translate_rect(r: Rect, delta: Vec2) -> Rect {
     Rect {
         origin: Vec2(r.origin.0 + delta.0, r.origin.1 + delta.1),
         size: r.size,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::Color;
+    use crate::placement::VectorPlacement;
+    use crate::shapes::Rectangle;
+    use crate::vector::Paint;
+
+    fn rect(w: f32, h: f32) -> Rectangle {
+        Rectangle {
+            size: Vec2(w, h),
+            fill: Paint::Solid(Color::rgb_u8(0, 0, 0)).into(),
+            stroke: None,
+        }
+    }
+
+    #[test]
+    fn vector_layer_fit_to_single_child_size() {
+        let layer = VectorLayer {
+            size: None,
+            children: vec![rect(80.0, 40.0).at(Vec2(10.0, 20.0))],
+        };
+        assert_eq!(layer.layout(Constraints::UNBOUNDED), Vec2(80.0, 40.0));
+    }
+
+    #[test]
+    fn vector_layer_fit_unions_disjoint_children() {
+        let layer = VectorLayer {
+            size: None,
+            children: vec![
+                rect(50.0, 50.0).at(Vec2(0.0, 0.0)),
+                rect(50.0, 50.0).at(Vec2(100.0, 100.0)),
+            ],
+        };
+        // bounding (0,0)..(150,150) → size (150, 150)
+        assert_eq!(layer.layout(Constraints::UNBOUNDED), Vec2(150.0, 150.0));
+    }
+
+    #[test]
+    fn vector_layer_fit_handles_negative_positions() {
+        let layer = VectorLayer {
+            size: None,
+            children: vec![
+                rect(100.0, 100.0).at(Vec2(-30.0, 0.0)),
+                rect(100.0, 100.0).at(Vec2(50.0, 20.0)),
+            ],
+        };
+        // bounding (-30,0)..(150,120) → size (180, 120)
+        assert_eq!(layer.layout(Constraints::UNBOUNDED), Vec2(180.0, 120.0));
+    }
+
+    #[test]
+    fn vector_layer_fixed_size_unchanged() {
+        let layer = VectorLayer {
+            size: Some(Vec2(500.0, 300.0)),
+            children: vec![rect(80.0, 40.0).at(Vec2(10.0, 20.0))],
+        };
+        assert_eq!(layer.layout(Constraints::UNBOUNDED), Vec2(500.0, 300.0));
+    }
+
+    #[test]
+    fn vector_layer_fit_empty_is_zero() {
+        let layer = VectorLayer {
+            size: None,
+            children: vec![],
+        };
+        assert_eq!(layer.layout(Constraints::UNBOUNDED), Vec2::ZERO);
     }
 }

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod placement;
 pub mod raster;
 pub mod render_context;
 pub mod shapes;
+pub mod text;
 pub mod time;
 pub mod timeline;
 pub mod vector;

--- a/tellur-core/src/placement.rs
+++ b/tellur-core/src/placement.rs
@@ -51,6 +51,31 @@ impl<C: ?Sized + Hash> Hash for Placed<C> {
     }
 }
 
+// Type-erasure conversions for handing a `Placed<ConcreteType>` to
+// containers typed against `Placed<dyn ...>` (e.g. `VectorLayer.children`).
+// The `Box<C>` → `Box<dyn ...>` unsizing is implicit via the explicit
+// `let` binding.
+
+impl<C: VectorComponent + 'static> From<Placed<C>> for Placed<dyn VectorComponent> {
+    fn from(placed: Placed<C>) -> Self {
+        let child: Box<dyn VectorComponent> = placed.child;
+        Placed {
+            position: placed.position,
+            child,
+        }
+    }
+}
+
+impl<C: RasterComponent + 'static> From<Placed<C>> for Placed<dyn RasterComponent> {
+    fn from(placed: Placed<C>) -> Self {
+        let child: Box<dyn RasterComponent> = placed.child;
+        Placed {
+            position: placed.position,
+            child,
+        }
+    }
+}
+
 /// Extension trait that adds placement methods to every [`VectorComponent`].
 ///
 /// Brought into scope alongside `use tellur_core::vector::VectorComponent`,

--- a/tellur-core/src/text.rs
+++ b/tellur-core/src/text.rs
@@ -442,10 +442,7 @@ impl Text {
     fn shape_and_layout(&self) -> (Vec<(Vec<PathCommand>, Paint)>, Vec2) {
         let (_, line_height) = self.line_metrics();
         let spans = self.shape_per_span();
-        let total_width = spans
-            .last()
-            .map(|s| s.start_x + s.width)
-            .unwrap_or(0.0);
+        let total_width = spans.last().map(|s| s.start_x + s.width).unwrap_or(0.0);
 
         let mut all_paths: Vec<(Vec<PathCommand>, Paint)> = Vec::new();
         for span in spans {
@@ -552,7 +549,9 @@ impl VectorComponent for TextSpanGraphic {
             .map(|(commands, fill)| {
                 Node::Path(VPath {
                     commands: commands.clone(),
-                    fill: Some(Fill { paint: fill.clone() }),
+                    fill: Some(Fill {
+                        paint: fill.clone(),
+                    }),
                     stroke: None,
                     transform: Transform::IDENTITY,
                 })

--- a/tellur-core/src/text.rs
+++ b/tellur-core/src/text.rs
@@ -1,0 +1,649 @@
+//! Text rendering as a vector component.
+//!
+//! [`Text`] shapes a sequence of [`TextSpan`]s with rustybuzz, lays the
+//! resulting glyph runs out left-to-right, and emits one filled
+//! [`Path`](crate::vector::Path) per glyph through the existing
+//! [`VectorGraphic`] pipeline. The base `Text { font, size, fill }`
+//! provides defaults that each `TextSpan` may override on a per-field
+//! basis: a `Some(_)` value on a span replaces the base; `None` inherits
+//! it. Coloring a substring red is therefore just "insert a `TextSpan`
+//! whose `fill: Some(Paint::Solid(red))` between plain spans".
+//!
+//! Single-line only for now: `\n` is not interpreted; multi-line layout
+//! and line breaking are deferred to a follow-up.
+
+use std::hash::{Hash, Hasher};
+use std::path::Path as FsPath;
+use std::sync::{Arc, LazyLock};
+
+use rustybuzz::{ttf_parser, UnicodeBuffer};
+use thiserror::Error;
+
+use crate::dyn_compare::hash_f32;
+use crate::geometry::{Constraints, Rect, Transform, Vec2};
+use crate::placement::Placed;
+use crate::vector::{
+    Fill, Group, Node, Paint, Path as VPath, PathCommand, VectorComponent, VectorGraphic,
+};
+
+#[derive(Debug, Error)]
+pub enum FontError {
+    #[error("failed to parse font data")]
+    Parse,
+    #[error("failed to read font file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("no system font found matching {name:?}")]
+    NotFound { name: String },
+    #[error("fontconfig is not available on this system")]
+    FontconfigUnavailable,
+}
+
+/// The system's default sans-serif font, resolved once via fontconfig
+/// on first access and shared thereafter. Use `SANS_SERIF.clone()` to
+/// get an `Arc<Font>` cheap to hand to `Text::font`. The first access
+/// panics if no sans-serif family is resolvable on this system; use
+/// [`Font::sans_serif`] if you need to handle that case yourself.
+pub static SANS_SERIF: LazyLock<Arc<Font>> =
+    LazyLock::new(|| Arc::new(Font::sans_serif().expect("resolve system sans-serif font")));
+
+/// The system's default serif font. See [`SANS_SERIF`] for sharing
+/// semantics.
+pub static SERIF: LazyLock<Arc<Font>> =
+    LazyLock::new(|| Arc::new(Font::serif().expect("resolve system serif font")));
+
+/// The system's default monospace font. See [`SANS_SERIF`].
+pub static MONOSPACE: LazyLock<Arc<Font>> =
+    LazyLock::new(|| Arc::new(Font::monospace().expect("resolve system monospace font")));
+
+/// The system's default cursive font. See [`SANS_SERIF`].
+pub static CURSIVE: LazyLock<Arc<Font>> =
+    LazyLock::new(|| Arc::new(Font::cursive().expect("resolve system cursive font")));
+
+/// The system's default fantasy font. See [`SANS_SERIF`].
+pub static FANTASY: LazyLock<Arc<Font>> =
+    LazyLock::new(|| Arc::new(Font::fantasy().expect("resolve system fantasy font")));
+
+/// An owned font, cheaply shareable via `Arc<Font>` across components.
+///
+/// The byte buffer is reference-counted; a fresh `rustybuzz::Face` is
+/// constructed per shaping/outlining call. The parse is not free but is
+/// inexpensive relative to a full text render, and this avoids the
+/// self-referential storage that would be needed to cache the face
+/// alongside its backing bytes.
+pub struct Font {
+    data: Arc<Vec<u8>>,
+    face_index: u32,
+}
+
+impl Font {
+    /// Constructs a `Font` from owned font bytes (the first face in the
+    /// file). The bytes are parsed once for validation; `FontError::Parse`
+    /// is returned if they do not represent a valid font face.
+    pub fn from_bytes(bytes: impl Into<Arc<Vec<u8>>>) -> Result<Self, FontError> {
+        Self::from_bytes_indexed(bytes, 0)
+    }
+
+    /// Like [`Font::from_bytes`] but selects `face_index` from inside the
+    /// container (used for font collections; .ttc files carry several
+    /// faces in one blob).
+    pub fn from_bytes_indexed(
+        bytes: impl Into<Arc<Vec<u8>>>,
+        face_index: u32,
+    ) -> Result<Self, FontError> {
+        let data: Arc<Vec<u8>> = bytes.into();
+        rustybuzz::Face::from_slice(data.as_ref(), face_index).ok_or(FontError::Parse)?;
+        Ok(Self { data, face_index })
+    }
+
+    /// Reads `path` into memory and constructs a `Font` from the bytes
+    /// (first face only).
+    pub fn load_file(path: impl AsRef<FsPath>) -> Result<Self, FontError> {
+        let bytes = std::fs::read(path)?;
+        Self::from_bytes(bytes)
+    }
+
+    /// Resolves the system's default sans-serif font through fontconfig
+    /// (e.g. "Noto Sans" or "DejaVu Sans" on Linux, "Helvetica" on
+    /// macOS).
+    pub fn sans_serif() -> Result<Self, FontError> {
+        Self::find_generic("sans-serif")
+    }
+
+    /// Resolves the system's default serif font through fontconfig.
+    pub fn serif() -> Result<Self, FontError> {
+        Self::find_generic("serif")
+    }
+
+    /// Resolves the system's default monospace font through fontconfig.
+    pub fn monospace() -> Result<Self, FontError> {
+        Self::find_generic("monospace")
+    }
+
+    /// Resolves the system's default cursive font through fontconfig.
+    pub fn cursive() -> Result<Self, FontError> {
+        Self::find_generic("cursive")
+    }
+
+    /// Resolves the system's default fantasy font through fontconfig.
+    pub fn fantasy() -> Result<Self, FontError> {
+        Self::find_generic("fantasy")
+    }
+
+    /// Shared backend for the generic-family lookups. Delegates to
+    /// fontconfig's `FcMatch` (the same machinery `fc-match` uses), so
+    /// the result reflects the user's actual system configuration —
+    /// including any per-language or per-script overrides — rather than
+    /// any hardcoded fallback list.
+    fn find_generic(family: &str) -> Result<Self, FontError> {
+        let fc = fontconfig::Fontconfig::new().ok_or(FontError::FontconfigUnavailable)?;
+        let resolved = fc.find(family, None).ok_or_else(|| FontError::NotFound {
+            name: family.to_owned(),
+        })?;
+        Self::load_file(resolved.path)
+    }
+
+    /// Resolves a font by family name through the system font database
+    /// (e.g. `"DejaVu Sans"`, `"Helvetica"`). The system fonts are scanned
+    /// on each call — fine for one-off setup, not for tight loops; cache
+    /// the returned `Font` in an `Arc` for reuse.
+    pub fn find_by_name(name: &str) -> Result<Self, FontError> {
+        Self::find_by_name_with_weight(name, Weight::NORMAL)
+    }
+
+    /// Like [`Font::find_by_name`] but selects a specific weight. Useful
+    /// for picking the actual "Bold" file out of a family that ships
+    /// each weight as a separate `.ttf` (e.g. `DejaVu Sans` →
+    /// `DejaVuSans-Bold.ttf`).
+    pub fn find_by_name_with_weight(name: &str, weight: Weight) -> Result<Self, FontError> {
+        let mut db = fontdb::Database::new();
+        db.load_system_fonts();
+        let query = fontdb::Query {
+            families: &[fontdb::Family::Name(name)],
+            weight: fontdb::Weight(weight.0),
+            ..fontdb::Query::default()
+        };
+        let not_found = || FontError::NotFound {
+            name: format!("{} (weight {})", name, weight.0),
+        };
+        let id = db.query(&query).ok_or_else(not_found)?;
+        let face = db.face(id).ok_or_else(not_found)?;
+        let face_index = face.index;
+        match &face.source {
+            fontdb::Source::File(path) => {
+                let bytes = std::fs::read(path)?;
+                Self::from_bytes_indexed(bytes, face_index)
+            }
+            fontdb::Source::Binary(arc) | fontdb::Source::SharedFile(_, arc) => {
+                let bytes: Vec<u8> = arc.as_ref().as_ref().to_vec();
+                Self::from_bytes_indexed(bytes, face_index)
+            }
+        }
+    }
+
+    fn face(&self) -> rustybuzz::Face<'_> {
+        rustybuzz::Face::from_slice(self.data.as_ref(), self.face_index)
+            .expect("font data validated in Font constructors")
+    }
+}
+
+// `PartialEq`/`Hash` use `Arc` pointer identity, so two `Font`s
+// referring to the same buffer compare equal cheaply. Loading the same
+// file twice yields distinct `Font`s, which is intentional — render
+// caches should miss on independent loads rather than re-validate that
+// two buffers contain identical bytes.
+impl PartialEq for Font {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.data, &other.data) && self.face_index == other.face_index
+    }
+}
+
+impl Hash for Font {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (Arc::as_ptr(&self.data) as usize).hash(state);
+        self.face_index.hash(state);
+    }
+}
+
+/// CSS-style weight value (100 = Thin, 400 = Normal, 700 = Bold, ...).
+///
+/// Applied as the OpenType `wght` variation axis. Has visible effect
+/// only on Variable Fonts that expose the `wght` axis; on a non-VF font
+/// the value is silently ignored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Weight(pub u16);
+
+impl Weight {
+    pub const THIN: Self = Self(100);
+    pub const EXTRA_LIGHT: Self = Self(200);
+    pub const LIGHT: Self = Self(300);
+    pub const NORMAL: Self = Self(400);
+    pub const MEDIUM: Self = Self(500);
+    pub const SEMIBOLD: Self = Self(600);
+    pub const BOLD: Self = Self(700);
+    pub const EXTRA_BOLD: Self = Self(800);
+    pub const BLACK: Self = Self(900);
+}
+
+impl Default for Weight {
+    fn default() -> Self {
+        Self::NORMAL
+    }
+}
+
+/// A run of text with optional per-field style overrides.
+///
+/// Any `None` field inherits the value from the enclosing [`Text`]'s
+/// base. To color a substring, insert a `TextSpan` whose `fill` is
+/// `Some(Paint::Solid(color))` between plain spans.
+#[derive(Default, Clone)]
+pub struct TextSpan {
+    pub text: String,
+    pub fill: Option<Paint>,
+    pub font: Option<Arc<Font>>,
+    pub size: Option<f32>,
+    pub weight: Option<Weight>,
+}
+
+impl TextSpan {
+    /// A span carrying only text — fill, font, and size inherit from
+    /// the enclosing [`Text`].
+    pub fn plain(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            ..Self::default()
+        }
+    }
+}
+
+impl PartialEq for TextSpan {
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text
+            && self.fill == other.fill
+            && match (&self.font, &other.font) {
+                (Some(a), Some(b)) => a == b,
+                (None, None) => true,
+                _ => false,
+            }
+            && self.size.map(f32::to_bits) == other.size.map(f32::to_bits)
+            && self.weight == other.weight
+    }
+}
+
+impl Hash for TextSpan {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.text.hash(state);
+        self.fill.hash(state);
+        match &self.font {
+            None => 0u8.hash(state),
+            Some(f) => {
+                1u8.hash(state);
+                f.as_ref().hash(state);
+            }
+        }
+        match self.size {
+            None => 0u8.hash(state),
+            Some(v) => {
+                1u8.hash(state);
+                hash_f32(v, state);
+            }
+        }
+        self.weight.hash(state);
+    }
+}
+
+/// A single line of styled text.
+///
+/// `font`, `size`, `weight`, and `fill` are the defaults used by every
+/// `TextSpan` that does not override them; `spans` carries the actual
+/// content and any per-region styling.
+#[derive(Clone)]
+pub struct Text {
+    pub spans: Vec<TextSpan>,
+    pub font: Arc<Font>,
+    pub size: f32,
+    pub weight: Weight,
+    pub fill: Paint,
+}
+
+impl PartialEq for Text {
+    fn eq(&self, other: &Self) -> bool {
+        self.spans == other.spans
+            && self.font == other.font
+            && self.size.to_bits() == other.size.to_bits()
+            && self.weight == other.weight
+            && self.fill == other.fill
+    }
+}
+
+impl Hash for Text {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.spans.hash(state);
+        self.font.as_ref().hash(state);
+        hash_f32(self.size, state);
+        self.weight.hash(state);
+        self.fill.hash(state);
+    }
+}
+
+impl Text {
+    fn effective_fill(&self, span: &TextSpan) -> Paint {
+        span.fill.clone().unwrap_or_else(|| self.fill.clone())
+    }
+
+    fn effective_font<'a>(&'a self, span: &'a TextSpan) -> &'a Arc<Font> {
+        span.font.as_ref().unwrap_or(&self.font)
+    }
+
+    fn effective_size(&self, span: &TextSpan) -> f32 {
+        span.size.unwrap_or(self.size)
+    }
+
+    fn effective_weight(&self, span: &TextSpan) -> Weight {
+        span.weight.unwrap_or(self.weight)
+    }
+
+    /// Vertical metrics of the base font at `self.size`, returned as
+    /// `(ascent, line_height)`.
+    fn line_metrics(&self) -> (f32, f32) {
+        let base_face = self.font.face();
+        let base_upem = base_face.units_per_em() as f32;
+        let base_scale = self.size / base_upem;
+        let ascent = base_face.ascender() as f32 * base_scale;
+        // `descender` is conventionally negative (below baseline).
+        let descent = base_face.descender() as f32 * base_scale;
+        let line_gap = base_face.line_gap() as f32 * base_scale;
+        let line_height = ascent - descent + line_gap;
+        (ascent, line_height)
+    }
+
+    /// Shapes each span and returns one [`ShapedSpan`] per input
+    /// [`TextSpan`], with paths in local (span-relative) coordinates so
+    /// each span graphic can be used as an independent placeable
+    /// component. The line height comes from the base font; spans that
+    /// override `font`/`size` may visually paint past the line box for
+    /// now.
+    fn shape_per_span(&self) -> Vec<ShapedSpan> {
+        let (ascent, _) = self.line_metrics();
+        let baseline_y = ascent;
+
+        let mut out = Vec::with_capacity(self.spans.len());
+        let mut pen_x: f32 = 0.0;
+
+        for span in &self.spans {
+            let span_start_x = pen_x;
+            let mut span_paths: Vec<(Vec<PathCommand>, Paint)> = Vec::new();
+
+            if !span.text.is_empty() {
+                let font = self.effective_font(span);
+                let size = self.effective_size(span);
+                let fill = self.effective_fill(span);
+                let weight = self.effective_weight(span);
+
+                let mut face = font.face();
+                // Apply the OpenType `wght` axis. No effect on fonts
+                // without a `wght` axis; the call returns `None` and
+                // we just keep going.
+                face.set_variations(&[rustybuzz::Variation {
+                    tag: ttf_parser::Tag::from_bytes(b"wght"),
+                    value: weight.0 as f32,
+                }]);
+                let upem = face.units_per_em() as f32;
+                let scale = size / upem;
+
+                let mut buffer = UnicodeBuffer::new();
+                buffer.push_str(&span.text);
+                let glyph_buffer = rustybuzz::shape(&face, &[], buffer);
+
+                for (info, pos) in glyph_buffer
+                    .glyph_infos()
+                    .iter()
+                    .zip(glyph_buffer.glyph_positions().iter())
+                {
+                    let glyph_id = ttf_parser::GlyphId(info.glyph_id as u16);
+                    let x_off = pos.x_offset as f32 * scale;
+                    let y_off = pos.y_offset as f32 * scale;
+                    // Local x: span starts at 0 in its own space.
+                    let glyph_x = (pen_x - span_start_x) + x_off;
+                    // Font Y points up; flipping by subtracting `y_off`
+                    // from the Y-down baseline puts the glyph in our
+                    // space.
+                    let glyph_y = baseline_y - y_off;
+
+                    let mut builder = OutlinePathBuilder {
+                        commands: Vec::new(),
+                        scale,
+                        origin_x: glyph_x,
+                        origin_y: glyph_y,
+                    };
+                    face.outline_glyph(glyph_id, &mut builder);
+                    if !builder.commands.is_empty() {
+                        span_paths.push((builder.commands, fill.clone()));
+                    }
+
+                    pen_x += pos.x_advance as f32 * scale;
+                    // y_advance is typically 0 for horizontal text.
+                }
+            }
+
+            let width = pen_x - span_start_x;
+            out.push(ShapedSpan {
+                start_x: span_start_x,
+                width,
+                paths: span_paths,
+            });
+        }
+
+        out
+    }
+
+    /// Shapes every span and returns `(glyph paths, intrinsic size)`,
+    /// with paths in the line's global coordinates (all spans
+    /// concatenated left-to-right).
+    fn shape_and_layout(&self) -> (Vec<(Vec<PathCommand>, Paint)>, Vec2) {
+        let (_, line_height) = self.line_metrics();
+        let spans = self.shape_per_span();
+        let total_width = spans
+            .last()
+            .map(|s| s.start_x + s.width)
+            .unwrap_or(0.0);
+
+        let mut all_paths: Vec<(Vec<PathCommand>, Paint)> = Vec::new();
+        for span in spans {
+            let delta = Vec2(span.start_x, 0.0);
+            for (commands, fill) in span.paths {
+                let shifted: Vec<PathCommand> = commands
+                    .into_iter()
+                    .map(|c| translate_command(c, delta))
+                    .collect();
+                all_paths.push((shifted, fill));
+            }
+        }
+
+        (all_paths, Vec2(total_width, line_height))
+    }
+
+    /// Decompose the text into per-span graphics, each placed at the
+    /// position where its first glyph would land in the line. The
+    /// returned `Vec` has exactly one entry per input
+    /// [`TextSpan`] (in the same order), and entries for empty spans
+    /// are zero-width placeholders so positional indexing matches.
+    ///
+    /// Useful for attaching per-span effects (transforms, drop shadows
+    /// on the rasterized form, outlines, ...) by manipulating each
+    /// [`Placed<TextSpanGraphic>`] before composing them back into a
+    /// layer:
+    ///
+    /// ```ignore
+    /// let [hello, world, bang]: [Placed<TextSpanGraphic>; 3] =
+    ///     Text { ... }.into_spans().try_into().unwrap();
+    ///
+    /// let layer = VectorLayer {
+    ///     size: None,                 // auto-fit
+    ///     children: vec![hello.into(), world.into(), bang.into()],
+    /// };
+    /// ```
+    pub fn into_spans(self) -> Vec<Placed<TextSpanGraphic>> {
+        let (_, line_height) = self.line_metrics();
+        self.shape_per_span()
+            .into_iter()
+            .map(|s| Placed {
+                position: Vec2(s.start_x, 0.0),
+                child: Box::new(TextSpanGraphic {
+                    paths: s.paths,
+                    size: Vec2(s.width, line_height),
+                }),
+            })
+            .collect()
+    }
+}
+
+/// One shaped span produced by [`Text::shape_per_span`].
+struct ShapedSpan {
+    start_x: f32,
+    width: f32,
+    /// Paths in local (span-relative) coordinates: the span starts at
+    /// `x = 0` in its own space; the line's baseline is at `y = ascent`.
+    paths: Vec<(Vec<PathCommand>, Paint)>,
+}
+
+/// Translates every coordinate in a path command by `delta`. Used when
+/// stitching per-span paths back into the line's global coordinates.
+fn translate_command(cmd: PathCommand, delta: Vec2) -> PathCommand {
+    match cmd {
+        PathCommand::MoveTo(p) => PathCommand::MoveTo(p + delta),
+        PathCommand::LineTo(p) => PathCommand::LineTo(p + delta),
+        PathCommand::QuadTo { control, to } => PathCommand::QuadTo {
+            control: control + delta,
+            to: to + delta,
+        },
+        PathCommand::CubicTo { c1, c2, to } => PathCommand::CubicTo {
+            c1: c1 + delta,
+            c2: c2 + delta,
+            to: to + delta,
+        },
+        PathCommand::Close => PathCommand::Close,
+    }
+}
+
+/// An independently placeable vector graphic of one shaped text span,
+/// produced by [`Text::into_spans`]. Implements [`VectorComponent`] so
+/// the span can be wrapped in any of the existing layout / decoration
+/// containers (e.g. dropped into a [`VectorLayer`](crate::layer::VectorLayer))
+/// and used for per-span effects.
+///
+/// The local coordinate space puts the span's leftmost glyph origin at
+/// `x = 0` and the line baseline at `y = ascent`; the layout/view_box
+/// size is `(span_width, line_height)`.
+#[derive(Clone, PartialEq, Hash)]
+pub struct TextSpanGraphic {
+    paths: Vec<(Vec<PathCommand>, Paint)>,
+    size: Vec2,
+}
+
+impl VectorComponent for TextSpanGraphic {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        constraints.constrain(self.size)
+    }
+
+    fn render(&self, size: Vec2) -> VectorGraphic {
+        let children: Vec<Node> = self
+            .paths
+            .iter()
+            .map(|(commands, fill)| {
+                Node::Path(VPath {
+                    commands: commands.clone(),
+                    fill: Some(Fill { paint: fill.clone() }),
+                    stroke: None,
+                    transform: Transform::IDENTITY,
+                })
+            })
+            .collect();
+        VectorGraphic {
+            view_box: Rect {
+                origin: Vec2::ZERO,
+                size,
+            },
+            root: Node::Group(Group {
+                transform: Transform::IDENTITY,
+                opacity: 1.0,
+                children,
+            }),
+        }
+    }
+}
+
+impl VectorComponent for Text {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        let (_paths, size) = self.shape_and_layout();
+        constraints.constrain(size)
+    }
+
+    fn render(&self, size: Vec2) -> VectorGraphic {
+        let (paths, _intrinsic) = self.shape_and_layout();
+        let nodes: Vec<Node> = paths
+            .into_iter()
+            .map(|(commands, fill)| {
+                Node::Path(VPath {
+                    commands,
+                    fill: Some(Fill { paint: fill }),
+                    stroke: None,
+                    transform: Transform::IDENTITY,
+                })
+            })
+            .collect();
+        VectorGraphic {
+            view_box: Rect {
+                origin: Vec2::ZERO,
+                size,
+            },
+            root: Node::Group(Group {
+                transform: Transform::IDENTITY,
+                opacity: 1.0,
+                children: nodes,
+            }),
+        }
+    }
+}
+
+/// Adapter from `ttf_parser`'s Y-up font-unit space to our Y-down
+/// logical space, used while pulling glyph outlines out of a face.
+struct OutlinePathBuilder {
+    commands: Vec<PathCommand>,
+    scale: f32,
+    origin_x: f32,
+    origin_y: f32,
+}
+
+impl OutlinePathBuilder {
+    fn map(&self, x: f32, y: f32) -> Vec2 {
+        Vec2(
+            self.origin_x + x * self.scale,
+            self.origin_y - y * self.scale,
+        )
+    }
+}
+
+impl ttf_parser::OutlineBuilder for OutlinePathBuilder {
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.commands.push(PathCommand::MoveTo(self.map(x, y)));
+    }
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.commands.push(PathCommand::LineTo(self.map(x, y)));
+    }
+    fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32) {
+        self.commands.push(PathCommand::QuadTo {
+            control: self.map(x1, y1),
+            to: self.map(x, y),
+        });
+    }
+    fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32) {
+        self.commands.push(PathCommand::CubicTo {
+            c1: self.map(x1, y1),
+            c2: self.map(x2, y2),
+            to: self.map(x, y),
+        });
+    }
+    fn close(&mut self) {
+        self.commands.push(PathCommand::Close);
+    }
+}

--- a/tellur-renderer/examples/raster_layer_to_png.rs
+++ b/tellur-renderer/examples/raster_layer_to_png.rs
@@ -31,7 +31,7 @@ fn blob(radius: f32, hue: f32) -> impl VectorComponent {
 fn main() {
     let scene_size = Vec2(1280.0, 720.0);
     let scene = Layer {
-        size: scene_size,
+        size: Some(scene_size),
         children: vec![
             Rectangle {
                 size: scene_size,

--- a/tellur-renderer/examples/scene_to_png.rs
+++ b/tellur-renderer/examples/scene_to_png.rs
@@ -15,7 +15,7 @@ use tellur_renderer::Rasterizable;
 fn main() {
     let scene_size = Vec2(1280.0, 720.0);
     let scene = VectorLayer {
-        size: scene_size,
+        size: Some(scene_size),
         children: vec![
             Rectangle {
                 size: scene_size,

--- a/tellur-renderer/examples/text_to_png.rs
+++ b/tellur-renderer/examples/text_to_png.rs
@@ -1,0 +1,57 @@
+//! Render "Hello world!" with the middle span in red, centered on a
+//! 1920x1080 white canvas, then write the result to PNG. Uses the
+//! system default sans-serif font resolved via fontconfig.
+
+use std::fs::File;
+
+use tellur_core::color::Color;
+use tellur_core::geometry::{Anchor, Vec2};
+use tellur_core::layer::VectorLayer;
+use tellur_core::placement::VectorPlacement;
+use tellur_core::raster::{RasterComponent, Resolution};
+use tellur_core::render_context::PassThrough;
+use tellur_core::shapes::Rectangle;
+use tellur_core::text::{Text, TextSpan, Weight, SANS_SERIF};
+use tellur_core::vector::Paint;
+use tellur_renderer::Rasterizable;
+
+fn main() {
+    let scene_size = Vec2(1920.0, 1080.0);
+    let scene = VectorLayer {
+        size: Some(scene_size),
+        children: vec![
+            Rectangle {
+                size: scene_size,
+                fill: Paint::Solid(Color::rgb_u8(255, 255, 255)).into(),
+                stroke: None,
+            }
+            .at(Vec2::ZERO),
+            Text {
+                font: SANS_SERIF.clone(),
+                size: 96.0,
+                weight: Weight::NORMAL,
+                fill: Paint::Solid(Color::rgb_u8(30, 30, 30)),
+                spans: vec![
+                    TextSpan::plain("Hello "),
+                    TextSpan {
+                        text: "world".into(),
+                        fill: Some(Paint::Solid(Color::rgb_u8(220, 60, 60))),
+                        ..TextSpan::default()
+                    },
+                    TextSpan::plain("!"),
+                ],
+            }
+            .anchored(Anchor::CENTER)
+            .snap_to(Anchor::CENTER.point(scene_size)),
+        ],
+    };
+
+    let image = scene
+        .rasterize()
+        .render(scene_size, Resolution::new(1920, 1080), &mut PassThrough);
+
+    let out = "/tmp/text.png";
+    let file = File::create(out).expect("create output file");
+    image.export_png(file).expect("export PNG");
+    println!("Wrote {} ({}x{})", out, image.width, image.height);
+}


### PR DESCRIPTION
Adds a `Text` vector component that shapes a sequence of styled spans through rustybuzz and emits one filled `Path` per glyph through the existing `VectorGraphic` pipeline. Per-span styling is expressed as overrides on each `TextSpan` (`fill` / `font` / `size` / `weight`), and the shaped spans can be pulled out as independently placeable graphics for per-span effects.

- `tellur-core::text` (new): `Text { font, size, weight, fill, spans: Vec<TextSpan> }`, with `TextSpan` holding `text` plus `Option<Paint>` / `Option<Arc<Font>>` / `Option<f32>` / `Option<Weight>` overrides. Spans inherit any unset field from the enclosing `Text`. Shaping runs through `rustybuzz::shape`; glyph outlines come from `ttf_parser::Face::outline_glyph` and are converted to `PathCommand`s. Line metrics (ascender/descender/line_gap) come from the base font.
- `Font`: owns the font bytes via `Arc<Vec<u8>>` plus a `face_index` for `.ttc` collections. Constructors:
  - `Font::from_bytes(bytes)` / `Font::from_bytes_indexed(bytes, index)`
  - `Font::load_file(path)`
  - `Font::find_by_name(name)` / `Font::find_by_name_with_weight(name, weight)` via `fontdb`
  - `Font::sans_serif()` / `serif()` / `monospace()` / `cursive()` / `fantasy()` via `fontconfig` (the same machinery `fc-match` uses, so per-language / per-script overrides on the host are honoured rather than relying on a hardcoded fallback list).
- Static `SANS_SERIF` / `SERIF` / `MONOSPACE` / `CURSIVE` / `FANTASY` as `LazyLock<Arc<Font>>`: the OS resolution runs once on first access; subsequent uses are just `Arc::clone`.
- `Weight` newtype (CSS-style 100..900 with `THIN` / ... / `BLACK` constants) drives the OpenType `wght` axis via `rustybuzz::Face::set_variations`. Has visible effect on fonts whose `wght` axis renders correctly through ttf-parser; on others (or non-VF fonts), use `find_by_name_with_weight` to load the per-weight file from the family instead.
- `Text::into_spans() -> Vec<Placed<TextSpanGraphic>>` decomposes a shaped line into one independently placed component per input `TextSpan`. Each `TextSpanGraphic` is a `VectorComponent` whose layout box matches the span's own width × the line height, so callers can pattern-match `let [a, b, c] = text.into_spans().try_into().unwrap();` and apply per-span effects (rasterize → outline / drop shadow / transform) before recomposing into a layer.
- `tellur-core::layer`: `VectorLayer.size` and `Layer.size` change from `Vec2` to `Option<Vec2>`. `None` auto-fits to the children's combined paint bounds — `view_box.origin` (vector) / `paint_rect.origin` (raster) tracks the bounding rect's origin so children at negative positions are kept inside the box rather than clipped. `::fit()` constructors mirror `::new(size)`. Auto-fit children are laid out under `Constraints::UNBOUNDED`; `Fill`-mode children there collapse to zero on each axis, which is the expected interaction.
- `tellur-core::placement`: `impl From<Placed<C>> for Placed<dyn VectorComponent>` (and the raster counterpart) for `C: VectorComponent + 'static`, so concrete-typed `Placed<TextSpanGraphic>` etc. flow into `Vec<Placed<dyn _>>` via `.into()` without a hand-written cast. This is what lets `Text::into_spans()`'s output drop straight into a `VectorLayer`.
- Dependencies: `rustybuzz` (shaping, re-exports `ttf-parser`), `fontdb` (system font database for `find_by_name`), `fontconfig` (FFI binding for `find_generic` — the dev shell's `flake.nix` gets `pkgs.fontconfig` so the linker resolves `libfontconfig`).
- Example: `tellur-renderer/examples/text_to_png.rs` (new) renders "Hello world!" with the middle span in red, centered on a 1920×1080 white canvas, font resolved via the `SANS_SERIF` static.