### PR TITLE
feat: add inline LaTeX math spans to Text via a Span trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,35 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "allocator-api2"
@@ -56,7 +81,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -64,6 +98,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -82,6 +122,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bon"
@@ -242,12 +291,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -293,6 +361,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -348,6 +426,17 @@ name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fdeflate"
@@ -475,6 +564,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -637,6 +736,12 @@ dependencies = [
  "unit-prefix",
  "web-time",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni-sys"
@@ -830,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.5.3",
  "bitflags 2.11.1",
  "codespan-reporting",
  "hexf-parse",
@@ -887,6 +992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1037,48 @@ checksum = "3c28d7294093837856bb80ad191cc46a2fcec8a30b43b7a3b0285325f0a917a9"
 dependencies = [
  "kurbo",
  "smallvec",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1003,10 +1159,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "ratex-font"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076f9ca8409eed1b0d9de1c666cf231665e0b6d1691b8c28e27c2bdd55f4c8b1"
+dependencies = [
+ "phf",
+ "ratex-types",
+]
+
+[[package]]
+name = "ratex-font-loader"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333f58d51a30e9a5dedc503bffb1e1592e80a7e754dd6b7024ad7b26766f73b8"
+dependencies = [
+ "ab_glyph",
+ "ratex-font",
+ "ratex-katex-fonts",
+ "ratex-types",
+ "ratex-unicode-font",
+]
+
+[[package]]
+name = "ratex-katex-fonts"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b451364ad69b55587baa549522244aaeabb0dc26d84f12a37987e9f1c59342b"
+dependencies = [
+ "rust-embed",
+]
+
+[[package]]
+name = "ratex-layout"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4253612c4cd7f28e40fcd4a3b8f35570b77c74717946796550dc873e086a6cd"
+dependencies = [
+ "ratex-font",
+ "ratex-parser",
+ "ratex-types",
+ "serde_json",
+]
+
+[[package]]
+name = "ratex-lexer"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0cc7746f4a617f857390f5361cb413d79d9cc0f607b05d398ddef0b8b21522"
+dependencies = [
+ "ratex-types",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ratex-parser"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d1c51aaae3f99f6f61e3d76d820b01afb3a0c19cf092ed11fedef7604930cd"
+dependencies = [
+ "fancy-regex",
+ "ratex-font",
+ "ratex-lexer",
+ "ratex-types",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "ratex-types"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694d45327eb6f5bf76d5d06f5dc1123a1d1202e3d392f2b260bd12bcca0dc19d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ratex-unicode-font"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692e6fb9ce62d33edc6f6beb6fe4ebaf1f61f8fc4297552573e74750c4472f86"
+dependencies = [
+ "fontdb",
+ "system-fonts",
+ "ttf-parser",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -1034,6 +1298,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1343,40 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1076,16 +1409,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skrifa"
@@ -1307,6 +1709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,15 +1731,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-fonts"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ba78ea149d4bb0626dacad10aa789eedc83395889890a0e6e7ec69a4577442"
+dependencies = [
+ "fontdb",
+ "sys-locale",
+ "web-sys",
+]
+
+[[package]]
 name = "tellur-core"
 version = "0.1.0"
 dependencies = [
+ "ab_glyph",
  "bon",
  "bytes",
  "fontconfig",
  "fontdb",
  "lru",
  "png",
+ "ratex-font",
+ "ratex-font-loader",
+ "ratex-layout",
+ "ratex-parser",
+ "ratex-types",
  "rustybuzz",
  "symphonia",
  "tellur-macros",
@@ -1470,6 +1898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-bidi-mirroring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1920,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-properties"
@@ -1572,6 +2015,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1681,7 +2134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.6.3",
  "bitflags 2.11.1",
  "cfg_aliases",
  "codespan-reporting",
@@ -1710,7 +2163,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.5.3",
  "bitflags 2.11.1",
  "block",
  "cfg_aliases",
@@ -1961,3 +2414,9 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/tellur-core/Cargo.toml
+++ b/tellur-core/Cargo.toml
@@ -3,6 +3,19 @@ name = "tellur-core"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Inline LaTeX math spans (`MathSpan`). Pulls in the RaTeX math-layout
+# crates and the embedded KaTeX fonts (~500 KB). Off by default so callers
+# that never typeset math do not pay the dependency or binary-size cost.
+latex = [
+    "dep:ratex-parser",
+    "dep:ratex-layout",
+    "dep:ratex-types",
+    "dep:ratex-font",
+    "dep:ratex-font-loader",
+    "dep:ab_glyph",
+]
+
 [dependencies]
 bon = "3.9.1"
 bytes = "1.11.1"
@@ -17,3 +30,14 @@ rustybuzz = "0.20"
 symphonia = { version = "0.5.4", features = ["wav", "pcm"] }
 tellur-macros = { path = "../tellur-macros", version = "0.1.0" }
 thiserror = "2.0.18"
+
+# LaTeX math layout (RaTeX), gated behind the `latex` feature. `ratex-layout`
+# turns a parsed formula into a flat display list of glyphs + rules in em
+# units; `ratex-font-loader`'s `embed-fonts` ships the KaTeX TTFs so glyph
+# outlines resolve without a system font, and `ab_glyph` outlines them.
+ab_glyph = { version = "0.2", optional = true }
+ratex-font = { version = "0.1.11", optional = true }
+ratex-font-loader = { version = "0.1.11", optional = true, features = ["embed-fonts"] }
+ratex-layout = { version = "0.1.11", optional = true }
+ratex-parser = { version = "0.1.11", optional = true }
+ratex-types = { version = "0.1.11", optional = true }

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -8,11 +8,14 @@ pub mod geometry;
 pub mod interpolate;
 pub mod layer;
 pub mod layout;
+#[cfg(feature = "latex")]
+pub mod math;
 pub mod phase;
 pub mod placement;
 pub mod raster;
 pub mod render_context;
 pub mod shapes;
+pub mod span;
 pub mod text;
 pub mod time;
 pub mod timeline;

--- a/tellur-core/src/math.rs
+++ b/tellur-core/src/math.rs
@@ -1,0 +1,378 @@
+//! Inline LaTeX math as a [`Span`], backed by [RaTeX](https://github.com/erweixin/RaTeX).
+//!
+//! [`MathSpan`] typesets a LaTeX math fragment and emits it as the same
+//! kind of baseline-relative vector paths a [`TextSpan`](crate::text::TextSpan)
+//! produces, so a formula drops into a line of [`Text`](crate::text::Text)
+//! beside ordinary words:
+//!
+//! ```ignore
+//! Text::builder()
+//!     .font(SERIF.clone())
+//!     .size(48.0)
+//!     .span("This is the line ")
+//!     .span(MathSpan::builder().source(r"y = \frac{2}{3} x^2"))
+//!     .span(".")
+//! ```
+//!
+//! RaTeX lays the formula out into a flat display list of glyphs and rules
+//! in **em** units with the baseline at `display_list.height`. We outline
+//! each glyph from the embedded KaTeX fonts (via `ab_glyph`), turn rules
+//! into rectangles, and re-origin everything so the formula's baseline is
+//! at `y = 0` — matching the [`Span`] contract. The font-independent
+//! geometry is memoized; the (possibly animating) fill is re-applied per
+//! call, exactly as text shaping does.
+//!
+//! Module is available only with the `latex` feature.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use ab_glyph::{Font as _, FontRef, OutlineCurve};
+use lru::LruCache;
+use ratex_font::FontId;
+use ratex_font_loader::outline_cache;
+use ratex_layout::LayoutOptions;
+use ratex_types::display_item::DisplayItem;
+use ratex_types::MathStyle;
+
+use crate::geometry::Vec2;
+use crate::span::{ShapedSpan, Span, SpanContext};
+use crate::text::TextSpan;
+use crate::vector::{Paint, PathCommand};
+use crate::Keyable;
+
+/// A run of inline LaTeX math within a line of [`Text`](crate::text::Text).
+///
+/// `source` is the LaTeX body (math mode — no surrounding `$`), e.g.
+/// `r"\frac{2}{3} x^2"`. `size` and `fill` inherit from the enclosing
+/// `Text` when left unset. Pass it to the builder like any other span:
+/// `Text::builder().span(MathSpan::builder().source(r"e^{i\pi}+1=0"))`.
+#[derive(Clone, Keyable, bon::Builder)]
+#[builder(derive(Into))]
+pub struct MathSpan {
+    /// The LaTeX math body, without `$` delimiters.
+    #[builder(into)]
+    pub source: String,
+    /// Em size in logical pixels; inherits the base `Text` size if `None`.
+    pub size: Option<f32>,
+    /// Fill for the whole formula; inherits the base `Text` fill if `None`.
+    #[builder(into)]
+    pub fill: Option<Paint>,
+}
+
+impl MathSpan {
+    /// A math span carrying only its source; size and fill inherit from
+    /// the enclosing [`Text`](crate::text::Text).
+    pub fn new(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            size: None,
+            fill: None,
+        }
+    }
+}
+
+impl Span for MathSpan {
+    fn shape(&self, ctx: &SpanContext<'_>) -> ShapedSpan {
+        let size = self.size.unwrap_or(ctx.size);
+        let fill = self.fill.clone().unwrap_or_else(|| ctx.fill.clone());
+
+        match math_geometry(&self.source, size) {
+            Some(geo) => ShapedSpan {
+                width: geo.width,
+                ascent: geo.ascent,
+                descent: geo.descent,
+                paths: geo
+                    .paths
+                    .iter()
+                    .map(|commands| (commands.clone(), fill.clone()))
+                    .collect(),
+            },
+            // Invalid LaTeX (or a layout/font failure) falls back to
+            // showing the raw source as plain text, so a typo is visible
+            // rather than silently dropped.
+            None => TextSpan::builder()
+                .text(self.source.clone())
+                .size(size)
+                .fill(fill)
+                .build()
+                .shape(ctx),
+        }
+    }
+}
+
+impl From<MathSpan> for Box<dyn Span> {
+    fn from(span: MathSpan) -> Self {
+        Box::new(span)
+    }
+}
+
+// Lets `Text::builder().span(MathSpan::builder()…)` accept a *complete*
+// builder with no explicit `.build()`, matching `TextSpan`.
+impl<S: math_span_builder::IsComplete> From<MathSpanBuilder<S>> for Box<dyn Span> {
+    fn from(builder: MathSpanBuilder<S>) -> Self {
+        Box::new(builder.build())
+    }
+}
+
+/// Font-independent geometry of one typeset formula, in baseline-relative
+/// coordinates (baseline at `y = 0`, y increasing downward). Paint is not
+/// stored; the caller pairs each path with the current fill.
+struct MathGeometry {
+    /// One filled path per glyph / rule / delimiter.
+    paths: Vec<Vec<PathCommand>>,
+    width: f32,
+    ascent: f32,
+    descent: f32,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct MathKey {
+    source: String,
+    size_bits: u32,
+}
+
+const MATH_CACHE_CAPACITY: usize = 256;
+
+// Geometry is fully determined by `(source, size)` and re-typesetting a
+// formula every frame is expensive, so memoize it. `None` (a parse or
+// layout failure) is cached too, so bad input is not reparsed each frame.
+static MATH_CACHE: LazyLock<Mutex<LruCache<MathKey, Option<Arc<MathGeometry>>>>> =
+    LazyLock::new(|| {
+        Mutex::new(LruCache::new(
+            NonZeroUsize::new(MATH_CACHE_CAPACITY).expect("cache capacity is non-zero"),
+        ))
+    });
+
+fn math_geometry(source: &str, size: f32) -> Option<Arc<MathGeometry>> {
+    let key = MathKey {
+        source: source.to_owned(),
+        size_bits: size.to_bits(),
+    };
+    if let Ok(mut cache) = MATH_CACHE.lock() {
+        if let Some(hit) = cache.get(&key) {
+            return hit.clone();
+        }
+    }
+    let geo = compute_geometry(source, size).map(Arc::new);
+    if let Ok(mut cache) = MATH_CACHE.lock() {
+        cache.put(key, geo.clone());
+    }
+    geo
+}
+
+/// Parses, lays out, and outlines `source` into baseline-relative paths.
+/// Returns `None` if the source does not parse.
+fn compute_geometry(source: &str, size: f32) -> Option<MathGeometry> {
+    let nodes = ratex_parser::parse(source).ok()?;
+    let options = LayoutOptions {
+        // Inline math uses text style (e.g. inline-size fractions), not
+        // the larger display style.
+        style: MathStyle::Text,
+        ..Default::default()
+    };
+    let layout_box = ratex_layout::layout(&nodes, &options);
+    let display_list = ratex_layout::to_display_list(&layout_box);
+
+    let em = size;
+    // RaTeX places the baseline at `height` (em) from the box top; shift
+    // every item up by it so our output is baseline-relative.
+    let baseline = display_list.height as f32;
+
+    // Embedded KaTeX fonts needed by this formula. `font_dir` is ignored
+    // because the `embed-fonts` feature supplies the bytes.
+    let fonts = ratex_font_loader::load_fonts_for_items("", &display_list.items).ok()?;
+    let mut font_refs: HashMap<FontId, FontRef<'_>> = HashMap::new();
+    for (id, bytes) in fonts.iter() {
+        if let Ok(font) = FontRef::try_from_slice(bytes) {
+            font_refs.insert(*id, font);
+        }
+    }
+
+    let mut paths: Vec<Vec<PathCommand>> = Vec::new();
+    for item in &display_list.items {
+        match item {
+            DisplayItem::GlyphPath {
+                x,
+                y,
+                scale,
+                font,
+                char_code,
+                ..
+            } => {
+                let font_id = FontId::parse(font).unwrap_or(FontId::MainRegular);
+                let Some(font_ref) = font_refs.get(&font_id) else {
+                    continue;
+                };
+                let ch = ratex_font::katex_ttf_glyph_char(font_id, *char_code);
+                let glyph_id = font_ref.glyph_id(ch);
+                if glyph_id.0 == 0 {
+                    continue;
+                }
+                let Some(curves) =
+                    outline_cache::get_or_compute_outline(font_id, font_ref, glyph_id)
+                else {
+                    continue;
+                };
+                if curves.is_empty() {
+                    continue;
+                }
+                let units_per_em = font_ref.units_per_em().unwrap_or(1000.0);
+                let glyph_scale = (*scale as f32 * em) / units_per_em;
+                let origin_x = *x as f32 * em;
+                let origin_y = (*y as f32 - baseline) * em;
+                let glyph = outline_to_path(&curves, origin_x, origin_y, glyph_scale);
+                if !glyph.is_empty() {
+                    paths.push(glyph);
+                }
+            }
+            DisplayItem::Line {
+                x,
+                y,
+                width,
+                thickness,
+                ..
+            } => {
+                // A rule (fraction bar, overline) centered on `y`.
+                let t = (*thickness as f32 * em).max(0.5);
+                let x0 = *x as f32 * em;
+                let y0 = (*y as f32 - baseline) * em - t / 2.0;
+                paths.push(rect_path(x0, y0, *width as f32 * em, t));
+            }
+            DisplayItem::Rect {
+                x,
+                y,
+                width,
+                height,
+                ..
+            } => {
+                let x0 = *x as f32 * em;
+                let y0 = (*y as f32 - baseline) * em;
+                paths.push(rect_path(x0, y0, *width as f32 * em, *height as f32 * em));
+            }
+            DisplayItem::Path {
+                x,
+                y,
+                commands,
+                fill,
+                ..
+            } => {
+                // v1 draws filled decorations (radicals, large delimiters,
+                // stretchy arrows); the rarer stroked paths are skipped.
+                if !*fill {
+                    continue;
+                }
+                let origin_x = *x as f32 * em;
+                let origin_y = (*y as f32 - baseline) * em;
+                paths.push(ratex_path_to_path(commands, origin_x, origin_y, em));
+            }
+        }
+    }
+
+    Some(MathGeometry {
+        paths,
+        width: display_list.width as f32 * em,
+        ascent: baseline * em,
+        descent: display_list.depth as f32 * em,
+    })
+}
+
+/// Converts `ab_glyph` outline curves (font units, y-up) into tellur path
+/// commands placed at `(origin_x, origin_y)` and scaled by `scale`, with
+/// y flipped into our y-down space. Contours are reconstructed by starting
+/// a new sub-path whenever a curve does not continue from the previous
+/// end, mirroring RaTeX's own renderers.
+fn outline_to_path(
+    curves: &[OutlineCurve],
+    origin_x: f32,
+    origin_y: f32,
+    scale: f32,
+) -> Vec<PathCommand> {
+    let map = |p: ab_glyph::Point| Vec2(origin_x + p.x * scale, origin_y - p.y * scale);
+    let mut commands = Vec::new();
+    let mut last_end: Option<Vec2> = None;
+
+    for curve in curves {
+        let (start, end) = match curve {
+            OutlineCurve::Line(p0, p1) => (map(*p0), map(*p1)),
+            OutlineCurve::Quad(p0, _, p2) => (map(*p0), map(*p2)),
+            OutlineCurve::Cubic(p0, _, _, p3) => (map(*p0), map(*p3)),
+        };
+        let need_move = match last_end {
+            None => true,
+            Some(le) => (le.0 - start.0).abs() > 0.01 || (le.1 - start.1).abs() > 0.01,
+        };
+        if need_move {
+            if last_end.is_some() {
+                commands.push(PathCommand::Close);
+            }
+            commands.push(PathCommand::MoveTo(start));
+        }
+        match curve {
+            OutlineCurve::Line(_, p1) => commands.push(PathCommand::LineTo(map(*p1))),
+            OutlineCurve::Quad(_, p1, p2) => commands.push(PathCommand::QuadTo {
+                control: map(*p1),
+                to: map(*p2),
+            }),
+            OutlineCurve::Cubic(_, p1, p2, p3) => commands.push(PathCommand::CubicTo {
+                c1: map(*p1),
+                c2: map(*p2),
+                to: map(*p3),
+            }),
+        }
+        last_end = Some(end);
+    }
+
+    if last_end.is_some() {
+        commands.push(PathCommand::Close);
+    }
+    commands
+}
+
+/// An axis-aligned filled rectangle as a closed path.
+fn rect_path(x: f32, y: f32, width: f32, height: f32) -> Vec<PathCommand> {
+    vec![
+        PathCommand::MoveTo(Vec2(x, y)),
+        PathCommand::LineTo(Vec2(x + width, y)),
+        PathCommand::LineTo(Vec2(x + width, y + height)),
+        PathCommand::LineTo(Vec2(x, y + height)),
+        PathCommand::Close,
+    ]
+}
+
+/// Converts a RaTeX display-list path (em units, already y-down) into
+/// tellur path commands at `(origin_x, origin_y)`, scaled by `em`.
+fn ratex_path_to_path(
+    commands: &[ratex_types::path_command::PathCommand],
+    origin_x: f32,
+    origin_y: f32,
+    em: f32,
+) -> Vec<PathCommand> {
+    use ratex_types::path_command::PathCommand as R;
+    let point = |x: f64, y: f64| Vec2(origin_x + x as f32 * em, origin_y + y as f32 * em);
+    commands
+        .iter()
+        .map(|cmd| match cmd {
+            R::MoveTo { x, y } => PathCommand::MoveTo(point(*x, *y)),
+            R::LineTo { x, y } => PathCommand::LineTo(point(*x, *y)),
+            R::QuadTo { x1, y1, x, y } => PathCommand::QuadTo {
+                control: point(*x1, *y1),
+                to: point(*x, *y),
+            },
+            R::CubicTo {
+                x1,
+                y1,
+                x2,
+                y2,
+                x,
+                y,
+            } => PathCommand::CubicTo {
+                c1: point(*x1, *y1),
+                c2: point(*x2, *y2),
+                to: point(*x, *y),
+            },
+            R::Close => PathCommand::Close,
+        })
+        .collect()
+}

--- a/tellur-core/src/span.rs
+++ b/tellur-core/src/span.rs
@@ -1,0 +1,99 @@
+//! The [`Span`] trait: one styled run within a line of
+//! [`Text`](crate::text::Text).
+//!
+//! A line is a sequence of spans laid out left-to-right. Each span shapes
+//! itself — given the base style it inherits from the enclosing `Text` —
+//! into placed vector paths plus the vertical metrics the line needs to
+//! position it. [`TextSpan`](crate::text::TextSpan) is the ordinary
+//! styled-text span; with the `latex` feature, [`MathSpan`](crate::math::MathSpan)
+//! renders a LaTeX formula as another kind of span. Anything implementing
+//! `Span` flows into `Text::builder().span(...)`.
+
+use std::any::Any;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use crate::dyn_compare::{DynEq, DynHash};
+use crate::text::{Font, Weight};
+use crate::vector::{Paint, PathCommand};
+
+/// The base style the enclosing [`Text`](crate::text::Text) hands to each
+/// span. A span uses these wherever it does not override them.
+pub struct SpanContext<'a> {
+    /// The base font; a span may shape with a different one.
+    pub font: &'a Arc<Font>,
+    /// The base size in logical pixels per em.
+    pub size: f32,
+    /// The base weight.
+    pub weight: Weight,
+    /// The base fill applied to ink without its own paint.
+    pub fill: &'a Paint,
+}
+
+/// The geometry and metrics one span contributes to a line.
+///
+/// `paths` are in span-local, baseline-relative coordinates: x starts at
+/// `0` and the text baseline is at `y = 0`, with y increasing downward
+/// (so ink above the baseline has negative y). The enclosing `Text`
+/// advances the pen by `width` and drops the span onto the line baseline.
+pub struct ShapedSpan {
+    /// Pen advance — how far the next span begins to the right.
+    pub width: f32,
+    /// Extent above the baseline (`>= 0`).
+    pub ascent: f32,
+    /// Extent below the baseline (`>= 0`).
+    pub descent: f32,
+    /// Filled paths, each paired with its paint.
+    pub paths: Vec<(Vec<PathCommand>, Paint)>,
+}
+
+/// One run within a line of [`Text`](crate::text::Text).
+///
+/// Implementors shape themselves into placed paths given the inherited
+/// base style. The super-traits let `Box<dyn Span>` live in the cache-key
+/// component trees that drive render memoization: [`DynEq`]/[`DynHash`]
+/// give it `PartialEq`/`Eq`/`Hash`, and [`SpanClone`] makes it cloneable.
+pub trait Span: SpanClone + DynEq + DynHash {
+    /// Shape this span against `ctx`, returning baseline-relative paths
+    /// and the metrics the line needs to place it.
+    fn shape(&self, ctx: &SpanContext<'_>) -> ShapedSpan;
+}
+
+// Compile-time guarantee that `Span` is dyn-safe.
+const _: Option<&dyn Span> = None;
+
+/// Clone support for `Box<dyn Span>`. Blanket-implemented for every
+/// `Span` that is `Clone`; callers never implement it by hand.
+pub trait SpanClone {
+    fn clone_box(&self) -> Box<dyn Span>;
+}
+
+impl<T: Span + Clone + 'static> SpanClone for T {
+    fn clone_box(&self) -> Box<dyn Span> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn Span> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+// Identity of a `dyn Span` is its concrete type plus that type's own
+// equality/hash — the same trait-object machinery `VectorComponent` uses,
+// so a `Box<dyn Span>` participates in derived cache keys.
+impl PartialEq for dyn Span {
+    fn eq(&self, other: &Self) -> bool {
+        DynEq::dyn_eq(self, other.as_any())
+    }
+}
+
+impl Eq for dyn Span {}
+
+impl Hash for dyn Span {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Any::type_id(self.as_any()).hash(state);
+        DynHash::dyn_hash(self, state);
+    }
+}

--- a/tellur-core/src/text.rs
+++ b/tellur-core/src/text.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 
 use crate::geometry::{Constraints, Rect, Transform, Vec2};
 use crate::placement::{Positioned, VectorPlacement};
+use crate::span::{ShapedSpan, Span, SpanContext};
 use crate::vector::{
     Fill, Group, Node, Paint, Path as VPath, PathCommand, VectorComponent, VectorGraphic,
 };
@@ -227,6 +228,21 @@ impl Font {
             .expect("font data validated in Font constructors")
     }
 
+    /// This font's `(ascent, descent)` at `size`, both as non-negative
+    /// distances from the baseline (ascent above, descent below). Used by
+    /// a [`TextSpan`] to report how far it paints around the line baseline
+    /// so the enclosing [`Text`] can size the line box to fit every span.
+    fn vertical_metrics(&self, size: f32) -> (f32, f32) {
+        let face = self.face();
+        let upem = face.units_per_em() as f32;
+        let scale = size / upem;
+        let ascent = face.ascender() as f32 * scale;
+        // `descender` is conventionally negative (below baseline); flip it
+        // to a non-negative depth.
+        let descent = -(face.descender() as f32) * scale;
+        (ascent.max(0.0), descent.max(0.0))
+    }
+
     /// Returns the memoized span-local geometry for `text` at the given
     /// style, computing and caching it on a miss. Keyed on
     /// `(weight, size, baseline, text)`; the result carries no paint, so
@@ -409,6 +425,69 @@ impl From<String> for TextSpan {
     }
 }
 
+impl Span for TextSpan {
+    fn shape(&self, ctx: &SpanContext<'_>) -> ShapedSpan {
+        let font = self.font.as_ref().unwrap_or(ctx.font);
+        let size = self.size.unwrap_or(ctx.size);
+        let weight = self.weight.unwrap_or(ctx.weight);
+        let fill = self.fill.clone().unwrap_or_else(|| ctx.fill.clone());
+
+        if self.text.is_empty() {
+            return ShapedSpan {
+                width: 0.0,
+                ascent: 0.0,
+                descent: 0.0,
+                paths: Vec::new(),
+            };
+        }
+
+        // Shape with the baseline at `y = 0`, so the geometry is
+        // baseline-relative (ink above the baseline lands at negative y).
+        // The shaping is memoized on the font; only the (possibly
+        // animating) fill is re-attached per call.
+        let shaped = font.shaped_glyphs(weight, size, 0.0, &self.text);
+        let paths = shaped
+            .glyphs
+            .iter()
+            .map(|commands| (commands.clone(), fill.clone()))
+            .collect();
+        let (ascent, descent) = font.vertical_metrics(size);
+        ShapedSpan {
+            width: shaped.width,
+            ascent,
+            descent,
+            paths,
+        }
+    }
+}
+
+impl From<TextSpan> for Box<dyn Span> {
+    fn from(span: TextSpan) -> Self {
+        Box::new(span)
+    }
+}
+
+impl From<&str> for Box<dyn Span> {
+    fn from(text: &str) -> Self {
+        Box::new(TextSpan::plain(text))
+    }
+}
+
+impl From<String> for Box<dyn Span> {
+    fn from(text: String) -> Self {
+        Box::new(TextSpan::plain(text))
+    }
+}
+
+// Lets `Text::builder().span(TextSpan::builder()…)` accept a *complete*
+// builder with no explicit `.build()`, mirroring the buildless children
+// the `#[component]` macro emits for boxed components.
+impl<S: text_span_builder::IsComplete> From<TextSpanBuilder<S>> for Box<dyn Span> {
+    fn from(builder: TextSpanBuilder<S>) -> Self {
+        Box::new(builder.build())
+    }
+}
+
 /// A single line of styled text.
 ///
 /// `font`, `size`, `weight`, and `fill` are the defaults used by every
@@ -418,7 +497,7 @@ impl From<String> for TextSpan {
 #[derive(Clone, Keyable)]
 pub struct Text {
     #[children(each = span)]
-    pub spans: Vec<TextSpan>,
+    pub spans: Vec<Box<dyn Span>>,
     pub font: Arc<Font>,
     pub size: f32,
     #[builder(default)]
@@ -428,22 +507,6 @@ pub struct Text {
 }
 
 impl Text {
-    fn effective_fill(&self, span: &TextSpan) -> Paint {
-        span.fill.clone().unwrap_or_else(|| self.fill.clone())
-    }
-
-    fn effective_font<'a>(&'a self, span: &'a TextSpan) -> &'a Arc<Font> {
-        span.font.as_ref().unwrap_or(&self.font)
-    }
-
-    fn effective_size(&self, span: &TextSpan) -> f32 {
-        span.size.unwrap_or(self.size)
-    }
-
-    fn effective_weight(&self, span: &TextSpan) -> Weight {
-        span.weight.unwrap_or(self.weight)
-    }
-
     /// Vertical metrics of the base font at `self.size`, returned as
     /// `(ascent, line_height)`.
     fn line_metrics(&self) -> (f32, f32) {
@@ -458,64 +521,54 @@ impl Text {
         (ascent, line_height)
     }
 
-    /// Shapes each span and returns one [`ShapedSpan`] per input
-    /// [`TextSpan`], with paths in local (span-relative) coordinates so
-    /// each span graphic can be used as an independent placeable
-    /// component. The line height comes from the base font; spans that
-    /// override `font`/`size` may visually paint past the line box for
-    /// now.
-    fn shape_per_span(&self) -> Vec<ShapedSpan> {
-        let (ascent, _) = self.line_metrics();
-        let baseline_y = ascent;
+    /// Shapes every span against the base style and lays them out
+    /// left-to-right. Returns each span's start-x paired with its
+    /// [`ShapedSpan`] (paths still baseline-relative), the line baseline
+    /// `y`, and the line's intrinsic `(width, height)`.
+    ///
+    /// The line box grows to fit the tallest span: its baseline sits at
+    /// `max(base ascent, span ascents)` and it extends down to
+    /// `max(base depth, span descents)`, so a span that overrides
+    /// `font`/`size` — or a [`MathSpan`](crate::math::MathSpan) taller
+    /// than the surrounding text — is enclosed rather than clipped.
+    fn shape_line(&self) -> (Vec<(f32, ShapedSpan)>, f32, Vec2) {
+        let ctx = SpanContext {
+            font: &self.font,
+            size: self.size,
+            weight: self.weight,
+            fill: &self.fill,
+        };
+        let (base_ascent, base_line_height) = self.line_metrics();
+        let base_below = (base_line_height - base_ascent).max(0.0);
 
-        let mut out = Vec::with_capacity(self.spans.len());
+        let mut placed: Vec<(f32, ShapedSpan)> = Vec::with_capacity(self.spans.len());
         let mut pen_x: f32 = 0.0;
+        let mut line_ascent = base_ascent;
+        let mut line_below = base_below;
 
         for span in &self.spans {
-            let span_start_x = pen_x;
-            let mut span_paths: Vec<(Vec<PathCommand>, Paint)> = Vec::new();
-            let mut width = 0.0;
-
-            if !span.text.is_empty() {
-                let font = self.effective_font(span);
-                let size = self.effective_size(span);
-                let fill = self.effective_fill(span);
-                let weight = self.effective_weight(span);
-
-                // The shaped geometry (face build + shaping + per-glyph
-                // outlining) is memoized on the font; only the fill — which
-                // may animate frame to frame — is re-applied here.
-                let shaped = font.shaped_glyphs(weight, size, baseline_y, &span.text);
-                span_paths.reserve(shaped.glyphs.len());
-                for commands in &shaped.glyphs {
-                    span_paths.push((commands.clone(), fill.clone()));
-                }
-                width = shaped.width;
-                pen_x += shaped.width;
-            }
-
-            out.push(ShapedSpan {
-                start_x: span_start_x,
-                width,
-                paths: span_paths,
-            });
+            let shaped = span.shape(&ctx);
+            line_ascent = line_ascent.max(shaped.ascent);
+            line_below = line_below.max(shaped.descent);
+            let start_x = pen_x;
+            pen_x += shaped.width;
+            placed.push((start_x, shaped));
         }
 
-        out
+        let size = Vec2(pen_x, line_ascent + line_below);
+        (placed, line_ascent, size)
     }
 
     /// Shapes every span and returns `(glyph paths, intrinsic size)`,
     /// with paths in the line's global coordinates (all spans
-    /// concatenated left-to-right).
+    /// concatenated left-to-right and dropped onto the baseline).
     fn shape_and_layout(&self) -> (Vec<(Vec<PathCommand>, Paint)>, Vec2) {
-        let (_, line_height) = self.line_metrics();
-        let spans = self.shape_per_span();
-        let total_width = spans.last().map(|s| s.start_x + s.width).unwrap_or(0.0);
+        let (placed, baseline_y, size) = self.shape_line();
 
         let mut all_paths: Vec<(Vec<PathCommand>, Paint)> = Vec::new();
-        for span in spans {
-            let delta = Vec2(span.start_x, 0.0);
-            for (commands, fill) in span.paths {
+        for (start_x, shaped) in placed {
+            let delta = Vec2(start_x, baseline_y);
+            for (commands, fill) in shaped.paths {
                 let shifted: Vec<PathCommand> = commands
                     .into_iter()
                     .map(|c| translate_command(c, delta))
@@ -524,14 +577,14 @@ impl Text {
             }
         }
 
-        (all_paths, Vec2(total_width, line_height))
+        (all_paths, size)
     }
 
     /// Decompose the text into per-span graphics, each placed at the
     /// position where its first glyph would land in the line. The
-    /// returned `Vec` has exactly one entry per input
-    /// [`TextSpan`] (in the same order), and entries for empty spans
-    /// are zero-width placeholders so positional indexing matches.
+    /// returned `Vec` has exactly one entry per input span (in the same
+    /// order), and entries for empty spans are zero-width placeholders so
+    /// positional indexing matches.
     ///
     /// Useful for attaching per-span effects (transforms, drop shadows
     /// on the rasterized form, outlines, ...) by composing each
@@ -545,27 +598,32 @@ impl Text {
     ///     .build();
     /// ```
     pub fn into_spans(self) -> Vec<Positioned> {
-        let (_, line_height) = self.line_metrics();
-        self.shape_per_span()
+        let (placed, baseline_y, size) = self.shape_line();
+        let line_height = size.1;
+        placed
             .into_iter()
-            .map(|s| {
+            .map(|(start_x, shaped)| {
+                // Drop the span's baseline-relative paths onto the line
+                // baseline within the span's own box.
+                let paths = shaped
+                    .paths
+                    .into_iter()
+                    .map(|(commands, fill)| {
+                        let shifted: Vec<PathCommand> = commands
+                            .into_iter()
+                            .map(|c| translate_command(c, Vec2(0.0, baseline_y)))
+                            .collect();
+                        (shifted, fill)
+                    })
+                    .collect();
                 TextSpanGraphic {
-                    paths: s.paths,
-                    size: Vec2(s.width, line_height),
+                    paths,
+                    size: Vec2(shaped.width, line_height),
                 }
-                .place_at(Vec2(s.start_x, 0.0))
+                .place_at(Vec2(start_x, 0.0))
             })
             .collect()
     }
-}
-
-/// One shaped span produced by [`Text::shape_per_span`].
-struct ShapedSpan {
-    start_x: f32,
-    width: f32,
-    /// Paths in local (span-relative) coordinates: the span starts at
-    /// `x = 0` in its own space; the line's baseline is at `y = ascent`.
-    paths: Vec<(Vec<PathCommand>, Paint)>,
 }
 
 /// Translates every coordinate in a path command by `delta`. Used when

--- a/tellur-renderer/Cargo.toml
+++ b/tellur-renderer/Cargo.toml
@@ -3,6 +3,15 @@ name = "tellur-renderer"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Forwards to `tellur-core/latex` so examples (and downstream renderers) can
+# typeset inline LaTeX math spans.
+latex = ["tellur-core/latex"]
+
+[[example]]
+name = "math_to_png"
+required-features = ["latex"]
+
 [dependencies]
 bytemuck = "1.25.0"
 bytes = "1.11.1"

--- a/tellur-renderer/examples/math_to_png.rs
+++ b/tellur-renderer/examples/math_to_png.rs
@@ -1,0 +1,57 @@
+//! Render a line that mixes ordinary text with an inline LaTeX math span
+//! ("This is the line y = 2/3 x^2.") centered on a white canvas, then
+//! write it to PNG. Run with the `latex` feature:
+//!
+//! ```sh
+//! cargo run -p tellur-renderer --example math_to_png --features latex
+//! ```
+
+use std::fs::File;
+
+use tellur_core::builder::VectorBuilderPlacement;
+use tellur_core::color::Color;
+use tellur_core::geometry::{Anchor, Vec2};
+use tellur_core::layer::VectorLayer;
+use tellur_core::math::MathSpan;
+use tellur_core::raster::{RasterComponent, Resolution};
+use tellur_core::render_context::PassThrough;
+use tellur_core::shapes::Rectangle;
+use tellur_core::text::{Text, SERIF};
+use tellur_core::vector::Paint;
+use tellur_renderer::Rasterizable;
+
+fn main() {
+    let scene_size = Vec2(1400.0, 360.0);
+    let scene = VectorLayer::builder()
+        .size(scene_size)
+        .child(
+            Rectangle::builder()
+                .size(scene_size)
+                .fill(Paint::Solid(Color::rgb_u8(255, 255, 255)))
+                .place_at(Vec2::ZERO),
+        )
+        .child(
+            Text::builder()
+                .font(SERIF.clone())
+                .size(90.0)
+                .fill(Paint::Solid(Color::rgb_u8(20, 20, 20)))
+                .span("This is the line ")
+                // An inline LaTeX formula — same `.span(...)` as text.
+                .span(MathSpan::builder().source(r"y = \frac{2}{3} x^2"))
+                .span(".")
+                .anchored(Anchor::CENTER)
+                .snap_to(Anchor::CENTER.point(scene_size)),
+        )
+        .build();
+
+    let image = scene.rasterize().render(
+        scene_size,
+        Resolution::new(scene_size.0 as u32, scene_size.1 as u32),
+        &mut PassThrough,
+    );
+
+    let out = "/tmp/math.png";
+    let file = File::create(out).expect("create output file");
+    image.export_png(file).expect("export PNG");
+    println!("Wrote {} ({}x{})", out, image.width(), image.height());
+}


### PR DESCRIPTION
Adds **inline LaTeX math** to `Text`: a formula drops into a line beside ordinary words, sharing the text baseline. The span model is generalized into a `Span` trait so text and math compose through the same `.span(...)` setter, and math is rendered as resolution-independent vector paths (not a raster image) via [RaTeX](https://github.com/erweixin/RaTeX), gated behind a default-off `latex` feature. 8 files (+1.2k / -85) in `tellur-core` and `tellur-renderer`.

```rust
Text::builder()
    .font(SERIF.clone())
    .size(90.0)
    .span("This is the line ")
    .span(MathSpan::builder().source(r"y = \frac{2}{3} x^2"))
    .span(".")
```

## Span trait (`tellur-core::span`)
- A `Span` trait — `shape(&self, &SpanContext) -> ShapedSpan` — returns baseline-relative paths plus `width`/`ascent`/`descent`. `SpanContext` carries the base style each span inherits.
- `Box<dyn Span>` joins render-cache keys (`PartialEq`/`Eq`/`Hash` via the existing `DynEq`/`DynHash`) and is cloneable through a `SpanClone` blanket impl — the `VectorComponent` pattern plus a clone-box.
- `TextSpan` now implements `Span`; `Text.spans` is `Vec<Box<dyn Span>>`. `&str`/`String`/`TextSpan`/a complete `TextSpan` builder all flow into `.span(...)` via `From` impls, so existing call sites are unchanged.

## Line layout (`tellur-core::text`)
- Spans shape in baseline-relative coordinates (baseline at `y = 0`); the line drops each onto a shared baseline.
- The line box grows to fit the tallest span — baseline at `max(base ascent, span ascents)`, depth at `max(base depth, span descents)` — so a tall fraction (or a size-overriding span) is enclosed rather than clipped, replacing the old "paints past the box" behavior.

## MathSpan (`tellur-core::math`, `latex` feature)
- `MathSpan { source, size?, fill? }` parses and lays out with RaTeX (text style), then turns the display list into tellur paths: glyphs outlined from the embedded KaTeX fonts via `ab_glyph`, rules into rectangles, RaTeX paths rescaled — all re-origined so the formula baseline is at `y = 0`.
- Font-independent geometry is LRU-memoized on `(source, size)`; the (possibly animating) fill is re-applied per call, matching text shaping.
- Invalid LaTeX falls back to showing the raw source as plain text.
- The `latex` feature pulls the RaTeX crates + embedded KaTeX fonts (~500 KB); off by default.

## Verification
- Baseline measured by pixel readback: roman-x and math-x ink bottoms within 2 px at a 240 px em; a `\frac` lands centered exactly 0.25 em above the text baseline (the TeX math axis), confirming correct baseline mapping. Spacing follows KaTeX (glyph sidebearings + `\nulldelimiterspace`).
- `cargo fmt --all --check`, `clippy -D warnings` (1.95.0) with and without `latex`, and `cargo test` (core + renderer) all pass; the full workspace and all examples build (backward compatible).
- `examples/math_to_png.rs` renders the mixed text+math line to PNG.

## Limitations
- `Text` remains single-line (`\n` not interpreted) — unchanged.
- `\color` inside a formula is overridden by the span fill; rare stroked decorations are not yet drawn (glyphs, fraction bars, scripts, and fill delimiters are).