### PR TITLE
feat: add core motion primitives and migrate the demo scene

### DIFF
--- a/tellur-core/src/builder.rs
+++ b/tellur-core/src/builder.rs
@@ -22,10 +22,10 @@
 
 use std::hash::Hash;
 
-use crate::geometry::{Anchor, Constraints, Vec2};
+use crate::geometry::{Anchor, Constraints, Transform, Vec2};
 use crate::placement::{raster::Positioned as RasterPositioned, Positioned};
 use crate::raster::RasterComponent;
-use crate::vector::VectorComponent;
+use crate::vector::{Transformed, VectorComponent, VectorTransform};
 
 /// Implemented (by the component macro) for a *complete* builder of a
 /// [`VectorComponent`]. The blanket [`VectorBuilderPlacement`] hangs off it.
@@ -65,6 +65,20 @@ pub trait VectorBuilderPlacement: VectorBuilder {
 }
 
 impl<B: VectorBuilder> VectorBuilderPlacement for B {}
+
+/// Transform wrappers on complete vector builders, mirroring
+/// [`VectorTransform`] on built components.
+pub trait VectorBuilderTransform: VectorBuilder {
+    fn transform(self, transform: Transform) -> Transformed {
+        self.build_component().transform(transform)
+    }
+
+    fn opacity(self, opacity: f32) -> Transformed {
+        self.build_component().opacity(opacity)
+    }
+}
+
+impl<B: VectorBuilder> VectorBuilderTransform for B {}
 
 /// Raster counterpart of [`VectorBuilderPlacement`].
 pub trait RasterBuilderPlacement: RasterBuilder {

--- a/tellur-core/src/color.rs
+++ b/tellur-core/src/color.rs
@@ -26,18 +26,22 @@ impl Color {
     }
 
     /// Returns this color with `a` replaced by `alpha`, clamped to `[0, 1]`.
-    pub fn with_alpha(self, alpha: f32) -> Self {
+    /// `alpha` accepts anything convertible to `f32` — passing a
+    /// [`Phase`](crate::phase::Phase) directly works via
+    /// `From<Phase> for f32`, so callers can avoid an explicit `.get()`.
+    pub fn with_alpha(self, alpha: impl Into<f32>) -> Self {
         Self {
-            a: alpha.clamp(0.0, 1.0),
+            a: alpha.into().clamp(0.0, 1.0),
             ..self
         }
     }
 
     /// Returns this color with its alpha multiplied by `factor`, clamped to
-    /// `[0, 1]` before multiplication.
-    pub fn multiply_alpha(self, factor: f32) -> Self {
+    /// `[0, 1]` before multiplication. See [`Self::with_alpha`] for the
+    /// `Into<f32>` rationale.
+    pub fn multiply_alpha(self, factor: impl Into<f32>) -> Self {
         Self {
-            a: self.a * factor.clamp(0.0, 1.0),
+            a: self.a * factor.into().clamp(0.0, 1.0),
             ..self
         }
     }

--- a/tellur-core/src/color.rs
+++ b/tellur-core/src/color.rs
@@ -1,3 +1,4 @@
+use crate::scalar::clamp_unit;
 use crate::Keyable;
 
 /// sRGB with straight alpha. Each component is in the range `[0.0, 1.0]`.
@@ -31,7 +32,7 @@ impl Color {
     /// `From<Phase> for f32`, so callers can avoid an explicit `.get()`.
     pub fn with_alpha(self, alpha: impl Into<f32>) -> Self {
         Self {
-            a: alpha.into().clamp(0.0, 1.0),
+            a: clamp_unit(alpha.into()),
             ..self
         }
     }
@@ -41,7 +42,7 @@ impl Color {
     /// `Into<f32>` rationale.
     pub fn multiply_alpha(self, factor: impl Into<f32>) -> Self {
         Self {
-            a: self.a * factor.into().clamp(0.0, 1.0),
+            a: self.a * clamp_unit(factor.into()),
             ..self
         }
     }
@@ -123,6 +124,7 @@ mod tests {
         assert_eq!(color.with_alpha(0.25).a, 0.25);
         assert_eq!(color.with_alpha(-1.0).a, 0.0);
         assert_eq!(color.with_alpha(2.0).a, 1.0);
+        assert_eq!(color.with_alpha(f32::NAN).a, 0.0);
     }
 
     #[test]
@@ -132,5 +134,6 @@ mod tests {
         assert_eq!(color.multiply_alpha(0.5).a, 0.25);
         assert_eq!(color.multiply_alpha(-1.0).a, 0.0);
         assert_eq!(color.multiply_alpha(2.0).a, 0.5);
+        assert_eq!(color.multiply_alpha(f32::NAN).a, 0.0);
     }
 }

--- a/tellur-core/src/color.rs
+++ b/tellur-core/src/color.rs
@@ -25,6 +25,23 @@ impl Color {
         }
     }
 
+    /// Returns this color with `a` replaced by `alpha`, clamped to `[0, 1]`.
+    pub fn with_alpha(self, alpha: f32) -> Self {
+        Self {
+            a: alpha.clamp(0.0, 1.0),
+            ..self
+        }
+    }
+
+    /// Returns this color with its alpha multiplied by `factor`, clamped to
+    /// `[0, 1]` before multiplication.
+    pub fn multiply_alpha(self, factor: f32) -> Self {
+        Self {
+            a: self.a * factor.clamp(0.0, 1.0),
+            ..self
+        }
+    }
+
     /// Opaque color from HSV.
     ///
     /// `h` is the hue in degrees (wraps around 360); `s` and `v` are in `[0, 1]`.
@@ -88,5 +105,28 @@ fn hue_sector(h: f32, c: f32, x: f32) -> (f32, f32, f32) {
         3 => (0.0, x, c),
         4 => (x, 0.0, c),
         _ => (c, 0.0, x),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_alpha_replaces_and_clamps_alpha() {
+        let color = Color::rgba_u8(10, 20, 30, 128);
+
+        assert_eq!(color.with_alpha(0.25).a, 0.25);
+        assert_eq!(color.with_alpha(-1.0).a, 0.0);
+        assert_eq!(color.with_alpha(2.0).a, 1.0);
+    }
+
+    #[test]
+    fn multiply_alpha_scales_existing_alpha() {
+        let color = Color::rgb_u8(10, 20, 30).with_alpha(0.5);
+
+        assert_eq!(color.multiply_alpha(0.5).a, 0.25);
+        assert_eq!(color.multiply_alpha(-1.0).a, 0.0);
+        assert_eq!(color.multiply_alpha(2.0).a, 0.5);
     }
 }

--- a/tellur-core/src/easing.rs
+++ b/tellur-core/src/easing.rs
@@ -3,79 +3,138 @@
 //! Bounded easing functions return [`Phase`], preserving Tellur's normalized
 //! progress type so callers can feed the result directly into
 //! [`Phase::interpolate`]. Curves that intentionally overshoot the unit interval
-//! return `f32` and are documented separately.
+//! take an explicit output range and return the interpolated value.
 
 use std::f32::consts::PI;
 
 use crate::phase::Phase;
 
+/// Easing methods on [`Phase`].
+pub trait PhaseEasing {
+    /// Identity easing.
+    fn ease_linear(self) -> Phase;
+    /// Smoothstep easing: zero slope at both endpoints.
+    fn ease_smoothstep(self) -> Phase;
+    /// Cubic ease-out: fast start, gentle settle.
+    fn ease_out_cubic(self) -> Phase;
+    /// Quintic ease-out.
+    fn ease_out_quint(self) -> Phase;
+    /// Quintic ease-in-out.
+    fn ease_in_out_quint(self) -> Phase;
+    /// Exponential ease-in-out.
+    fn ease_in_out_expo(self) -> Phase;
+    /// Back ease-in between `from` and `to`. Intentionally dips before `from`.
+    fn ease_in_back_between(self, from: f32, to: f32) -> f32;
+    /// Elastic ease-out between `from` and `to`. Intentionally overshoots past
+    /// `to`.
+    fn ease_out_elastic_between(self, from: f32, to: f32) -> f32;
+}
+
+impl PhaseEasing for Phase {
+    fn ease_linear(self) -> Phase {
+        self
+    }
+
+    fn ease_smoothstep(self) -> Phase {
+        let x = self.get();
+        Phase::saturating(x * x * (3.0 - 2.0 * x))
+    }
+
+    fn ease_out_cubic(self) -> Phase {
+        let x = self.get();
+        Phase::saturating(1.0 - (1.0 - x).powi(3))
+    }
+
+    fn ease_out_quint(self) -> Phase {
+        let x = self.get();
+        Phase::saturating(1.0 - (1.0 - x).powi(5))
+    }
+
+    fn ease_in_out_quint(self) -> Phase {
+        let x = self.get();
+        let y = if x < 0.5 {
+            16.0 * x.powi(5)
+        } else {
+            1.0 - (-2.0 * x + 2.0).powi(5) * 0.5
+        };
+        Phase::saturating(y)
+    }
+
+    fn ease_in_out_expo(self) -> Phase {
+        let x = self.get();
+        let y = if x <= 0.0 {
+            0.0
+        } else if x >= 1.0 {
+            1.0
+        } else if x < 0.5 {
+            2.0_f32.powf(20.0 * x - 10.0) * 0.5
+        } else {
+            (2.0 - 2.0_f32.powf(-20.0 * x + 10.0)) * 0.5
+        };
+        Phase::saturating(y)
+    }
+
+    fn ease_in_back_between(self, from: f32, to: f32) -> f32 {
+        interpolate_unbounded(from, to, in_back_factor(self))
+    }
+
+    fn ease_out_elastic_between(self, from: f32, to: f32) -> f32 {
+        interpolate_unbounded(from, to, out_elastic_factor(self))
+    }
+}
+
 /// Identity easing.
 pub fn linear(p: Phase) -> Phase {
-    p
+    p.ease_linear()
 }
 
 /// Smoothstep easing: zero slope at both endpoints.
 pub fn smoothstep(p: Phase) -> Phase {
-    let x = p.get();
-    Phase::saturating(x * x * (3.0 - 2.0 * x))
+    p.ease_smoothstep()
 }
 
 /// Cubic ease-out: fast start, gentle settle.
 pub fn out_cubic(p: Phase) -> Phase {
-    let x = p.get();
-    Phase::saturating(1.0 - (1.0 - x).powi(3))
+    p.ease_out_cubic()
 }
 
 /// Quintic ease-out.
 pub fn out_quint(p: Phase) -> Phase {
-    let x = p.get();
-    Phase::saturating(1.0 - (1.0 - x).powi(5))
+    p.ease_out_quint()
 }
 
 /// Quintic ease-in-out.
 pub fn in_out_quint(p: Phase) -> Phase {
-    let x = p.get();
-    let y = if x < 0.5 {
-        16.0 * x.powi(5)
-    } else {
-        1.0 - (-2.0 * x + 2.0).powi(5) * 0.5
-    };
-    Phase::saturating(y)
+    p.ease_in_out_quint()
 }
 
 /// Exponential ease-in-out.
 pub fn in_out_expo(p: Phase) -> Phase {
-    let x = p.get();
-    let y = if x <= 0.0 {
-        0.0
-    } else if x >= 1.0 {
-        1.0
-    } else if x < 0.5 {
-        2.0_f32.powf(20.0 * x - 10.0) * 0.5
-    } else {
-        (2.0 - 2.0_f32.powf(-20.0 * x + 10.0)) * 0.5
-    };
-    Phase::saturating(y)
+    p.ease_in_out_expo()
 }
 
-/// Back ease-in.
-///
-/// This curve intentionally dips below `0.0`, so it returns a scalar rather
-/// than [`Phase`]. Clamp or map the output explicitly if bounded progress is
-/// desired.
-pub fn in_back(p: Phase) -> f32 {
+/// Back ease-in between `from` and `to`.
+pub fn in_back_between(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_in_back_between(from, to)
+}
+
+/// Elastic ease-out between `from` and `to`.
+pub fn out_elastic_between(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_out_elastic_between(from, to)
+}
+
+fn interpolate_unbounded(from: f32, to: f32, factor: f32) -> f32 {
+    from + (to - from) * factor
+}
+
+fn in_back_factor(p: Phase) -> f32 {
     let x = p.get();
     let c1 = 1.70158;
     let c3 = c1 + 1.0;
     c3 * x.powi(3) - c1 * x.powi(2)
 }
 
-/// Elastic ease-out.
-///
-/// This curve intentionally overshoots above `1.0`, so it returns a scalar
-/// rather than [`Phase`]. Clamp or map the output explicitly if bounded
-/// progress is desired.
-pub fn out_elastic(p: Phase) -> f32 {
+fn out_elastic_factor(p: Phase) -> f32 {
     let x = p.get();
     if x <= 0.0 {
         0.0
@@ -117,16 +176,22 @@ mod tests {
 
     #[test]
     fn bounded_curves_return_phase_values() {
-        assert_near(smoothstep(Phase::HALF).get(), 0.5);
-        assert_near(out_cubic(Phase::HALF).get(), 0.875);
-        assert_near(out_quint(Phase::HALF).get(), 0.96875);
-        assert_near(in_out_quint(Phase::HALF).get(), 0.5);
-        assert_near(in_out_expo(Phase::HALF).get(), 0.5);
+        assert_near(Phase::HALF.ease_smoothstep().get(), 0.5);
+        assert_near(Phase::HALF.ease_out_cubic().get(), 0.875);
+        assert_near(Phase::HALF.ease_out_quint().get(), 0.96875);
+        assert_near(Phase::HALF.ease_in_out_quint().get(), 0.5);
+        assert_near(Phase::HALF.ease_in_out_expo().get(), 0.5);
     }
 
     #[test]
-    fn overshoot_curves_are_not_clamped_to_phase() {
-        assert!(in_back(Phase::HALF) < 0.0);
-        assert!(out_elastic(Phase::new(0.2).unwrap()) > 1.0);
+    fn overshoot_curves_interpolate_outside_the_range() {
+        assert!(Phase::HALF.ease_in_back_between(0.0, 1.0) < 0.0);
+        assert!(Phase::new(0.2).unwrap().ease_out_elastic_between(0.0, 1.0) > 1.0);
+        assert!(
+            Phase::new(0.2)
+                .unwrap()
+                .ease_out_elastic_between(80.0, 300.0)
+                > 300.0
+        );
     }
 }

--- a/tellur-core/src/easing.rs
+++ b/tellur-core/src/easing.rs
@@ -1,0 +1,132 @@
+//! Easing curves for normalized animation progress.
+//!
+//! Bounded easing functions return [`Phase`], preserving Tellur's normalized
+//! progress type so callers can feed the result directly into
+//! [`Phase::interpolate`]. Curves that intentionally overshoot the unit interval
+//! return `f32` and are documented separately.
+
+use std::f32::consts::PI;
+
+use crate::phase::Phase;
+
+/// Identity easing.
+pub fn linear(p: Phase) -> Phase {
+    p
+}
+
+/// Smoothstep easing: zero slope at both endpoints.
+pub fn smoothstep(p: Phase) -> Phase {
+    let x = p.get();
+    Phase::saturating(x * x * (3.0 - 2.0 * x))
+}
+
+/// Cubic ease-out: fast start, gentle settle.
+pub fn out_cubic(p: Phase) -> Phase {
+    let x = p.get();
+    Phase::saturating(1.0 - (1.0 - x).powi(3))
+}
+
+/// Quintic ease-out.
+pub fn out_quint(p: Phase) -> Phase {
+    let x = p.get();
+    Phase::saturating(1.0 - (1.0 - x).powi(5))
+}
+
+/// Quintic ease-in-out.
+pub fn in_out_quint(p: Phase) -> Phase {
+    let x = p.get();
+    let y = if x < 0.5 {
+        16.0 * x.powi(5)
+    } else {
+        1.0 - (-2.0 * x + 2.0).powi(5) * 0.5
+    };
+    Phase::saturating(y)
+}
+
+/// Exponential ease-in-out.
+pub fn in_out_expo(p: Phase) -> Phase {
+    let x = p.get();
+    let y = if x <= 0.0 {
+        0.0
+    } else if x >= 1.0 {
+        1.0
+    } else if x < 0.5 {
+        2.0_f32.powf(20.0 * x - 10.0) * 0.5
+    } else {
+        (2.0 - 2.0_f32.powf(-20.0 * x + 10.0)) * 0.5
+    };
+    Phase::saturating(y)
+}
+
+/// Back ease-in.
+///
+/// This curve intentionally dips below `0.0`, so it returns a scalar rather
+/// than [`Phase`]. Clamp or map the output explicitly if bounded progress is
+/// desired.
+pub fn in_back(p: Phase) -> f32 {
+    let x = p.get();
+    let c1 = 1.70158;
+    let c3 = c1 + 1.0;
+    c3 * x.powi(3) - c1 * x.powi(2)
+}
+
+/// Elastic ease-out.
+///
+/// This curve intentionally overshoots above `1.0`, so it returns a scalar
+/// rather than [`Phase`]. Clamp or map the output explicitly if bounded
+/// progress is desired.
+pub fn out_elastic(p: Phase) -> f32 {
+    let x = p.get();
+    if x <= 0.0 {
+        0.0
+    } else if x >= 1.0 {
+        1.0
+    } else {
+        let c4 = (2.0 * PI) / 3.0;
+        2.0_f32.powf(-10.0 * x) * ((x * 10.0 - 0.75) * c4).sin() + 1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_near(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn bounded_curves_preserve_endpoints() {
+        let curves = [
+            linear as fn(Phase) -> Phase,
+            smoothstep,
+            out_cubic,
+            out_quint,
+            in_out_quint,
+            in_out_expo,
+        ];
+
+        for curve in curves {
+            assert_eq!(curve(Phase::ZERO), Phase::ZERO);
+            assert_eq!(curve(Phase::ONE), Phase::ONE);
+        }
+    }
+
+    #[test]
+    fn bounded_curves_return_phase_values() {
+        assert_near(smoothstep(Phase::HALF).get(), 0.5);
+        assert_near(out_cubic(Phase::HALF).get(), 0.875);
+        assert_near(out_quint(Phase::HALF).get(), 0.96875);
+        assert_near(in_out_quint(Phase::HALF).get(), 0.5);
+        assert_near(in_out_expo(Phase::HALF).get(), 0.5);
+    }
+
+    #[test]
+    fn overshoot_curves_are_not_clamped_to_phase() {
+        assert!(in_back(Phase::HALF) < 0.0);
+        assert!(out_elastic(Phase::new(0.2).unwrap()) > 1.0);
+    }
+}

--- a/tellur-core/src/easing.rs
+++ b/tellur-core/src/easing.rs
@@ -1,66 +1,77 @@
 //! Easing curves for normalized animation progress.
 //!
-//! Bounded easing functions return [`Phase`], preserving Tellur's normalized
-//! progress type so callers can feed the result directly into
-//! [`Phase::interpolate`]. Curves that intentionally overshoot the unit interval
-//! take an explicit output range and return the interpolated value.
+//! Every method on [`PhaseEasing`] takes the [`Phase`] as the driver plus a
+//! `(from, to)` output range and returns an `f32` — the eased value already
+//! interpolated into the caller's quantity (alpha, length, radius, …). The
+//! uniform shape means callers never juggle "does this return Phase or
+//! f32?" — they pick the curve and the range. Bounded curves
+//! (`linear` / smoothstep / cubic / quint / expo) stay inside
+//! `[from, to]`; overshoot curves (`ease_in_back` / `ease_out_elastic`)
+//! intentionally exceed the range — that visual "snap-past" is the point.
 
 use std::f32::consts::PI;
 
 use crate::phase::Phase;
 
-/// Easing methods on [`Phase`].
+/// Easing methods on [`Phase`]. Every method takes `(from, to)` as the
+/// output range and returns the eased `f32` interpolated into it. Callers
+/// pick `(0.0, 1.0)` for an alpha-style factor and `(start, end)` for a
+/// physical quantity (radius, x-position, …).
 pub trait PhaseEasing {
-    /// Identity easing.
-    fn ease_linear(self) -> Phase;
+    /// Linear interpolation — no easing curve. `phase.linear(from, to)`
+    /// returns `from + (to - from) * phase.get()`. The identity-easing
+    /// shape, kept on the trait so callers reach for it the same way they
+    /// reach for the eased variants.
+    fn linear(self, from: f32, to: f32) -> f32;
     /// Smoothstep easing: zero slope at both endpoints.
-    fn ease_smoothstep(self) -> Phase;
+    fn ease_smoothstep(self, from: f32, to: f32) -> f32;
     /// Cubic ease-out: fast start, gentle settle.
-    fn ease_out_cubic(self) -> Phase;
+    fn ease_out_cubic(self, from: f32, to: f32) -> f32;
     /// Quintic ease-out.
-    fn ease_out_quint(self) -> Phase;
+    fn ease_out_quint(self, from: f32, to: f32) -> f32;
     /// Quintic ease-in-out.
-    fn ease_in_out_quint(self) -> Phase;
+    fn ease_in_out_quint(self, from: f32, to: f32) -> f32;
     /// Exponential ease-in-out.
-    fn ease_in_out_expo(self) -> Phase;
-    /// Back ease-in between `from` and `to`. Intentionally dips before `from`.
-    fn ease_in_back_between(self, from: f32, to: f32) -> f32;
-    /// Elastic ease-out between `from` and `to`. Intentionally overshoots past
-    /// `to`.
-    fn ease_out_elastic_between(self, from: f32, to: f32) -> f32;
+    fn ease_in_out_expo(self, from: f32, to: f32) -> f32;
+    /// Back ease-in. Intentionally dips before `from` before snapping to
+    /// `to` — used for visual anticipation.
+    fn ease_in_back(self, from: f32, to: f32) -> f32;
+    /// Elastic ease-out. Intentionally overshoots past `to` before
+    /// settling — used for "spring snap" motion.
+    fn ease_out_elastic(self, from: f32, to: f32) -> f32;
 }
 
 impl PhaseEasing for Phase {
-    fn ease_linear(self) -> Phase {
-        self
+    fn linear(self, from: f32, to: f32) -> f32 {
+        lerp_unbounded(from, to, self.get())
     }
 
-    fn ease_smoothstep(self) -> Phase {
+    fn ease_smoothstep(self, from: f32, to: f32) -> f32 {
         let x = self.get();
-        Phase::saturating(x * x * (3.0 - 2.0 * x))
+        lerp_unbounded(from, to, x * x * (3.0 - 2.0 * x))
     }
 
-    fn ease_out_cubic(self) -> Phase {
+    fn ease_out_cubic(self, from: f32, to: f32) -> f32 {
         let x = self.get();
-        Phase::saturating(1.0 - (1.0 - x).powi(3))
+        lerp_unbounded(from, to, 1.0 - (1.0 - x).powi(3))
     }
 
-    fn ease_out_quint(self) -> Phase {
+    fn ease_out_quint(self, from: f32, to: f32) -> f32 {
         let x = self.get();
-        Phase::saturating(1.0 - (1.0 - x).powi(5))
+        lerp_unbounded(from, to, 1.0 - (1.0 - x).powi(5))
     }
 
-    fn ease_in_out_quint(self) -> Phase {
+    fn ease_in_out_quint(self, from: f32, to: f32) -> f32 {
         let x = self.get();
         let y = if x < 0.5 {
             16.0 * x.powi(5)
         } else {
             1.0 - (-2.0 * x + 2.0).powi(5) * 0.5
         };
-        Phase::saturating(y)
+        lerp_unbounded(from, to, y)
     }
 
-    fn ease_in_out_expo(self) -> Phase {
+    fn ease_in_out_expo(self, from: f32, to: f32) -> f32 {
         let x = self.get();
         let y = if x <= 0.0 {
             0.0
@@ -71,59 +82,60 @@ impl PhaseEasing for Phase {
         } else {
             (2.0 - 2.0_f32.powf(-20.0 * x + 10.0)) * 0.5
         };
-        Phase::saturating(y)
+        lerp_unbounded(from, to, y)
     }
 
-    fn ease_in_back_between(self, from: f32, to: f32) -> f32 {
-        interpolate_unbounded(from, to, in_back_factor(self))
+    fn ease_in_back(self, from: f32, to: f32) -> f32 {
+        lerp_unbounded(from, to, in_back_factor(self))
     }
 
-    fn ease_out_elastic_between(self, from: f32, to: f32) -> f32 {
-        interpolate_unbounded(from, to, out_elastic_factor(self))
+    fn ease_out_elastic(self, from: f32, to: f32) -> f32 {
+        lerp_unbounded(from, to, out_elastic_factor(self))
     }
 }
 
-/// Identity easing.
-pub fn linear(p: Phase) -> Phase {
-    p.ease_linear()
+/// Linear interpolation — no easing curve.
+pub fn linear(p: Phase, from: f32, to: f32) -> f32 {
+    p.linear(from, to)
 }
 
 /// Smoothstep easing: zero slope at both endpoints.
-pub fn smoothstep(p: Phase) -> Phase {
-    p.ease_smoothstep()
+pub fn smoothstep(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_smoothstep(from, to)
 }
 
 /// Cubic ease-out: fast start, gentle settle.
-pub fn out_cubic(p: Phase) -> Phase {
-    p.ease_out_cubic()
+pub fn out_cubic(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_out_cubic(from, to)
 }
 
 /// Quintic ease-out.
-pub fn out_quint(p: Phase) -> Phase {
-    p.ease_out_quint()
+pub fn out_quint(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_out_quint(from, to)
 }
 
 /// Quintic ease-in-out.
-pub fn in_out_quint(p: Phase) -> Phase {
-    p.ease_in_out_quint()
+pub fn in_out_quint(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_in_out_quint(from, to)
 }
 
 /// Exponential ease-in-out.
-pub fn in_out_expo(p: Phase) -> Phase {
-    p.ease_in_out_expo()
+pub fn in_out_expo(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_in_out_expo(from, to)
 }
 
-/// Back ease-in between `from` and `to`.
-pub fn in_back_between(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_in_back_between(from, to)
+/// Back ease-in: dips before `from` for visual anticipation.
+pub fn in_back(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_in_back(from, to)
 }
 
-/// Elastic ease-out between `from` and `to`.
-pub fn out_elastic_between(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_out_elastic_between(from, to)
+/// Elastic ease-out: overshoots past `to` before settling.
+pub fn out_elastic(p: Phase, from: f32, to: f32) -> f32 {
+    p.ease_out_elastic(from, to)
 }
 
-fn interpolate_unbounded(from: f32, to: f32, factor: f32) -> f32 {
+#[inline]
+fn lerp_unbounded(from: f32, to: f32, factor: f32) -> f32 {
     from + (to - from) * factor
 }
 
@@ -158,9 +170,9 @@ mod tests {
     }
 
     #[test]
-    fn bounded_curves_preserve_endpoints() {
-        let curves = [
-            linear as fn(Phase) -> Phase,
+    fn bounded_curves_hit_endpoints() {
+        let curves: [fn(Phase, f32, f32) -> f32; 6] = [
+            linear,
             smoothstep,
             out_cubic,
             out_quint,
@@ -169,29 +181,50 @@ mod tests {
         ];
 
         for curve in curves {
-            assert_eq!(curve(Phase::ZERO), Phase::ZERO);
-            assert_eq!(curve(Phase::ONE), Phase::ONE);
+            assert_near(curve(Phase::ZERO, 0.0, 1.0), 0.0);
+            assert_near(curve(Phase::ONE, 0.0, 1.0), 1.0);
         }
     }
 
     #[test]
-    fn bounded_curves_return_phase_values() {
-        assert_near(Phase::HALF.ease_smoothstep().get(), 0.5);
-        assert_near(Phase::HALF.ease_out_cubic().get(), 0.875);
-        assert_near(Phase::HALF.ease_out_quint().get(), 0.96875);
-        assert_near(Phase::HALF.ease_in_out_quint().get(), 0.5);
-        assert_near(Phase::HALF.ease_in_out_expo().get(), 0.5);
+    fn linear_is_the_lerp() {
+        assert_near(Phase::HALF.linear(0.0, 10.0), 5.0);
+        assert_near(Phase::HALF.linear(10.0, 0.0), 5.0);
+        assert_near(Phase::ZERO.linear(80.0, 300.0), 80.0);
+        assert_near(Phase::ONE.linear(80.0, 300.0), 300.0);
     }
 
     #[test]
-    fn overshoot_curves_interpolate_outside_the_range() {
-        assert!(Phase::HALF.ease_in_back_between(0.0, 1.0) < 0.0);
-        assert!(Phase::new(0.2).unwrap().ease_out_elastic_between(0.0, 1.0) > 1.0);
-        assert!(
-            Phase::new(0.2)
-                .unwrap()
-                .ease_out_elastic_between(80.0, 300.0)
-                > 300.0
-        );
+    fn bounded_curves_match_known_midpoints() {
+        assert_near(Phase::HALF.ease_smoothstep(0.0, 1.0), 0.5);
+        assert_near(Phase::HALF.ease_out_cubic(0.0, 1.0), 0.875);
+        assert_near(Phase::HALF.ease_out_quint(0.0, 1.0), 0.96875);
+        assert_near(Phase::HALF.ease_in_out_quint(0.0, 1.0), 0.5);
+        assert_near(Phase::HALF.ease_in_out_expo(0.0, 1.0), 0.5);
+    }
+
+    #[test]
+    fn bounded_curves_scale_to_arbitrary_range() {
+        // Linear half between (80, 300) is 190.
+        assert_near(Phase::HALF.linear(80.0, 300.0), 190.0);
+        // Cubic at 0.5 is 0.875 (eased into 1.0); scaled to (10, 30) is 27.5.
+        assert_near(Phase::HALF.ease_out_cubic(10.0, 30.0), 27.5);
+    }
+
+    #[test]
+    fn overshoot_curves_leave_the_range() {
+        assert!(Phase::HALF.ease_in_back(0.0, 1.0) < 0.0);
+        assert!(Phase::new(0.2).unwrap().ease_out_elastic(0.0, 1.0) > 1.0);
+        assert!(Phase::new(0.2).unwrap().ease_out_elastic(80.0, 300.0) > 300.0);
+    }
+
+    #[test]
+    fn swapping_from_to_reverses_curve() {
+        // Linear: (0→1) and (1→0) are mirror images.
+        for x in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            let p = Phase::new(x).unwrap();
+            assert_near(p.linear(1.0, 0.0), 1.0 - p.linear(0.0, 1.0));
+            assert_near(p.ease_out_cubic(1.0, 0.0), 1.0 - p.ease_out_cubic(0.0, 1.0));
+        }
     }
 }

--- a/tellur-core/src/easing.rs
+++ b/tellur-core/src/easing.rs
@@ -94,46 +94,6 @@ impl PhaseEasing for Phase {
     }
 }
 
-/// Linear interpolation — no easing curve.
-pub fn linear(p: Phase, from: f32, to: f32) -> f32 {
-    p.linear(from, to)
-}
-
-/// Smoothstep easing: zero slope at both endpoints.
-pub fn smoothstep(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_smoothstep(from, to)
-}
-
-/// Cubic ease-out: fast start, gentle settle.
-pub fn out_cubic(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_out_cubic(from, to)
-}
-
-/// Quintic ease-out.
-pub fn out_quint(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_out_quint(from, to)
-}
-
-/// Quintic ease-in-out.
-pub fn in_out_quint(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_in_out_quint(from, to)
-}
-
-/// Exponential ease-in-out.
-pub fn in_out_expo(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_in_out_expo(from, to)
-}
-
-/// Back ease-in: dips before `from` for visual anticipation.
-pub fn in_back(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_in_back(from, to)
-}
-
-/// Elastic ease-out: overshoots past `to` before settling.
-pub fn out_elastic(p: Phase, from: f32, to: f32) -> f32 {
-    p.ease_out_elastic(from, to)
-}
-
 #[inline]
 fn lerp_unbounded(from: f32, to: f32, factor: f32) -> f32 {
     from + (to - from) * factor
@@ -171,18 +131,18 @@ mod tests {
 
     #[test]
     fn bounded_curves_hit_endpoints() {
-        let curves: [fn(Phase, f32, f32) -> f32; 6] = [
-            linear,
-            smoothstep,
-            out_cubic,
-            out_quint,
-            in_out_quint,
-            in_out_expo,
+        let curves: [fn(Phase) -> f32; 6] = [
+            |p| p.linear(0.0, 1.0),
+            |p| p.ease_smoothstep(0.0, 1.0),
+            |p| p.ease_out_cubic(0.0, 1.0),
+            |p| p.ease_out_quint(0.0, 1.0),
+            |p| p.ease_in_out_quint(0.0, 1.0),
+            |p| p.ease_in_out_expo(0.0, 1.0),
         ];
 
         for curve in curves {
-            assert_near(curve(Phase::ZERO, 0.0, 1.0), 0.0);
-            assert_near(curve(Phase::ONE, 0.0, 1.0), 1.0);
+            assert_near(curve(Phase::ZERO), 0.0);
+            assert_near(curve(Phase::ONE), 1.0);
         }
     }
 

--- a/tellur-core/src/geometry.rs
+++ b/tellur-core/src/geometry.rs
@@ -81,6 +81,82 @@ impl Transform {
             ty: offset.1,
         }
     }
+
+    pub const fn scale(scale: Vec2) -> Self {
+        Self {
+            a: scale.0,
+            b: 0.0,
+            c: 0.0,
+            d: scale.1,
+            tx: 0.0,
+            ty: 0.0,
+        }
+    }
+
+    pub fn rotate(radians: f32) -> Self {
+        let cos = radians.cos();
+        let sin = radians.sin();
+        Self {
+            a: cos,
+            b: sin,
+            c: -sin,
+            d: cos,
+            tx: 0.0,
+            ty: 0.0,
+        }
+    }
+
+    /// Matrix concatenation: `self * child`, applying `child` first and then
+    /// `self` to points.
+    pub fn concat(self, child: Self) -> Self {
+        Self {
+            a: self.a * child.a + self.c * child.b,
+            b: self.b * child.a + self.d * child.b,
+            c: self.a * child.c + self.c * child.d,
+            d: self.b * child.c + self.d * child.d,
+            tx: self.a * child.tx + self.c * child.ty + self.tx,
+            ty: self.b * child.tx + self.d * child.ty + self.ty,
+        }
+    }
+
+    /// Returns a transform that applies `self` first, then `next`.
+    pub fn then(self, next: Self) -> Self {
+        next.concat(self)
+    }
+
+    /// Applies `transform` around `point` instead of the origin.
+    pub fn around_point(point: Vec2, transform: Self) -> Self {
+        Self::translate(point)
+            .concat(transform)
+            .concat(Self::translate(Vec2(-point.0, -point.1)))
+    }
+
+    pub fn transform_point(self, point: Vec2) -> Vec2 {
+        Vec2(
+            self.a * point.0 + self.c * point.1 + self.tx,
+            self.b * point.0 + self.d * point.1 + self.ty,
+        )
+    }
+
+    pub fn transform_rect(self, rect: Rect) -> Rect {
+        let p0 = self.transform_point(rect.origin);
+        let p1 = self.transform_point(Vec2(rect.origin.0 + rect.size.0, rect.origin.1));
+        let p2 = self.transform_point(Vec2(rect.origin.0, rect.origin.1 + rect.size.1));
+        let p3 = self.transform_point(Vec2(
+            rect.origin.0 + rect.size.0,
+            rect.origin.1 + rect.size.1,
+        ));
+
+        let min_x = p0.0.min(p1.0).min(p2.0).min(p3.0);
+        let max_x = p0.0.max(p1.0).max(p2.0).max(p3.0);
+        let min_y = p0.1.min(p1.1).min(p2.1).min(p3.1);
+        let max_y = p0.1.max(p1.1).max(p2.1).max(p3.1);
+
+        Rect {
+            origin: Vec2(min_x, min_y),
+            size: Vec2(max_x - min_x, max_y - min_y),
+        }
+    }
 }
 
 /// A relative position within an axis-aligned box.
@@ -293,4 +369,50 @@ impl Constraints {
 pub enum Axis {
     Horizontal,
     Vertical,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::FRAC_PI_2;
+
+    fn assert_near(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 1e-5,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn assert_vec_near(actual: Vec2, expected: Vec2) {
+        assert_near(actual.0, expected.0);
+        assert_near(actual.1, expected.1);
+    }
+
+    #[test]
+    fn then_applies_transforms_in_reading_order() {
+        let transform = Transform::scale(Vec2(2.0, 3.0)).then(Transform::rotate(FRAC_PI_2));
+        assert_vec_near(transform.transform_point(Vec2(1.0, 0.0)), Vec2(0.0, 2.0));
+    }
+
+    #[test]
+    fn around_point_keeps_pivot_fixed() {
+        let pivot = Vec2(10.0, 20.0);
+        let transform = Transform::around_point(pivot, Transform::scale(Vec2(2.0, 3.0)));
+        assert_vec_near(transform.transform_point(pivot), pivot);
+        assert_vec_near(
+            transform.transform_point(Vec2(11.0, 21.0)),
+            Vec2(12.0, 23.0),
+        );
+    }
+
+    #[test]
+    fn transform_rect_returns_axis_aligned_bounds() {
+        let rect = Rect {
+            origin: Vec2(0.0, 0.0),
+            size: Vec2(2.0, 4.0),
+        };
+        let bounds = Transform::rotate(FRAC_PI_2).transform_rect(rect);
+        assert_vec_near(bounds.origin, Vec2(-4.0, 0.0));
+        assert_vec_near(bounds.size, Vec2(4.0, 2.0));
+    }
 }

--- a/tellur-core/src/interpolate.rs
+++ b/tellur-core/src/interpolate.rs
@@ -1,10 +1,15 @@
 //! [`Interpolate`] — linear interpolation parameterized by [`Phase`].
 //!
-//! The trait is the value-side counterpart of [`Phase::interpolate`]: the
-//! [`Phase`] holds the "where am I between 0 and 1", and the [`Interpolate`]
-//! implementation knows how to combine two values of its type given that
-//! fraction. Provide an impl for a new type to make `phase.interpolate(a, b)`
-//! work for it.
+//! The [`Phase`] holds the "where am I between 0 and 1", and the
+//! [`Interpolate`] implementation knows how to combine two values of its
+//! type given that fraction. Provide an impl for a new type so callers can
+//! lerp it with a Phase: `a.interpolate(b, phase)`.
+//!
+//! For `f32`, the canonical entry point is
+//! [`PhaseEasing::linear`](crate::easing::PhaseEasing::linear) (and the
+//! eased variants on the same trait) — they wrap this trait so callers
+//! reach `phase.linear(from, to)` directly. This trait exists primarily so
+//! richer value types (`Vec2`, `Anchor`, …) can be lerped the same way.
 
 use crate::geometry::{Anchor, Vec2};
 use crate::phase::Phase;

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod timeline_component;
 pub mod timeline_container;
 pub mod vector;
 pub mod video_decode;
+pub mod window;
 
 // Re-export the component macros so users only need to depend on `tellur-core`.
 // The macros emit fully-qualified `::tellur_core::...` paths, so this self-name

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod builder;
 pub mod color;
 pub mod composite;
 pub mod dyn_compare;
+pub mod easing;
 pub mod fragment;
 pub mod geometry;
 pub mod interpolate;

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod phase;
 pub mod placement;
 pub mod raster;
 pub mod render_context;
+pub(crate) mod scalar;
 pub mod shapes;
 pub mod span;
 pub mod text;

--- a/tellur-core/src/phase.rs
+++ b/tellur-core/src/phase.rs
@@ -29,6 +29,7 @@ use std::ops::Range;
 use thiserror::Error;
 
 use crate::dyn_compare::hash_f32;
+use crate::scalar::clamp_unit;
 
 /// A finite `f32` constrained to the unit interval `[0.0, 1.0]` (both
 /// endpoints included), optionally tagged with the seconds-width of the
@@ -39,10 +40,9 @@ use crate::dyn_compare::hash_f32;
 /// additionally carry a [`Phase::width`] equal to `end - start`, enabling
 /// window-local seconds-based sub-phasing via [`Phase::sub_secs`].
 ///
-/// `PartialEq`/`Eq`/`Hash`/`PartialOrd` consider the value only — width is
-/// advisory metadata and does not affect identity, so cache keys remain
-/// stable across rebuilds that re-derive the same value from a different
-/// window.
+/// `PartialEq`/`Eq`/`Hash` include both the value and the optional width.
+/// A `Phase` whose downstream `sub_secs` behavior differs must not collide
+/// in cache keys just because its visible unit-interval value matches.
 #[derive(Debug, Clone, Copy)]
 pub struct Phase {
     value: f32,
@@ -84,7 +84,7 @@ impl Phase {
     /// Phase carries no [`width`](Self::width).
     pub fn saturating(v: f32) -> Self {
         Self {
-            value: clamp_canonical(v),
+            value: clamp_unit(v),
             width: None,
         }
     }
@@ -94,8 +94,12 @@ impl Phase {
     /// sub-phasing methods on this type — direct callers usually want
     /// [`Self::saturating`] or `time.phase(...)` instead.
     pub(crate) fn windowed_saturating(v: f32, width: f32) -> Self {
+        assert!(
+            width.is_finite() && width > 0.0,
+            "Phase::windowed_saturating requires a finite positive width"
+        );
         Self {
-            value: clamp_canonical(v),
+            value: clamp_unit(v),
             width: Some(width),
         }
     }
@@ -118,47 +122,55 @@ impl Phase {
     /// same window. Used internally by the easing methods and by callers
     /// that want a custom non-linear remap (e.g. `4x(1-x)` for a hat-shaped
     /// visibility curve).
+    ///
+    /// Because this remaps value-space, not wall-clock time, call
+    /// `sub_secs` before `map` when a sub-window should be addressed by
+    /// elapsed seconds in the original source window.
     pub fn map(self, f: impl FnOnce(f32) -> f32) -> Phase {
         Self {
-            value: clamp_canonical(f(self.value)),
+            value: clamp_unit(f(self.value)),
             width: self.width,
         }
     }
 
     /// Reinterprets `range` (in unit-interval ratios of the source window)
-    /// as the full extent of a new Phase. The returned Phase rises from 0
-    /// at `range.start` to 1 at `range.end` and saturates outside. Width,
-    /// when known, scales proportionally to the sub-window.
-    pub fn sub_ratio(self, range: Range<f32>) -> Phase {
-        let span = range.end - range.start;
+    /// as the full extent of a new Phase. Returns `None` unless `range` is
+    /// finite, non-empty, ordered, and inside `[0.0, 1.0]`.
+    ///
+    /// The returned Phase rises from 0 at `range.start` to 1 at `range.end`
+    /// and saturates outside. Width, when known, scales proportionally to
+    /// the sub-window.
+    pub fn sub_ratio(self, range: Range<f32>) -> Option<Phase> {
+        let span = checked_ratio_span(&range)?;
         let inner = (self.value - range.start) / span;
-        Self {
-            value: clamp_canonical(inner),
+        Some(Self {
+            value: clamp_unit(inner),
             width: self.width.map(|w| w * span),
-        }
+        })
     }
 
     /// Reinterprets `range` (in seconds from the source window's start) as
     /// the full extent of a new Phase. Requires this Phase to carry a
-    /// [`width`](Self::width) — panics otherwise. The returned Phase's own
-    /// width is `range.end - range.start`, so further `sub_secs` calls
-    /// remain in window-local seconds.
+    /// [`width`](Self::width). Returns `None` if the Phase has no width, or
+    /// if `range` is finite, ordered, non-empty, and inside the source
+    /// window's seconds-width.
+    ///
+    /// The returned Phase's own width is `range.end - range.start`, so
+    /// further `sub_secs` calls remain in window-local seconds.
     ///
     /// This is the natural inverse of the "elapsed seconds inside a window"
     /// pattern: instead of converting the Phase back to seconds, doing
     /// arithmetic, and re-wrapping, callers express each sub-event directly
     /// in window-local seconds.
-    pub fn sub_secs(self, range: Range<f32>) -> Phase {
-        let width = self.width.expect(
-            "Phase::sub_secs requires a width — produce the Phase via time.phase(s, e) or sub_secs",
-        );
+    pub fn sub_secs(self, range: Range<f32>) -> Option<Phase> {
+        let width = self.width?;
+        let span = checked_seconds_span(&range, width)?;
         let elapsed = self.value * width;
-        let span = range.end - range.start;
         let inner = (elapsed - range.start) / span;
-        Self {
-            value: clamp_canonical(inner),
+        Some(Self {
+            value: clamp_unit(inner),
             width: Some(span),
-        }
+        })
     }
 
     /// `true` iff the inner value is exactly `0.0`.
@@ -184,24 +196,39 @@ impl Phase {
     }
 }
 
-/// Clamps to `[0.0, 1.0]`, treating `NaN` as `0.0`, then canonicalizes
-/// `-0.0` to `+0.0` so the bit-pattern-based equality / hashing matches
-/// `PartialOrd` (which treats the two zeroes as equal).
-fn clamp_canonical(v: f32) -> f32 {
-    if v.is_nan() {
-        0.0
-    } else {
-        v.clamp(0.0, 1.0) + 0.0
-    }
+fn checked_ratio_span(range: &Range<f32>) -> Option<f32> {
+    let span = range.end - range.start;
+    (range.start.is_finite()
+        && range.end.is_finite()
+        && range.start >= 0.0
+        && range.end <= 1.0
+        && span.is_finite()
+        && span > 0.0)
+        .then_some(span)
+}
+
+fn checked_seconds_span(range: &Range<f32>, source_width: f32) -> Option<f32> {
+    const EPSILON: f32 = 1.0e-6;
+    let span = range.end - range.start;
+    (range.start.is_finite()
+        && range.end.is_finite()
+        && source_width.is_finite()
+        && source_width > 0.0
+        && range.start >= 0.0
+        && range.end <= source_width + EPSILON
+        && span.is_finite()
+        && span > 0.0)
+        .then_some(span)
 }
 
 impl PartialEq for Phase {
     fn eq(&self, other: &Self) -> bool {
-        // Bit-pattern equality on the value — width is advisory metadata
-        // and intentionally ignored so two Phases that resolved to the
-        // same value from different windows still compare equal (and hash
-        // identically, keeping cache keys stable).
         self.value.to_bits() == other.value.to_bits()
+            && match (self.width, other.width) {
+                (Some(a), Some(b)) => a.to_bits() == b.to_bits(),
+                (None, None) => true,
+                _ => false,
+            }
     }
 }
 
@@ -210,6 +237,13 @@ impl Eq for Phase {}
 impl Hash for Phase {
     fn hash<H: Hasher>(&self, state: &mut H) {
         hash_f32(self.value, state);
+        match self.width {
+            Some(width) => {
+                1_u8.hash(state);
+                hash_f32(width, state);
+            }
+            None => 0_u8.hash(state),
+        }
     }
 }
 
@@ -309,44 +343,69 @@ mod tests {
     #[test]
     fn sub_ratio_carves_unit_interval_window() {
         // value 0.5 with no width — sub_ratio 0.2..0.8 → (0.5 - 0.2) / 0.6 = 0.5.
-        let p = Phase::saturating(0.5).sub_ratio(0.2..0.8);
+        let p = Phase::saturating(0.5).sub_ratio(0.2..0.8).unwrap();
         assert!((p.get() - 0.5).abs() < 1e-6);
         assert!(p.width().is_none());
     }
 
     #[test]
     fn sub_ratio_scales_width_proportionally() {
-        let p = Phase::windowed_saturating(0.5, 2.0).sub_ratio(0.0..0.5);
+        let p = Phase::windowed_saturating(0.5, 2.0)
+            .sub_ratio(0.0..0.5)
+            .unwrap();
         // The new window covers half the parent, so its width is half.
         assert_eq!(p.width(), Some(1.0));
     }
 
     #[test]
     fn sub_ratio_saturates_outside_inner_window() {
-        let p = Phase::saturating(0.1).sub_ratio(0.3..0.7);
+        let p = Phase::saturating(0.1).sub_ratio(0.3..0.7).unwrap();
         assert_eq!(p.get(), 0.0);
-        let p = Phase::saturating(0.9).sub_ratio(0.3..0.7);
+        let p = Phase::saturating(0.9).sub_ratio(0.3..0.7).unwrap();
         assert_eq!(p.get(), 1.0);
+    }
+
+    #[test]
+    fn sub_ratio_rejects_empty_reversed_and_out_of_unit_ranges() {
+        let p = Phase::HALF;
+
+        assert!(p.sub_ratio(0.5..0.5).is_none());
+        assert!(p.sub_ratio(0.6..0.2).is_none());
+        assert!(p.sub_ratio(-0.1..0.5).is_none());
+        assert!(p.sub_ratio(0.5..1.1).is_none());
     }
 
     #[test]
     fn sub_secs_uses_window_width() {
         // Source window is 2.0s long, current value is 0.5 → elapsed = 1.0s.
         // sub_secs(0.0..0.4) → (1.0 - 0.0) / 0.4 = 2.5 → saturates to 1.0.
-        let p = Phase::windowed_saturating(0.5, 2.0).sub_secs(0.0..0.4);
+        let p = Phase::windowed_saturating(0.5, 2.0)
+            .sub_secs(0.0..0.4)
+            .unwrap();
         assert_eq!(p.get(), 1.0);
         assert_eq!(p.width(), Some(0.4));
 
         // value 0.1 of a 2.0s window → elapsed 0.2s.
         // sub_secs(0.0..0.4) → 0.2 / 0.4 = 0.5.
-        let p = Phase::windowed_saturating(0.1, 2.0).sub_secs(0.0..0.4);
+        let p = Phase::windowed_saturating(0.1, 2.0)
+            .sub_secs(0.0..0.4)
+            .unwrap();
         assert!((p.get() - 0.5).abs() < 1e-6);
     }
 
     #[test]
-    #[should_panic(expected = "Phase::sub_secs requires a width")]
-    fn sub_secs_without_width_panics() {
-        let _ = Phase::saturating(0.5).sub_secs(0.0..0.4);
+    fn sub_secs_without_width_returns_none() {
+        assert!(Phase::saturating(0.5).sub_secs(0.0..0.4).is_none());
+    }
+
+    #[test]
+    fn sub_secs_rejects_empty_reversed_and_out_of_source_ranges() {
+        let p = Phase::windowed_saturating(0.5, 1.0);
+
+        assert!(p.sub_secs(0.5..0.5).is_none());
+        assert!(p.sub_secs(0.6..0.2).is_none());
+        assert!(p.sub_secs(-0.1..0.5).is_none());
+        assert!(p.sub_secs(0.5..1.1).is_none());
     }
 
     #[test]
@@ -368,12 +427,14 @@ mod tests {
     }
 
     #[test]
-    fn equality_ignores_width() {
+    fn equality_and_hash_include_width() {
         let a = Phase::saturating(0.5);
         let b = Phase::windowed_saturating(0.5, 2.0);
         let c = Phase::windowed_saturating(0.5, 10.0);
-        assert_eq!(a, b);
-        assert_eq!(b, c);
+        let d = Phase::windowed_saturating(0.5, 2.0);
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_eq!(b, d);
         // Hash agrees with eq.
         use std::collections::hash_map::DefaultHasher;
         let h = |p: Phase| {
@@ -381,7 +442,8 @@ mod tests {
             p.hash(&mut s);
             s.finish()
         };
-        assert_eq!(h(a), h(b));
-        assert_eq!(h(b), h(c));
+        assert_ne!(h(a), h(b));
+        assert_ne!(h(b), h(c));
+        assert_eq!(h(b), h(d));
     }
 }

--- a/tellur-core/src/phase.rs
+++ b/tellur-core/src/phase.rs
@@ -29,7 +29,6 @@ use std::ops::Range;
 use thiserror::Error;
 
 use crate::dyn_compare::hash_f32;
-use crate::interpolate::Interpolate;
 
 /// A finite `f32` constrained to the unit interval `[0.0, 1.0]` (both
 /// endpoints included), optionally tagged with the seconds-width of the
@@ -104,23 +103,6 @@ impl Phase {
     /// Returns the inner value, guaranteed to be a finite `f32` in `[0.0, 1.0]`.
     pub const fn get(self) -> f32 {
         self.value
-    }
-
-    /// Returns `1.0 - self`. The result is still a valid `Phase` (the
-    /// closed unit interval is closed under this reflection). Width is
-    /// preserved.
-    pub fn invert(self) -> Self {
-        Self {
-            value: 1.0 - self.value,
-            width: self.width,
-        }
-    }
-
-    /// Linearly interpolates between `from` (at `self == 0`) and `to`
-    /// (at `self == 1`). Convenience wrapper for `from.interpolate(to, self)`
-    /// so the `Phase` reads as "the driver" in animation code.
-    pub fn interpolate<T: Interpolate>(self, from: T, to: T) -> T {
-        from.interpolate(to, self)
     }
 
     /// Returns the seconds-width of the source window if this Phase was
@@ -289,16 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn invert_is_one_minus() {
-        assert_eq!(Phase::ZERO.invert(), Phase::ONE);
-        assert_eq!(Phase::ONE.invert(), Phase::ZERO);
-        assert_eq!(
-            Phase::new(0.25).unwrap().invert(),
-            Phase::new(0.75).unwrap()
-        );
-    }
-
-    #[test]
     fn try_from_reports_offending_value() {
         let err = Phase::try_from(2.5).unwrap_err();
         assert_eq!(err.0, 2.5);
@@ -316,13 +288,6 @@ mod tests {
         assert_eq!(Phase::ZERO.get(), 0.0);
         assert_eq!(Phase::HALF.get(), 0.5);
         assert_eq!(Phase::ONE.get(), 1.0);
-    }
-
-    #[test]
-    fn interpolate_drives_f32_value() {
-        assert_eq!(Phase::HALF.interpolate(0.0, 10.0), 5.0);
-        assert_eq!(Phase::ZERO.interpolate(0.0, 10.0), 0.0);
-        assert_eq!(Phase::ONE.interpolate(0.0, 10.0), 10.0);
     }
 
     #[test]

--- a/tellur-core/src/phase.rs
+++ b/tellur-core/src/phase.rs
@@ -1,63 +1,119 @@
-//! [`Phase`] — a finite `f32` constrained to `[0.0, 1.0]`.
+//! [`Phase`] — a finite `f32` constrained to `[0.0, 1.0]`, optionally tagged
+//! with the seconds-extent of the time window it was sampled from.
 //!
-//! Intended for normalized scalars such as animation progress, easing
-//! parameters, and similar "fraction of something" quantities. The type
-//! is a newtype wrapper that validates at construction so downstream code
-//! can rely on the invariant without re-checking.
+//! Phase is the unit-interval scalar Tellur uses as the **input** to easing
+//! and interpolation. Easing happens via [`crate::easing::PhaseEasing`],
+//! whose methods all take `(self, from, to)` and return `f32` — the
+//! Phase-to-physical-quantity bridge lives there, not on `Phase` itself.
+//! Phase stays a small "fraction with metadata" type, owning:
+//!
+//! - the unit-interval value ([`Phase::get`])
+//! - the source window's seconds-width ([`Phase::width`]), set by
+//!   [`crate::time::Time::phase`], used to carve sub-windows by elapsed
+//!   seconds via [`Phase::sub_secs`]
+//! - in-Phase remaps via [`Phase::map`] and predicates
+//!   ([`Phase::is_active`] etc.) for gating and threshold checks
+//!
+//! ### Past saturation
+//!
+//! Phase is saturating by design: it forgets how far the cursor traveled
+//! past the window end. For "5 seconds after this envelope saturates"-type
+//! timing, reach for [`crate::window::Window`] — it packages the same
+//! `[start, end)` interval with the cursor so `Window::elapsed` and
+//! `Window::after` are available alongside the Phase.
 
 use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::Range;
 
 use thiserror::Error;
 
+use crate::dyn_compare::hash_f32;
 use crate::interpolate::Interpolate;
-use crate::Keyable;
 
 /// A finite `f32` constrained to the unit interval `[0.0, 1.0]` (both
-/// endpoints included).
+/// endpoints included), optionally tagged with the seconds-width of the
+/// window it was sampled from.
 ///
 /// Construct via [`Phase::new`] (validating) or [`Phase::saturating`]
-/// (clamping). The wrapped value is accessible through [`Phase::get`] and
-/// `Into<f32>`.
-#[derive(Debug, Clone, Copy, PartialOrd, Keyable)]
-pub struct Phase(f32);
+/// (clamping). Phases that originate from [`crate::time::Time::phase`]
+/// additionally carry a [`Phase::width`] equal to `end - start`, enabling
+/// window-local seconds-based sub-phasing via [`Phase::sub_secs`].
+///
+/// `PartialEq`/`Eq`/`Hash`/`PartialOrd` consider the value only — width is
+/// advisory metadata and does not affect identity, so cache keys remain
+/// stable across rebuilds that re-derive the same value from a different
+/// window.
+#[derive(Debug, Clone, Copy)]
+pub struct Phase {
+    value: f32,
+    width: Option<f32>,
+}
 
 impl Phase {
-    pub const ZERO: Self = Self(0.0);
-    pub const HALF: Self = Self(0.5);
-    pub const ONE: Self = Self(1.0);
+    pub const ZERO: Self = Self {
+        value: 0.0,
+        width: None,
+    };
+    pub const HALF: Self = Self {
+        value: 0.5,
+        width: None,
+    };
+    pub const ONE: Self = Self {
+        value: 1.0,
+        width: None,
+    };
 
     /// Returns `Some(Self)` if `v` is finite and within `[0.0, 1.0]`.
-    /// `NaN`, `±inf`, or out-of-range values yield `None`.
+    /// `NaN`, `±inf`, or out-of-range values yield `None`. The resulting
+    /// Phase carries no [`width`](Self::width).
     pub fn new(v: f32) -> Option<Self> {
         if v.is_finite() && (0.0..=1.0).contains(&v) {
-            // Canonicalize -0.0 to +0.0 (`+ 0.0` is exact for every other
-            // finite value) so the bit-pattern `PartialEq`/`Hash` from
-            // `Keyable` agrees with the derived `PartialOrd`, which treats
-            // the two zeroes as equal.
-            Some(Self(v + 0.0))
+            // Canonicalize -0.0 to +0.0 so the bit-pattern-based `PartialEq`
+            // / `Hash` agree with `PartialOrd`, which treats the two zeroes
+            // as equal. `+ 0.0` is exact for every other finite value.
+            Some(Self {
+                value: v + 0.0,
+                width: None,
+            })
         } else {
             None
         }
     }
 
-    /// Clamps `v` to `[0.0, 1.0]`. `NaN` is treated as `0.0`.
+    /// Clamps `v` to `[0.0, 1.0]`. `NaN` is treated as `0.0`. The resulting
+    /// Phase carries no [`width`](Self::width).
     pub fn saturating(v: f32) -> Self {
-        if v.is_nan() {
-            Self::ZERO
-        } else {
-            Self(v.clamp(0.0, 1.0) + 0.0)
+        Self {
+            value: clamp_canonical(v),
+            width: None,
+        }
+    }
+
+    /// Constructs a saturating Phase carrying the seconds-width of the
+    /// source window. Intended for [`crate::time::Time::phase`] and the
+    /// sub-phasing methods on this type — direct callers usually want
+    /// [`Self::saturating`] or `time.phase(...)` instead.
+    pub(crate) fn windowed_saturating(v: f32, width: f32) -> Self {
+        Self {
+            value: clamp_canonical(v),
+            width: Some(width),
         }
     }
 
     /// Returns the inner value, guaranteed to be a finite `f32` in `[0.0, 1.0]`.
     pub const fn get(self) -> f32 {
-        self.0
+        self.value
     }
 
     /// Returns `1.0 - self`. The result is still a valid `Phase` (the
-    /// closed unit interval is closed under this reflection).
+    /// closed unit interval is closed under this reflection). Width is
+    /// preserved.
     pub fn invert(self) -> Self {
-        Self(1.0 - self.0)
+        Self {
+            value: 1.0 - self.value,
+            width: self.width,
+        }
     }
 
     /// Linearly interpolates between `from` (at `self == 0`) and `to`
@@ -66,11 +122,124 @@ impl Phase {
     pub fn interpolate<T: Interpolate>(self, from: T, to: T) -> T {
         from.interpolate(to, self)
     }
+
+    /// Returns the seconds-width of the source window if this Phase was
+    /// produced via [`crate::time::Time::phase`] or a sub-phasing method.
+    /// Returns `None` for Phases built directly (constants, [`Self::new`],
+    /// [`Self::saturating`]).
+    pub const fn width(self) -> Option<f32> {
+        self.width
+    }
+
+    /// Applies `f` to the inner value and rewraps via saturating clamp.
+    /// Width is preserved — `f` is interpreted as a value-space remap of the
+    /// same window. Used internally by the easing methods and by callers
+    /// that want a custom non-linear remap (e.g. `4x(1-x)` for a hat-shaped
+    /// visibility curve).
+    pub fn map(self, f: impl FnOnce(f32) -> f32) -> Phase {
+        Self {
+            value: clamp_canonical(f(self.value)),
+            width: self.width,
+        }
+    }
+
+    /// Reinterprets `range` (in unit-interval ratios of the source window)
+    /// as the full extent of a new Phase. The returned Phase rises from 0
+    /// at `range.start` to 1 at `range.end` and saturates outside. Width,
+    /// when known, scales proportionally to the sub-window.
+    pub fn sub_ratio(self, range: Range<f32>) -> Phase {
+        let span = range.end - range.start;
+        let inner = (self.value - range.start) / span;
+        Self {
+            value: clamp_canonical(inner),
+            width: self.width.map(|w| w * span),
+        }
+    }
+
+    /// Reinterprets `range` (in seconds from the source window's start) as
+    /// the full extent of a new Phase. Requires this Phase to carry a
+    /// [`width`](Self::width) — panics otherwise. The returned Phase's own
+    /// width is `range.end - range.start`, so further `sub_secs` calls
+    /// remain in window-local seconds.
+    ///
+    /// This is the natural inverse of the "elapsed seconds inside a window"
+    /// pattern: instead of converting the Phase back to seconds, doing
+    /// arithmetic, and re-wrapping, callers express each sub-event directly
+    /// in window-local seconds.
+    pub fn sub_secs(self, range: Range<f32>) -> Phase {
+        let width = self.width.expect(
+            "Phase::sub_secs requires a width — produce the Phase via time.phase(s, e) or sub_secs",
+        );
+        let elapsed = self.value * width;
+        let span = range.end - range.start;
+        let inner = (elapsed - range.start) / span;
+        Self {
+            value: clamp_canonical(inner),
+            width: Some(span),
+        }
+    }
+
+    /// `true` iff the inner value is exactly `0.0`.
+    pub fn is_zero(self) -> bool {
+        self.value == 0.0
+    }
+
+    /// `true` iff the inner value is exactly `1.0`.
+    pub fn is_full(self) -> bool {
+        self.value == 1.0
+    }
+
+    /// `true` iff the inner value is strictly greater than `0.0`. Useful for
+    /// "render this only when there's any visibility" gates.
+    pub fn is_active(self) -> bool {
+        self.value > 0.0
+    }
+
+    /// `true` iff the inner value is strictly between `0.0` and `1.0`.
+    /// Useful for transition wipes that should only paint mid-sweep.
+    pub fn is_in_progress(self) -> bool {
+        self.value > 0.0 && self.value < 1.0
+    }
+}
+
+/// Clamps to `[0.0, 1.0]`, treating `NaN` as `0.0`, then canonicalizes
+/// `-0.0` to `+0.0` so the bit-pattern-based equality / hashing matches
+/// `PartialOrd` (which treats the two zeroes as equal).
+fn clamp_canonical(v: f32) -> f32 {
+    if v.is_nan() {
+        0.0
+    } else {
+        v.clamp(0.0, 1.0) + 0.0
+    }
+}
+
+impl PartialEq for Phase {
+    fn eq(&self, other: &Self) -> bool {
+        // Bit-pattern equality on the value — width is advisory metadata
+        // and intentionally ignored so two Phases that resolved to the
+        // same value from different windows still compare equal (and hash
+        // identically, keeping cache keys stable).
+        self.value.to_bits() == other.value.to_bits()
+    }
+}
+
+impl Eq for Phase {}
+
+impl Hash for Phase {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        hash_f32(self.value, state);
+    }
+}
+
+impl PartialOrd for Phase {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
 }
 
 impl From<Phase> for f32 {
     fn from(p: Phase) -> f32 {
-        p.0
+        p.value
     }
 }
 
@@ -83,7 +252,7 @@ impl TryFrom<f32> for Phase {
 
 impl fmt::Display for Phase {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.value)
     }
 }
 
@@ -154,5 +323,100 @@ mod tests {
         assert_eq!(Phase::HALF.interpolate(0.0, 10.0), 5.0);
         assert_eq!(Phase::ZERO.interpolate(0.0, 10.0), 0.0);
         assert_eq!(Phase::ONE.interpolate(0.0, 10.0), 10.0);
+    }
+
+    #[test]
+    fn map_remaps_value_and_preserves_width() {
+        let p = Phase::windowed_saturating(0.5, 1.2);
+        let q = p.map(|x| 4.0 * x * (1.0 - x));
+        assert!((q.get() - 1.0).abs() < 1e-6);
+        assert_eq!(q.width(), Some(1.2));
+    }
+
+    #[test]
+    fn map_saturates_overshoot() {
+        let p = Phase::HALF.map(|_| 2.5);
+        assert_eq!(p.get(), 1.0);
+        let p = Phase::HALF.map(|_| -1.0);
+        assert_eq!(p.get(), 0.0);
+    }
+
+    #[test]
+    fn sub_ratio_carves_unit_interval_window() {
+        // value 0.5 with no width — sub_ratio 0.2..0.8 → (0.5 - 0.2) / 0.6 = 0.5.
+        let p = Phase::saturating(0.5).sub_ratio(0.2..0.8);
+        assert!((p.get() - 0.5).abs() < 1e-6);
+        assert!(p.width().is_none());
+    }
+
+    #[test]
+    fn sub_ratio_scales_width_proportionally() {
+        let p = Phase::windowed_saturating(0.5, 2.0).sub_ratio(0.0..0.5);
+        // The new window covers half the parent, so its width is half.
+        assert_eq!(p.width(), Some(1.0));
+    }
+
+    #[test]
+    fn sub_ratio_saturates_outside_inner_window() {
+        let p = Phase::saturating(0.1).sub_ratio(0.3..0.7);
+        assert_eq!(p.get(), 0.0);
+        let p = Phase::saturating(0.9).sub_ratio(0.3..0.7);
+        assert_eq!(p.get(), 1.0);
+    }
+
+    #[test]
+    fn sub_secs_uses_window_width() {
+        // Source window is 2.0s long, current value is 0.5 → elapsed = 1.0s.
+        // sub_secs(0.0..0.4) → (1.0 - 0.0) / 0.4 = 2.5 → saturates to 1.0.
+        let p = Phase::windowed_saturating(0.5, 2.0).sub_secs(0.0..0.4);
+        assert_eq!(p.get(), 1.0);
+        assert_eq!(p.width(), Some(0.4));
+
+        // value 0.1 of a 2.0s window → elapsed 0.2s.
+        // sub_secs(0.0..0.4) → 0.2 / 0.4 = 0.5.
+        let p = Phase::windowed_saturating(0.1, 2.0).sub_secs(0.0..0.4);
+        assert!((p.get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    #[should_panic(expected = "Phase::sub_secs requires a width")]
+    fn sub_secs_without_width_panics() {
+        let _ = Phase::saturating(0.5).sub_secs(0.0..0.4);
+    }
+
+    #[test]
+    fn predicates_distinguish_endpoints_and_interior() {
+        assert!(Phase::ZERO.is_zero());
+        assert!(!Phase::ZERO.is_active());
+        assert!(!Phase::ZERO.is_in_progress());
+        assert!(!Phase::ZERO.is_full());
+
+        assert!(Phase::ONE.is_full());
+        assert!(Phase::ONE.is_active());
+        assert!(!Phase::ONE.is_in_progress());
+        assert!(!Phase::ONE.is_zero());
+
+        assert!(Phase::HALF.is_active());
+        assert!(Phase::HALF.is_in_progress());
+        assert!(!Phase::HALF.is_zero());
+        assert!(!Phase::HALF.is_full());
+    }
+
+    #[test]
+    fn equality_ignores_width() {
+        let a = Phase::saturating(0.5);
+        let b = Phase::windowed_saturating(0.5, 2.0);
+        let c = Phase::windowed_saturating(0.5, 10.0);
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+        // Hash agrees with eq.
+        use std::collections::hash_map::DefaultHasher;
+        let h = |p: Phase| {
+            let mut s = DefaultHasher::new();
+            p.hash(&mut s);
+            s.finish()
+        };
+        assert_eq!(h(a), h(b));
+        assert_eq!(h(b), h(c));
     }
 }

--- a/tellur-core/src/scalar.rs
+++ b/tellur-core/src/scalar.rs
@@ -1,0 +1,9 @@
+/// Clamps to `[0.0, 1.0]`, treating `NaN` as `0.0`, then canonicalizes
+/// `-0.0` to `+0.0` so bit-pattern equality and hashing stay stable.
+pub(crate) fn clamp_unit(v: f32) -> f32 {
+    if v.is_nan() {
+        0.0
+    } else {
+        v.clamp(0.0, 1.0) + 0.0
+    }
+}

--- a/tellur-core/src/shapes.rs
+++ b/tellur-core/src/shapes.rs
@@ -25,6 +25,10 @@ impl VectorComponent for Rectangle {
         constraints.constrain(self.size)
     }
 
+    fn paint_bounds(&self, size: Vec2) -> Rect {
+        stroked_bounds(size, &self.stroke)
+    }
+
     fn render(&self, size: Vec2) -> VectorGraphic {
         let Vec2(w, h) = size;
         let commands = vec![
@@ -64,6 +68,10 @@ impl VectorComponent for Circle {
         constraints.constrain(Vec2(self.radius * 2.0, self.radius * 2.0))
     }
 
+    fn paint_bounds(&self, size: Vec2) -> Rect {
+        stroked_bounds(size, &self.stroke)
+    }
+
     fn render(&self, size: Vec2) -> VectorGraphic {
         ellipse_to_graphic(
             Vec2(size.0 * 0.5, size.1 * 0.5),
@@ -88,6 +96,10 @@ impl VectorComponent for Ellipse {
         constraints.constrain(Vec2(self.radii.0 * 2.0, self.radii.1 * 2.0))
     }
 
+    fn paint_bounds(&self, size: Vec2) -> Rect {
+        stroked_bounds(size, &self.stroke)
+    }
+
     fn render(&self, size: Vec2) -> VectorGraphic {
         ellipse_to_graphic(
             Vec2(size.0 * 0.5, size.1 * 0.5),
@@ -100,6 +112,17 @@ impl VectorComponent for Ellipse {
 // Magic constant for approximating a quarter-circle with a cubic Bezier:
 // 4 * (sqrt(2) - 1) / 3. The maximum error is around 0.027% of the radius.
 const KAPPA: f32 = 0.552_284_8;
+
+fn stroked_bounds(size: Vec2, stroke: &Option<Stroke>) -> Rect {
+    let outset = stroke
+        .as_ref()
+        .map(|stroke| (stroke.width * 0.5).max(0.0))
+        .unwrap_or(0.0);
+    Rect {
+        origin: Vec2(-outset, -outset),
+        size: Vec2(size.0 + outset * 2.0, size.1 + outset * 2.0),
+    }
+}
 
 // Builds an ellipse whose tight bounding box is anchored at the local origin
 // `(0, 0)` and has size `2 * radii`.
@@ -152,9 +175,9 @@ fn ellipse_to_graphic(radii: Vec2, fill: Option<Fill>, stroke: Option<Stroke>) -
 #[cfg(test)]
 mod builder_tests {
     use super::*;
-    use crate::builder::VectorBuilderPlacement;
+    use crate::builder::{VectorBuilderPlacement, VectorBuilderTransform};
     use crate::color::Color;
-    use crate::geometry::Anchor;
+    use crate::geometry::{Anchor, Transform};
     use crate::vector::Paint;
 
     fn paint() -> Paint {
@@ -198,5 +221,33 @@ mod builder_tests {
             .anchored(Anchor::CENTER)
             .snap_to(Vec2(10.0, 10.0));
         assert_eq!(p2.offset, Vec2(5.0, 5.0));
+    }
+
+    #[test]
+    fn builder_transform_and_opacity() {
+        let transformed = Ellipse::builder()
+            .radii(Vec2(5.0, 5.0))
+            .transform(Transform::scale(Vec2(2.0, 2.0)))
+            .opacity(0.5);
+        assert_eq!(transformed.transform, Transform::scale(Vec2(2.0, 2.0)));
+        assert_eq!(transformed.opacity, 0.5);
+    }
+
+    #[test]
+    fn shape_paint_bounds_include_stroke_outset() {
+        let rect = Rectangle::builder()
+            .size(Vec2(10.0, 20.0))
+            .stroke(Stroke {
+                paint: paint(),
+                width: 4.0,
+            })
+            .build();
+        assert_eq!(
+            rect.paint_bounds(Vec2(10.0, 20.0)),
+            Rect {
+                origin: Vec2(-2.0, -2.0),
+                size: Vec2(14.0, 24.0),
+            }
+        );
     }
 }

--- a/tellur-core/src/shapes.rs
+++ b/tellur-core/src/shapes.rs
@@ -1,10 +1,10 @@
 //! Basic shape components that implement `VectorComponent`.
 //!
-//! Each shape declares its intrinsic size through `layout` and produces
-//! a `VectorGraphic` covering the layout-chosen size in `render`. The
-//! shape will adapt if the parent imposes tight constraints — e.g. a
-//! `Circle` placed under tight non-square constraints renders as an
-//! ellipse.
+//! Each shape declares its intrinsic size through `layout` and produces a
+//! `VectorGraphic` whose view box matches its paint bounds. A stroked shape
+//! widens that view box by half the stroke width on each side. The shape will
+//! adapt if the parent imposes tight constraints — e.g. a `Circle` placed
+//! under tight non-square constraints renders as an ellipse.
 
 use crate::geometry::{Constraints, Rect, Transform, Vec2};
 use crate::vector::{Fill, Node, Path, PathCommand, Stroke, VectorComponent, VectorGraphic};
@@ -39,10 +39,7 @@ impl VectorComponent for Rectangle {
             PathCommand::Close,
         ];
         VectorGraphic {
-            view_box: Rect {
-                origin: Vec2::ZERO,
-                size,
-            },
+            view_box: stroked_bounds(size, &self.stroke),
             root: Node::Path(Path {
                 commands,
                 fill: self.fill.clone(),
@@ -128,6 +125,7 @@ fn stroked_bounds(size: Vec2, stroke: &Option<Stroke>) -> Rect {
 // `(0, 0)` and has size `2 * radii`.
 fn ellipse_to_graphic(radii: Vec2, fill: Option<Fill>, stroke: Option<Stroke>) -> VectorGraphic {
     let Vec2(rx, ry) = radii;
+    let size = Vec2(rx * 2.0, ry * 2.0);
     let cx = rx;
     let cy = ry;
     let ox = rx * KAPPA;
@@ -159,10 +157,7 @@ fn ellipse_to_graphic(radii: Vec2, fill: Option<Fill>, stroke: Option<Stroke>) -
     ];
 
     VectorGraphic {
-        view_box: Rect {
-            origin: Vec2::ZERO,
-            size: Vec2(rx * 2.0, ry * 2.0),
-        },
+        view_box: stroked_bounds(size, &stroke),
         root: Node::Path(Path {
             commands,
             fill,
@@ -247,6 +242,39 @@ mod builder_tests {
             Rect {
                 origin: Vec2(-2.0, -2.0),
                 size: Vec2(14.0, 24.0),
+            }
+        );
+    }
+
+    #[test]
+    fn shape_view_box_matches_stroked_paint_bounds() {
+        let stroke = Stroke {
+            paint: paint(),
+            width: 4.0,
+        };
+        let expected = Rect {
+            origin: Vec2(-2.0, -2.0),
+            size: Vec2(14.0, 24.0),
+        };
+
+        let rect = Rectangle::builder()
+            .size(Vec2(10.0, 20.0))
+            .stroke(stroke.clone())
+            .build();
+        assert_eq!(rect.render(Vec2(10.0, 20.0)).view_box, expected);
+
+        let ellipse = Ellipse::builder()
+            .radii(Vec2(5.0, 10.0))
+            .stroke(stroke.clone())
+            .build();
+        assert_eq!(ellipse.render(Vec2(10.0, 20.0)).view_box, expected);
+
+        let circle = Circle::builder().radius(5.0).stroke(stroke).build();
+        assert_eq!(
+            circle.render(Vec2(10.0, 10.0)).view_box,
+            Rect {
+                origin: Vec2(-2.0, -2.0),
+                size: Vec2(14.0, 14.0),
             }
         );
     }

--- a/tellur-core/src/time.rs
+++ b/tellur-core/src/time.rs
@@ -132,6 +132,7 @@ pub trait Time: Copy + Sized {
     /// [`Phase::sub_secs`](crate::phase::Phase::sub_secs) without having
     /// to thread the width through manually.
     fn phase(&self, start: f32, end: f32) -> Phase {
+        assert_valid_span(start, end, "Time::phase");
         let u = (self.seconds() - start) / (end - start);
         Phase::windowed_saturating(u, end - start)
     }
@@ -143,6 +144,13 @@ pub trait Time: Copy + Sized {
     fn window(&self, start: f32, end: f32) -> Window {
         Window::new(start, end, self.seconds())
     }
+}
+
+fn assert_valid_span(start: f32, end: f32, caller: &str) {
+    assert!(
+        start.is_finite() && end.is_finite() && end > start,
+        "{caller} requires finite start/end with end > start"
+    );
 }
 
 /// A point on the global timeline that a [`crate::timeline::Timeline`] is
@@ -422,9 +430,21 @@ mod tests {
     #[test]
     fn phase_clamps_outside_range() {
         let before = TimelineTime::new(2.0);
-        assert_eq!(before.phase(3.0, 5.0), Phase::ZERO);
+        assert_eq!(before.phase(3.0, 5.0).get(), Phase::ZERO.get());
         let after = TimelineTime::new(6.0);
-        assert_eq!(after.phase(3.0, 5.0), Phase::ONE);
+        assert_eq!(after.phase(3.0, 5.0).get(), Phase::ONE.get());
+    }
+
+    #[test]
+    #[should_panic(expected = "Time::phase requires finite start/end with end > start")]
+    fn phase_rejects_equal_bounds() {
+        let _ = TimelineTime::new(5.0).phase(5.0, 5.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Time::phase requires finite start/end with end > start")]
+    fn phase_rejects_reversed_bounds() {
+        let _ = TimelineTime::new(1.0).phase(2.0, 1.0);
     }
 
     #[test]

--- a/tellur-core/src/time.rs
+++ b/tellur-core/src/time.rs
@@ -31,6 +31,7 @@
 //! ```
 
 use crate::phase::Phase;
+use crate::window::Window;
 use crate::Keyable;
 
 /// A point in time, measured in seconds.
@@ -134,6 +135,14 @@ pub trait Time: Copy + Sized {
         let u = (self.seconds() - start) / (end - start);
         Phase::windowed_saturating(u, end - start)
     }
+
+    /// Packages this time and a `[start, end)` interval into a [`Window`]
+    /// that exposes both the saturating [`Phase`] view and the unbounded
+    /// [`Window::elapsed`] / [`Window::after`] durations [`Phase`] alone
+    /// cannot represent (e.g. "5 seconds after the intro finishes").
+    fn window(&self, start: f32, end: f32) -> Window {
+        Window::new(start, end, self.seconds())
+    }
 }
 
 /// A point on the global timeline that a [`crate::timeline::Timeline`] is
@@ -204,6 +213,7 @@ pub trait TimeOptionExt<T: Time> {
     fn bounce(self, period: f32) -> Option<(Phase, i32)>;
     fn bounce_with_zero(self, period: f32, zero: f32) -> Option<(Phase, i32)>;
     fn phase(self, start: f32, end: f32) -> Option<Phase>;
+    fn window(self, start: f32, end: f32) -> Option<Window>;
 }
 
 impl<T: Time> TimeOptionExt<T> for Option<T> {
@@ -233,6 +243,9 @@ impl<T: Time> TimeOptionExt<T> for Option<T> {
     }
     fn phase(self, start: f32, end: f32) -> Option<Phase> {
         self.map(|t| t.phase(start, end))
+    }
+    fn window(self, start: f32, end: f32) -> Option<Window> {
+        self.map(|t| t.window(start, end))
     }
 }
 

--- a/tellur-core/src/time.rs
+++ b/tellur-core/src/time.rs
@@ -124,9 +124,15 @@ pub trait Time: Copy + Sized {
     /// Maps `[start, end]` to `[0.0, 1.0]` linearly, clamping outside.
     /// Useful for driving an easing or interpolation whose input is a
     /// [`Phase`] rather than a raw time value.
+    ///
+    /// The returned Phase remembers `end - start` as its
+    /// [`Phase::width`](crate::phase::Phase::width), so callers can carve
+    /// the window into sub-phases in window-local seconds via
+    /// [`Phase::sub_secs`](crate::phase::Phase::sub_secs) without having
+    /// to thread the width through manually.
     fn phase(&self, start: f32, end: f32) -> Phase {
         let u = (self.seconds() - start) / (end - start);
-        Phase::saturating(u)
+        Phase::windowed_saturating(u, end - start)
     }
 }
 

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -216,15 +216,45 @@ pub enum Paint {
     Solid(Color),
 }
 
+impl Paint {
+    pub const fn solid(color: Color) -> Self {
+        Self::Solid(color)
+    }
+}
+
+impl From<Color> for Paint {
+    fn from(color: Color) -> Self {
+        Self::solid(color)
+    }
+}
+
+impl From<Color> for Option<Paint> {
+    fn from(color: Color) -> Self {
+        Some(color.into())
+    }
+}
+
 impl From<Paint> for Fill {
     fn from(paint: Paint) -> Self {
         Self { paint }
     }
 }
 
+impl From<Color> for Fill {
+    fn from(color: Color) -> Self {
+        Paint::from(color).into()
+    }
+}
+
 impl From<Paint> for Option<Fill> {
     fn from(paint: Paint) -> Self {
         Some(Fill { paint })
+    }
+}
+
+impl From<Color> for Option<Fill> {
+    fn from(color: Color) -> Self {
+        Some(color.into())
     }
 }
 
@@ -235,8 +265,58 @@ impl From<Paint> for Stroke {
     }
 }
 
+impl From<Color> for Stroke {
+    fn from(color: Color) -> Self {
+        Paint::from(color).into()
+    }
+}
+
 impl From<Paint> for Option<Stroke> {
     fn from(paint: Paint) -> Self {
         Some(paint.into())
+    }
+}
+
+impl From<Color> for Option<Stroke> {
+    fn from(color: Color) -> Self {
+        Some(color.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_converts_to_paint_fill_and_stroke() {
+        let color = Color::rgb_u8(10, 20, 30);
+
+        assert_eq!(Paint::solid(color), Paint::Solid(color));
+        assert_eq!(Paint::from(color), Paint::Solid(color));
+        assert_eq!(Fill::from(color).paint, Paint::Solid(color));
+
+        let stroke = Stroke::from(color);
+        assert_eq!(stroke.paint, Paint::Solid(color));
+        assert_eq!(stroke.width, 1.0);
+    }
+
+    #[test]
+    fn color_converts_to_optional_paint_styles() {
+        let color = Color::rgb_u8(40, 50, 60);
+
+        assert_eq!(Option::<Paint>::from(color), Some(Paint::Solid(color)));
+        assert_eq!(
+            Option::<Fill>::from(color),
+            Some(Fill {
+                paint: Paint::Solid(color),
+            })
+        );
+        assert_eq!(
+            Option::<Stroke>::from(color),
+            Some(Stroke {
+                paint: Paint::Solid(color),
+                width: 1.0,
+            })
+        );
     }
 }

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -31,9 +31,10 @@ pub struct VectorGraphic {
 ///    chosen size to obtain the graphic.
 ///
 /// Optionally the parent calls [`paint_bounds`](VectorComponent::paint_bounds)
-/// with the chosen size to know how far the component paints outside the
-/// layout box (useful for `Layer::render` sub-resolution sizing and for
-/// rasterize buffer allocation).
+/// with the chosen size to know the layout box plus anything the component
+/// paints outside it (useful for `Layer::render` sub-resolution sizing and for
+/// rasterize buffer allocation). Implementations should include the layout
+/// rectangle `(0, 0)..size` in the returned bounds.
 ///
 /// Element components implement `layout` and `render` directly. Composite
 /// components (produced by `#[vector_component]`) usually do the same,
@@ -103,9 +104,10 @@ impl Hash for dyn VectorComponent {
 ///
 /// Transforms are layout-neutral: `layout` forwards to the child unchanged.
 /// The transform is reflected in `paint_bounds`, `render().view_box`, and the
-/// emitted node tree. Anchor-based placement therefore snaps the pre-transform
-/// intrinsic box; callers that need transformed geometry to affect layout
-/// should wrap the transformed component in an explicit container.
+/// emitted node tree, while the untransformed layout box remains inside those
+/// bounds. Anchor-based placement therefore snaps the pre-transform intrinsic
+/// box; callers that need transformed geometry to affect layout should wrap the
+/// transformed component in an explicit container.
 #[derive(Keyable)]
 pub struct Transformed {
     pub transform: Transform,
@@ -142,13 +144,13 @@ impl VectorComponent for Transformed {
     }
 
     fn paint_bounds(&self, size: Vec2) -> Rect {
-        self.transform.transform_rect(self.child.paint_bounds(size))
+        transformed_bounds(size, self.child.paint_bounds(size), self.transform)
     }
 
     fn render(&self, size: Vec2) -> VectorGraphic {
         let inner = self.child.render(size);
         VectorGraphic {
-            view_box: self.transform.transform_rect(inner.view_box),
+            view_box: transformed_bounds(size, inner.view_box, self.transform),
             root: Node::single_group(self.transform, self.opacity, inner.root),
         }
     }
@@ -172,6 +174,26 @@ pub trait VectorTransform: VectorComponent + Sized + 'static {
 }
 
 impl<T: VectorComponent + 'static> VectorTransform for T {}
+
+fn transformed_bounds(size: Vec2, child_bounds: Rect, transform: Transform) -> Rect {
+    let layout_bounds = Rect {
+        origin: Vec2::ZERO,
+        size,
+    };
+    let base_bounds = union_rect(layout_bounds, child_bounds);
+    union_rect(base_bounds, transform.transform_rect(base_bounds))
+}
+
+fn union_rect(a: Rect, b: Rect) -> Rect {
+    let a_end = Vec2(a.origin.0 + a.size.0, a.origin.1 + a.size.1);
+    let b_end = Vec2(b.origin.0 + b.size.0, b.origin.1 + b.size.1);
+    let origin = Vec2(a.origin.0.min(b.origin.0), a.origin.1.min(b.origin.1));
+    let end = Vec2(a_end.0.max(b_end.0), a_end.1.max(b_end.1));
+    Rect {
+        origin,
+        size: Vec2(end.0 - origin.0, end.1 - origin.1),
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Node {
@@ -355,17 +377,42 @@ mod tests {
         assert_eq!(
             transformed.paint_bounds(Vec2(10.0, 20.0)),
             Rect {
-                origin: Vec2(5.0, 7.0),
-                size: Vec2(10.0, 20.0),
+                origin: Vec2::ZERO,
+                size: Vec2(15.0, 27.0),
             }
         );
         assert_eq!(
             transformed.render(Vec2(10.0, 20.0)).view_box,
             Rect {
-                origin: Vec2(5.0, 7.0),
-                size: Vec2(10.0, 20.0),
+                origin: Vec2::ZERO,
+                size: Vec2(15.0, 27.0),
             }
         );
+    }
+
+    #[test]
+    fn transformed_bounds_do_not_shrink_the_layout_box() {
+        let transformed = Rectangle {
+            size: Vec2(4.0, 20.0),
+            fill: None,
+            stroke: None,
+        }
+        .transform(Transform {
+            a: 0.0,
+            b: 1.0,
+            c: -1.0,
+            d: 0.0,
+            tx: 12.0,
+            ty: 8.0,
+        });
+        let expected = Rect {
+            origin: Vec2(-8.0, 0.0),
+            size: Vec2(20.0, 20.0),
+        };
+
+        assert_eq!(transformed.layout(Constraints::UNBOUNDED), Vec2(4.0, 20.0));
+        assert_eq!(transformed.paint_bounds(Vec2(4.0, 20.0)), expected);
+        assert_eq!(transformed.render(Vec2(4.0, 20.0)).view_box, expected);
     }
 
     #[test]

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -98,6 +98,78 @@ impl Hash for dyn VectorComponent {
     }
 }
 
+/// A [`VectorComponent`] wrapped in an affine transform and group opacity.
+#[derive(Keyable)]
+pub struct Transformed {
+    pub transform: Transform,
+    pub opacity: f32,
+    pub child: Box<dyn VectorComponent>,
+}
+
+impl Transformed {
+    pub fn new<C: VectorComponent + 'static>(transform: Transform, child: C) -> Self {
+        Self {
+            transform,
+            opacity: 1.0,
+            child: Box::new(child),
+        }
+    }
+
+    pub fn from_box(transform: Transform, child: Box<dyn VectorComponent>) -> Self {
+        Self {
+            transform,
+            opacity: 1.0,
+            child,
+        }
+    }
+
+    pub fn opacity(mut self, opacity: f32) -> Self {
+        self.opacity = opacity;
+        self
+    }
+}
+
+impl VectorComponent for Transformed {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        self.child.layout(constraints)
+    }
+
+    fn paint_bounds(&self, size: Vec2) -> Rect {
+        self.transform.transform_rect(self.child.paint_bounds(size))
+    }
+
+    fn render(&self, size: Vec2) -> VectorGraphic {
+        let inner = self.child.render(size);
+        VectorGraphic {
+            view_box: self.transform.transform_rect(inner.view_box),
+            root: Node::Group(Group {
+                transform: self.transform,
+                opacity: self.opacity.clamp(0.0, 1.0),
+                children: vec![inner.root],
+            }),
+        }
+    }
+}
+
+impl From<Transformed> for Box<dyn VectorComponent> {
+    fn from(transformed: Transformed) -> Self {
+        Box::new(transformed)
+    }
+}
+
+/// Extension trait adding transform wrappers to vector components.
+pub trait VectorTransform: VectorComponent + Sized + 'static {
+    fn transform(self, transform: Transform) -> Transformed {
+        Transformed::new(transform, self)
+    }
+
+    fn opacity(self, opacity: f32) -> Transformed {
+        Transformed::new(Transform::IDENTITY, self).opacity(opacity)
+    }
+}
+
+impl<T: VectorComponent + 'static> VectorTransform for T {}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Node {
     Group(Group),

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 use crate::color::Color;
 use crate::dyn_compare::{DynEq, DynHash};
 use crate::geometry::{Constraints, Rect, Transform, Vec2};
+use crate::scalar::clamp_unit;
 use crate::Keyable;
 
 /// A piece of vector content with a paint-bounds rectangle.
@@ -99,6 +100,12 @@ impl Hash for dyn VectorComponent {
 }
 
 /// A [`VectorComponent`] wrapped in an affine transform and group opacity.
+///
+/// Transforms are layout-neutral: `layout` forwards to the child unchanged.
+/// The transform is reflected in `paint_bounds`, `render().view_box`, and the
+/// emitted node tree. Anchor-based placement therefore snaps the pre-transform
+/// intrinsic box; callers that need transformed geometry to affect layout
+/// should wrap the transformed component in an explicit container.
 #[derive(Keyable)]
 pub struct Transformed {
     pub transform: Transform,
@@ -142,11 +149,7 @@ impl VectorComponent for Transformed {
         let inner = self.child.render(size);
         VectorGraphic {
             view_box: self.transform.transform_rect(inner.view_box),
-            root: Node::Group(Group {
-                transform: self.transform,
-                opacity: self.opacity.clamp(0.0, 1.0),
-                children: vec![inner.root],
-            }),
+            root: Node::single_group(self.transform, self.opacity, inner.root),
         }
     }
 }
@@ -173,7 +176,18 @@ impl<T: VectorComponent + 'static> VectorTransform for T {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Node {
     Group(Group),
+    SingleGroup(SingleGroup),
     Path(Path),
+}
+
+impl Node {
+    pub fn single_group(transform: Transform, opacity: f32, child: Node) -> Self {
+        Self::SingleGroup(SingleGroup {
+            transform,
+            opacity: clamp_unit(opacity),
+            child: Box::new(child),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Keyable)]
@@ -181,6 +195,13 @@ pub struct Group {
     pub transform: Transform,
     pub opacity: f32,
     pub children: Vec<Node>,
+}
+
+#[derive(Debug, Clone, Keyable)]
+pub struct SingleGroup {
+    pub transform: Transform,
+    pub opacity: f32,
+    pub child: Box<Node>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -286,6 +307,7 @@ impl From<Color> for Option<Stroke> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shapes::Rectangle;
 
     #[test]
     fn color_converts_to_paint_fill_and_stroke() {
@@ -318,5 +340,47 @@ mod tests {
                 width: 1.0,
             })
         );
+    }
+
+    #[test]
+    fn transformed_layout_is_layout_neutral() {
+        let transformed = Rectangle {
+            size: Vec2(10.0, 20.0),
+            fill: None,
+            stroke: None,
+        }
+        .transform(Transform::translate(Vec2(5.0, 7.0)));
+
+        assert_eq!(transformed.layout(Constraints::UNBOUNDED), Vec2(10.0, 20.0));
+        assert_eq!(
+            transformed.paint_bounds(Vec2(10.0, 20.0)),
+            Rect {
+                origin: Vec2(5.0, 7.0),
+                size: Vec2(10.0, 20.0),
+            }
+        );
+        assert_eq!(
+            transformed.render(Vec2(10.0, 20.0)).view_box,
+            Rect {
+                origin: Vec2(5.0, 7.0),
+                size: Vec2(10.0, 20.0),
+            }
+        );
+    }
+
+    #[test]
+    fn transformed_opacity_treats_nan_as_zero() {
+        let transformed = Rectangle {
+            size: Vec2(1.0, 1.0),
+            fill: None,
+            stroke: None,
+        }
+        .opacity(f32::NAN);
+
+        let graphic = transformed.render(Vec2(1.0, 1.0));
+        let Node::SingleGroup(group) = graphic.root else {
+            panic!("Transformed should render as a single-child group");
+        };
+        assert_eq!(group.opacity, 0.0);
     }
 }

--- a/tellur-core/src/window.rs
+++ b/tellur-core/src/window.rs
@@ -1,0 +1,194 @@
+//! [`Window`] — a time interval `[start, end)` paired with the current time
+//! cursor, packaging together the saturating [`Phase`] view and the unbounded
+//! "seconds since the anchor" / "seconds past the close" durations that the
+//! [`Phase`] alone cannot represent.
+//!
+//! `Window` exists because [`Phase`] is saturating by design: once the cursor
+//! passes the window end, the Phase clamps at `1.0` and forgets how far past
+//! it went. For envelopes (rise / saturate / fall) that is exactly right;
+//! for "spin since this moment", "5 seconds after the intro finishes", or
+//! any ongoing motion that outlives the window, callers need the absolute
+//! time anchors back. `Window` keeps them attached.
+//!
+//! ```
+//! use tellur_core::time::{Time, TimelineTime};
+//! let t = TimelineTime::new(7.0);
+//! let w = t.window(5.0, 6.0);
+//! assert_eq!(w.phase().get(), 1.0);       // saturated
+//! assert_eq!(w.elapsed(), 2.0);           // 2s since the window opened
+//! assert_eq!(w.after(), 1.0);             // 1s past close
+//! ```
+
+use crate::phase::Phase;
+use crate::Keyable;
+
+/// A time interval `[start, end)` plus the current time cursor — the pair
+/// `Phase` needs to talk about coordinates outside the window.
+///
+/// Construct via [`crate::time::Time::window`]. All accessors are derived
+/// from `(start, end, current)`; the struct itself stores those three `f32`s
+/// directly so it can be `Keyable`-hashed for cache keys.
+#[derive(Debug, Clone, Copy, Keyable)]
+pub struct Window {
+    start: f32,
+    end: f32,
+    current: f32,
+}
+
+impl Window {
+    /// Constructs a `Window` directly. Most callers should reach for
+    /// [`crate::time::Time::window`] instead; this is exposed for tests and
+    /// the rare case of building a window without a `Time` in hand.
+    pub const fn new(start: f32, end: f32, current: f32) -> Self {
+        Self {
+            start,
+            end,
+            current,
+        }
+    }
+
+    /// The window's start time in absolute seconds.
+    pub const fn start(self) -> f32 {
+        self.start
+    }
+
+    /// The window's end time in absolute seconds.
+    pub const fn end(self) -> f32 {
+        self.end
+    }
+
+    /// The cursor's absolute time, copied from the `Time` that built this
+    /// `Window`. Can be before [`Self::start`] or after [`Self::end`].
+    pub const fn current(self) -> f32 {
+        self.current
+    }
+
+    /// `end - start`. Always reflects the declared window; does not collapse
+    /// when the cursor is outside the window.
+    pub fn width(self) -> f32 {
+        self.end - self.start
+    }
+
+    /// The saturating [`Phase`] view: `0.0` before `start`, `1.0` after
+    /// `end`, linearly interpolated in between. Carries [`Phase::width`]
+    /// so the resulting Phase can be further carved with
+    /// [`Phase::sub_secs`].
+    pub fn phase(self) -> Phase {
+        let u = (self.current - self.start) / (self.end - self.start);
+        Phase::windowed_saturating(u, self.end - self.start)
+    }
+
+    /// Seconds the cursor has lived past `start`, clamped at `0` before the
+    /// window opens. **Not** clamped at the end — keeps counting once the
+    /// window closes, which is exactly the "ongoing motion since this
+    /// anchor" case [`Phase`] cannot express.
+    pub fn elapsed(self) -> f32 {
+        (self.current - self.start).max(0.0)
+    }
+
+    /// Seconds remaining until the window opens, `0` once it has.
+    pub fn before(self) -> f32 {
+        (self.start - self.current).max(0.0)
+    }
+
+    /// Seconds the cursor has lived past `end`, `0` before the window
+    /// closes. The companion to [`Self::elapsed`] for post-saturation
+    /// timing (e.g. "5 seconds after the intro finishes").
+    pub fn after(self) -> f32 {
+        (self.current - self.end).max(0.0)
+    }
+
+    /// `true` iff the cursor is within `[start, end)` — the same gate as
+    /// [`crate::time::Time::during`].
+    pub fn is_inside(self) -> bool {
+        self.current >= self.start && self.current < self.end
+    }
+
+    /// `true` iff the cursor has not reached `start` yet.
+    pub fn is_before(self) -> bool {
+        self.current < self.start
+    }
+
+    /// `true` iff the cursor has reached or passed `end`.
+    pub fn is_after(self) -> bool {
+        self.current >= self.end
+    }
+
+    /// Unclamped `(current - start) / (end - start)`. Goes negative before
+    /// the window opens, exceeds `1.0` after it closes. Useful when the
+    /// downstream consumer wants the linear progress without the saturating
+    /// clamp — most callers want [`Self::phase`] instead.
+    pub fn raw_progress(self) -> f32 {
+        (self.current - self.start) / (self.end - self.start)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn w(start: f32, end: f32, current: f32) -> Window {
+        Window::new(start, end, current)
+    }
+
+    #[test]
+    fn phase_saturates_at_endpoints() {
+        assert_eq!(w(3.0, 5.0, 2.0).phase().get(), 0.0);
+        assert_eq!(w(3.0, 5.0, 6.0).phase().get(), 1.0);
+        assert!((w(3.0, 5.0, 4.0).phase().get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn phase_carries_width() {
+        assert_eq!(w(3.0, 5.0, 4.0).phase().width(), Some(2.0));
+    }
+
+    #[test]
+    fn elapsed_keeps_counting_past_end() {
+        // Before: 0.
+        assert_eq!(w(3.0, 5.0, 2.0).elapsed(), 0.0);
+        // Inside: current - start.
+        assert!((w(3.0, 5.0, 4.0).elapsed() - 1.0).abs() < 1e-6);
+        // After: still current - start, NOT clamped at width.
+        assert!((w(3.0, 5.0, 7.5).elapsed() - 4.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn before_counts_down_then_zero() {
+        assert!((w(3.0, 5.0, 1.0).before() - 2.0).abs() < 1e-6);
+        assert_eq!(w(3.0, 5.0, 3.0).before(), 0.0);
+        assert_eq!(w(3.0, 5.0, 4.0).before(), 0.0);
+        assert_eq!(w(3.0, 5.0, 6.0).before(), 0.0);
+    }
+
+    #[test]
+    fn after_zero_until_close_then_climbs() {
+        assert_eq!(w(3.0, 5.0, 4.0).after(), 0.0);
+        assert_eq!(w(3.0, 5.0, 5.0).after(), 0.0);
+        assert!((w(3.0, 5.0, 6.5).after() - 1.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn gates_partition_the_timeline() {
+        let win = w(3.0, 5.0, 2.0);
+        assert!(win.is_before() && !win.is_inside() && !win.is_after());
+        let win = w(3.0, 5.0, 4.0);
+        assert!(!win.is_before() && win.is_inside() && !win.is_after());
+        // End is exclusive, like Time::during.
+        let win = w(3.0, 5.0, 5.0);
+        assert!(!win.is_before() && !win.is_inside() && win.is_after());
+        let win = w(3.0, 5.0, 6.0);
+        assert!(!win.is_before() && !win.is_inside() && win.is_after());
+    }
+
+    #[test]
+    fn raw_progress_is_unclamped() {
+        assert!((w(3.0, 5.0, 2.0).raw_progress() - (-0.5)).abs() < 1e-6);
+        assert!((w(3.0, 5.0, 7.0).raw_progress() - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn width_matches_declared_span() {
+        assert_eq!(w(3.0, 5.0, 999.0).width(), 2.0);
+    }
+}

--- a/tellur-core/src/window.rs
+++ b/tellur-core/src/window.rs
@@ -66,7 +66,7 @@ impl Window {
     /// `end - start`. Always reflects the declared window; does not collapse
     /// when the cursor is outside the window.
     pub fn width(self) -> f32 {
-        self.end - self.start
+        self.span()
     }
 
     /// The saturating [`Phase`] view: `0.0` before `start`, `1.0` after
@@ -74,8 +74,9 @@ impl Window {
     /// so the resulting Phase can be further carved with
     /// [`Phase::sub_secs`].
     pub fn phase(self) -> Phase {
-        let u = (self.current - self.start) / (self.end - self.start);
-        Phase::windowed_saturating(u, self.end - self.start)
+        let width = self.span();
+        let u = (self.current - self.start) / width;
+        Phase::windowed_saturating(u, width)
     }
 
     /// Seconds the cursor has lived past `start`, clamped at `0` before the
@@ -119,7 +120,15 @@ impl Window {
     /// downstream consumer wants the linear progress without the saturating
     /// clamp — most callers want [`Self::phase`] instead.
     pub fn raw_progress(self) -> f32 {
-        (self.current - self.start) / (self.end - self.start)
+        (self.current - self.start) / self.span()
+    }
+
+    fn span(self) -> f32 {
+        assert!(
+            self.start.is_finite() && self.end.is_finite() && self.end > self.start,
+            "Window requires finite start/end with end > start"
+        );
+        self.end - self.start
     }
 }
 
@@ -190,5 +199,17 @@ mod tests {
     #[test]
     fn width_matches_declared_span() {
         assert_eq!(w(3.0, 5.0, 999.0).width(), 2.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Window requires finite start/end with end > start")]
+    fn phase_rejects_equal_bounds() {
+        let _ = w(5.0, 5.0, 5.0).phase();
+    }
+
+    #[test]
+    #[should_panic(expected = "Window requires finite start/end with end > start")]
+    fn raw_progress_rejects_equal_bounds() {
+        let _ = w(5.0, 5.0, 7.0).raw_progress();
     }
 }

--- a/tellur-live/examples/demo_scene/backdrop.rs
+++ b/tellur-live/examples/demo_scene/backdrop.rs
@@ -42,7 +42,9 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
         // Faint horizon lines sliding in from the left.
         .children((0..18).map(move |i| {
             let y = 64.0 + i as f32 * 56.0;
-            let reveal = ease_in_out_expo(local_phase(t, i as f32 * 0.008, 0.4 + i as f32 * 0.008));
+            let reveal = local_phase(t, i as f32 * 0.008, 0.4 + i as f32 * 0.008)
+                .ease_in_out_expo()
+                .get();
             Rect::builder()
                 .position(Vec2(lerp(-1920.0, 0.0, reveal), y))
                 .size(Vec2(1920.0, 1.0))
@@ -53,7 +55,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
         // measured field" and pull the eye toward center without actually
         // darkening the corners.
         .maybe_child({
-            let ring_reveal = ease_in_out_expo(local_phase(t, 0.55, 1.05));
+            let ring_reveal = local_phase(t, 0.55, 1.05).ease_in_out_expo().get();
             (ring_reveal > 0.0).then(|| {
                 [(720.0_f32, 1.0_f32), (860.0_f32, 0.55_f32)]
                     .into_iter()
@@ -71,11 +73,9 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
         // subliminal "graduated horizon" detail.
         .children((0..12).map(move |i| {
             let a = i as f32 / 12.0 * TAU - PI * 0.5;
-            let reveal = ease_in_out_expo(local_phase(
-                t,
-                0.7 + i as f32 * 0.012,
-                1.15 + i as f32 * 0.012,
-            ));
+            let reveal = local_phase(t, 0.7 + i as f32 * 0.012, 1.15 + i as f32 * 0.012)
+                .ease_in_out_expo()
+                .get();
             let major = i % 3 == 0;
             let r_base = 720.0;
             let length = if major { 16.0 } else { 8.0 };

--- a/tellur-live/examples/demo_scene/backdrop.rs
+++ b/tellur-live/examples/demo_scene/backdrop.rs
@@ -19,43 +19,32 @@ use super::common::*;
 // hash-equal across the steady-state span and be reused from the cache.
 pub const BACKDROP_REVEAL_START: f32 = 0.05;
 pub const BACKDROP_REVEAL_END: f32 = 1.332;
-const BACKDROP_REVEAL_WIDTH: f32 = BACKDROP_REVEAL_END - BACKDROP_REVEAL_START;
-
-// Sub-phase of an event spanning `[start, end]` (both measured from the reveal
-// window start) at virtual elapsed time `t`. Mirrors `hud::local_phase`.
-fn local_phase(t: f32, start: f32, end: f32) -> Phase {
-    Phase::saturating((t - start) / (end - start))
-}
 
 #[tellur_core::component(vector)]
 pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
     let p = palette;
-    // Virtual elapsed seconds inside the reveal window. Once `reveal` saturates
-    // this is constant, so every sub-`local_phase` below saturates too and the
-    // built layer is identical frame to frame.
-    let t = reveal.get() * BACKDROP_REVEAL_WIDTH;
-    // bg color is painted by the outer `.background(...)`. This layer carries
-    // only the faintest ambient texture so the foreground reads as the
-    // intended subject.
+    // Sub-events are addressed in window-local seconds via `reveal.sub_secs`,
+    // so once `reveal` saturates every sub-Phase saturates too and the built
+    // layer is identical frame to frame.
     VectorLayer::builder()
         .size(SCENE_SIZE)
         // Faint horizon lines sliding in from the left.
         .children((0..18).map(move |i| {
             let y = 64.0 + i as f32 * 56.0;
-            let reveal = local_phase(t, i as f32 * 0.008, 0.4 + i as f32 * 0.008)
-                .ease_in_out_expo()
-                .get();
+            let line_in = reveal
+                .sub_secs((i as f32 * 0.008)..(0.4 + i as f32 * 0.008))
+                .ease_in_out_expo(0.0, 1.0);
             Rect::builder()
-                .position(Vec2(lerp(-1920.0, 0.0, reveal), y))
+                .position(Vec2(lerp(-1920.0, 0.0, line_in), y))
                 .size(Vec2(1920.0, 1.0))
-                .color(p.paper.with_alpha(0.022 * reveal))
+                .color(p.paper.with_alpha(0.022 * line_in))
         }))
         // Two extremely dim "field boundary" rings — just inside the HUD frame
         // and just outside it. They suggest "this scene happens inside a
         // measured field" and pull the eye toward center without actually
         // darkening the corners.
         .maybe_child({
-            let ring_reveal = local_phase(t, 0.55, 1.05).ease_in_out_expo().get();
+            let ring_reveal = reveal.sub_secs(0.55..1.05).ease_in_out_expo(0.0, 1.0);
             (ring_reveal > 0.0).then(|| {
                 [(720.0_f32, 1.0_f32), (860.0_f32, 0.55_f32)]
                     .into_iter()
@@ -73,9 +62,9 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
         // subliminal "graduated horizon" detail.
         .children((0..12).map(move |i| {
             let a = i as f32 / 12.0 * TAU - PI * 0.5;
-            let reveal = local_phase(t, 0.7 + i as f32 * 0.012, 1.15 + i as f32 * 0.012)
-                .ease_in_out_expo()
-                .get();
+            let tick_in = reveal
+                .sub_secs((0.7 + i as f32 * 0.012)..(1.15 + i as f32 * 0.012))
+                .ease_in_out_expo(0.0, 1.0);
             let major = i % 3 == 0;
             let r_base = 720.0;
             let length = if major { 16.0 } else { 8.0 };
@@ -83,7 +72,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
             let mid = Vec2(CX + a.cos() * mid_r, CY + a.sin() * mid_r);
             FxRect::builder()
                 .center(mid)
-                .size(Vec2(if major { 2.0 } else { 1.4 }, length * reveal))
+                .size(Vec2(if major { 2.0 } else { 1.4 }, length * tick_in))
                 .angle(a + PI * 0.5)
                 .color(p.paper.with_alpha(if major { 0.16 } else { 0.1 }))
                 .opacity(1.0)

--- a/tellur-live/examples/demo_scene/backdrop.rs
+++ b/tellur-live/examples/demo_scene/backdrop.rs
@@ -23,7 +23,7 @@ pub const BACKDROP_REVEAL_END: f32 = 1.332;
 #[tellur_core::component(vector)]
 pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
     let p = palette;
-    // Sub-events are addressed in window-local seconds via `reveal.sub_secs`,
+    // Sub-events are addressed in window-local seconds via `sub_secs(reveal, ...)`,
     // so once `reveal` saturates every sub-Phase saturates too and the built
     // layer is identical frame to frame.
     VectorLayer::builder()
@@ -31,8 +31,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
         // Faint horizon lines sliding in from the left.
         .children((0..18).map(move |i| {
             let y = 64.0 + i as f32 * 56.0;
-            let line_in = reveal
-                .sub_secs((i as f32 * 0.008)..(0.4 + i as f32 * 0.008))
+            let line_in = sub_secs(reveal, (i as f32 * 0.008)..(0.4 + i as f32 * 0.008))
                 .ease_in_out_expo(0.0, 1.0);
             Rect::builder()
                 .position(Vec2(lerp(-1920.0, 0.0, line_in), y))
@@ -44,7 +43,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
         // measured field" and pull the eye toward center without actually
         // darkening the corners.
         .maybe_child({
-            let ring_reveal = reveal.sub_secs(0.55..1.05).ease_in_out_expo(0.0, 1.0);
+            let ring_reveal = sub_secs(reveal, 0.55..1.05).ease_in_out_expo(0.0, 1.0);
             (ring_reveal > 0.0).then(|| {
                 [(720.0_f32, 1.0_f32), (860.0_f32, 0.55_f32)]
                     .into_iter()
@@ -62,8 +61,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
         // subliminal "graduated horizon" detail.
         .children((0..12).map(move |i| {
             let a = i as f32 / 12.0 * TAU - PI * 0.5;
-            let tick_in = reveal
-                .sub_secs((0.7 + i as f32 * 0.012)..(1.15 + i as f32 * 0.012))
+            let tick_in = sub_secs(reveal, (0.7 + i as f32 * 0.012)..(1.15 + i as f32 * 0.012))
                 .ease_in_out_expo(0.0, 1.0);
             let major = i % 3 == 0;
             let r_base = 720.0;

--- a/tellur-live/examples/demo_scene/backdrop.rs
+++ b/tellur-live/examples/demo_scene/backdrop.rs
@@ -48,7 +48,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
             Rect::builder()
                 .position(Vec2(lerp(-1920.0, 0.0, reveal), y))
                 .size(Vec2(1920.0, 1.0))
-                .color(alpha(p.paper, 0.022 * reveal))
+                .color(p.paper.with_alpha(0.022 * reveal))
         }))
         // Two extremely dim "field boundary" rings — just inside the HUD frame
         // and just outside it. They suggest "this scene happens inside a
@@ -63,7 +63,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
                         Circle::builder()
                             .center(Vec2(CX, CY))
                             .radius(r * ring_reveal)
-                            .stroke(alpha(p.paper, 0.05 * a_mult))
+                            .stroke(p.paper.with_alpha(0.05 * a_mult))
                             .stroke_width(1.0)
                     })
                     .collect::<Fragment>()
@@ -85,7 +85,7 @@ pub fn Backdrop(reveal: Phase, palette: Palette) -> impl VectorComponent {
                 .center(mid)
                 .size(Vec2(if major { 2.0 } else { 1.4 }, length * reveal))
                 .angle(a + PI * 0.5)
-                .color(alpha(p.paper, if major { 0.16 } else { 0.1 }))
+                .color(p.paper.with_alpha(if major { 0.16 } else { 0.1 }))
                 .opacity(1.0)
                 .scale(Vec2(1.0, 1.0))
         }))

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -48,10 +48,6 @@ pub struct Palette {
     pub cyan: Color,
 }
 
-pub fn alpha(color: Color, value: f32) -> Color {
-    color.with_alpha(value)
-}
-
 pub fn lerp(from: f32, to: f32, p: f32) -> f32 {
     from + (to - from) * p
 }

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -24,7 +24,7 @@ use tellur_core::placement::VectorPlacement;
 use tellur_core::shapes;
 use tellur_core::text::{Text, TextSpan, Weight, MONOSPACE};
 use tellur_core::time::Time;
-use tellur_core::vector::{Group, Node, Paint, Stroke, VectorComponent, VectorGraphic};
+use tellur_core::vector::{Paint, Stroke, VectorComponent, VectorGraphic, VectorTransform};
 use tellur_core::Keyable;
 
 pub const DURATION: f32 = 7.6;
@@ -45,56 +45,6 @@ pub struct Palette {
     pub paper: Color,
     pub pink: Color,
     pub cyan: Color,
-}
-
-// Composable rotation + non-uniform scale + opacity wrapper.
-#[derive(Keyable)]
-pub struct Fx {
-    pub angle: f32,
-    pub sx: f32,
-    pub sy: f32,
-    pub opacity: f32,
-    pub child: Box<dyn VectorComponent>,
-}
-
-impl VectorComponent for Fx {
-    fn layout(&self, constraints: Constraints) -> Vec2 {
-        self.child.layout(constraints)
-    }
-
-    fn paint_bounds(&self, size: Vec2) -> Aabb {
-        Aabb {
-            origin: Vec2(-size.0 * 2.0, -size.1 * 2.0),
-            size: Vec2(size.0 * 5.0, size.1 * 5.0),
-        }
-    }
-
-    fn render(&self, size: Vec2) -> VectorGraphic {
-        let inner = self.child.render(size);
-        let sx = self.sx.max(0.0001);
-        let sy = self.sy.max(0.0001);
-        let cos = self.angle.cos();
-        let sin = self.angle.sin();
-        let a = cos * sx;
-        let b = sin * sx;
-        let c = -sin * sy;
-        let d = cos * sy;
-        let center = Vec2(size.0 * 0.5, size.1 * 0.5);
-        let tx = center.0 - (a * center.0 + c * center.1);
-        let ty = center.1 - (b * center.0 + d * center.1);
-
-        VectorGraphic {
-            view_box: Aabb {
-                origin: Vec2(-size.0 * 2.0, -size.1 * 2.0),
-                size: Vec2(size.0 * 5.0, size.1 * 5.0),
-            },
-            root: Node::Group(Group {
-                transform: Transform { a, b, c, d, tx, ty },
-                opacity: self.opacity.clamp(0.0, 1.0),
-                children: vec![inner.root],
-            }),
-        }
-    }
 }
 
 pub fn solid(color: Color) -> Paint {
@@ -157,6 +107,12 @@ where
     let r = rise(time.phase(rise_span.0, rise_span.1));
     let f = fall(time.phase(fall_span.0, fall_span.1));
     (r * (1.0 - f)).clamp(0.0, 1.0)
+}
+
+fn center_transform(size: Vec2, angle: f32, scale: Vec2) -> Transform {
+    let transform = Transform::scale(Vec2(scale.0.max(0.0001), scale.1.max(0.0001)))
+        .then(Transform::rotate(angle));
+    Transform::around_point(Vec2(size.0 * 0.5, size.1 * 0.5), transform)
 }
 
 // --- leaf components ---
@@ -294,20 +250,14 @@ pub fn FxRect(
         return Fragment::empty();
     }
     Fragment::single(
-        Fx {
-            angle,
-            sx: scale.0,
-            sy: scale.1,
-            opacity,
-            child: Box::new(
-                shapes::Rectangle::builder()
-                    .size(size)
-                    .fill(solid(color))
-                    .build(),
-            ),
-        }
-        .anchored(Anchor::CENTER)
-        .snap_to(center),
+        shapes::Rectangle::builder()
+            .size(size)
+            .fill(solid(color))
+            .build()
+            .transform(center_transform(size, angle, scale))
+            .opacity(opacity)
+            .anchored(Anchor::CENTER)
+            .snap_to(center),
     )
 }
 
@@ -331,22 +281,16 @@ pub fn FxOutlineRect(
         return Fragment::empty();
     }
     Fragment::single(
-        Fx {
-            angle,
-            sx: scale.0,
-            sy: scale.1,
-            opacity,
-            child: Box::new(
-                shapes::Rectangle::builder()
-                    .size(size)
-                    .stroke(Stroke {
-                        paint: solid(color),
-                        width,
-                    })
-                    .build(),
-            ),
-        }
-        .anchored(Anchor::CENTER)
-        .snap_to(center),
+        shapes::Rectangle::builder()
+            .size(size)
+            .stroke(Stroke {
+                paint: solid(color),
+                width,
+            })
+            .build()
+            .transform(center_transform(size, angle, scale))
+            .opacity(opacity)
+            .anchored(Anchor::CENTER)
+            .snap_to(center),
     )
 }

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -23,7 +23,7 @@ use tellur_core::placement::VectorPlacement;
 use tellur_core::shapes;
 use tellur_core::text::{Text, TextSpan, Weight, MONOSPACE};
 use tellur_core::time::Time;
-use tellur_core::vector::{Paint, Stroke, VectorComponent, VectorGraphic, VectorTransform};
+use tellur_core::vector::{Stroke, VectorComponent, VectorGraphic, VectorTransform};
 use tellur_core::Keyable;
 
 pub use tellur_core::easing::PhaseEasing;
@@ -46,10 +46,6 @@ pub struct Palette {
     pub paper: Color,
     pub pink: Color,
     pub cyan: Color,
-}
-
-pub fn solid(color: Color) -> Paint {
-    Paint::Solid(color)
 }
 
 pub fn alpha(color: Color, value: f32) -> Color {
@@ -99,7 +95,7 @@ pub fn Rect(position: Vec2, size: Vec2, color: Color) -> impl VectorComponent {
     Fragment::single(
         shapes::Rectangle::builder()
             .size(size)
-            .fill(solid(color))
+            .fill(color)
             .place_at(position),
     )
 }
@@ -136,9 +132,9 @@ impl VectorComponent for TrueCircle {
         let d = self.radius * 2.0;
         let inner = shapes::Circle::builder()
             .radius(self.radius)
-            .maybe_fill(self.fill.map(solid))
+            .maybe_fill(self.fill)
             .maybe_stroke(self.stroke_color.map(|c| Stroke {
-                paint: solid(c),
+                paint: c.into(),
                 width: self.stroke_width,
             }))
             .build();
@@ -197,7 +193,7 @@ pub fn Label(
             .font(MONOSPACE.clone())
             .size(size)
             .weight(weight)
-            .fill(solid(color))
+            .fill(color)
             .span(TextSpan::plain(text))
             .anchored(anchor)
             .snap_to(position),
@@ -224,7 +220,7 @@ pub fn FxRect(
     Fragment::single(
         shapes::Rectangle::builder()
             .size(size)
-            .fill(solid(color))
+            .fill(color)
             .build()
             .transform(center_transform(size, angle, scale))
             .opacity(opacity)
@@ -256,7 +252,7 @@ pub fn FxOutlineRect(
         shapes::Rectangle::builder()
             .size(size)
             .stroke(Stroke {
-                paint: solid(color),
+                paint: color.into(),
                 width,
             })
             .build()

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -16,7 +16,6 @@ use std::f32::consts::TAU;
 use tellur_core::builder::VectorBuilderPlacement;
 use tellur_core::color::Color;
 use tellur_core::component;
-use tellur_core::easing;
 use tellur_core::fragment::Fragment;
 use tellur_core::geometry::{Anchor, Constraints, Rect as Aabb, Transform, Vec2};
 use tellur_core::phase::Phase;
@@ -26,6 +25,8 @@ use tellur_core::text::{Text, TextSpan, Weight, MONOSPACE};
 use tellur_core::time::Time;
 use tellur_core::vector::{Paint, Stroke, VectorComponent, VectorGraphic, VectorTransform};
 use tellur_core::Keyable;
+
+pub use tellur_core::easing::PhaseEasing;
 
 pub const DURATION: f32 = 7.6;
 pub const SCENE_SIZE: Vec2 = Vec2(1920.0, 1080.0);
@@ -57,32 +58,6 @@ pub fn alpha(color: Color, value: f32) -> Color {
 
 pub fn lerp(from: f32, to: f32, p: f32) -> f32 {
     from + (to - from) * p
-}
-
-// --- easing functions ---
-
-pub fn ease_out_cubic(p: Phase) -> f32 {
-    easing::out_cubic(p).get()
-}
-
-pub fn ease_out_quint(p: Phase) -> f32 {
-    easing::out_quint(p).get()
-}
-
-pub fn ease_in_out_quint(p: Phase) -> f32 {
-    easing::in_out_quint(p).get()
-}
-
-pub fn ease_in_out_expo(p: Phase) -> f32 {
-    easing::in_out_expo(p).get()
-}
-
-pub fn ease_in_back(p: Phase) -> f32 {
-    easing::in_back(p)
-}
-
-pub fn ease_out_elastic(p: Phase) -> f32 {
-    easing::out_elastic(p)
 }
 
 pub fn wave<T: Time>(time: T, period: f32, offset: f32) -> f32 {

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -136,9 +136,13 @@ impl VectorComponent for TrueCircle {
     }
 
     fn paint_bounds(&self, size: Vec2) -> Aabb {
+        let outset = self
+            .stroke_color
+            .map(|_| (self.stroke_width * 0.5).max(0.0))
+            .unwrap_or(0.0);
         Aabb {
-            origin: Vec2::ZERO,
-            size,
+            origin: Vec2(-outset, -outset),
+            size: Vec2(size.0 + outset * 2.0, size.1 + outset * 2.0),
         }
     }
 

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -11,11 +11,12 @@
 //! path-qualified here: `shapes::Rectangle` / `shapes::Circle` and the
 //! `Aabb` alias for `geometry::Rect`.
 
-use std::f32::consts::{PI, TAU};
+use std::f32::consts::TAU;
 
 use tellur_core::builder::VectorBuilderPlacement;
 use tellur_core::color::Color;
 use tellur_core::component;
+use tellur_core::easing;
 use tellur_core::fragment::Fragment;
 use tellur_core::geometry::{Anchor, Constraints, Rect as Aabb, Transform, Vec2};
 use tellur_core::phase::Phase;
@@ -114,52 +115,27 @@ pub fn lerp(from: f32, to: f32, p: f32) -> f32 {
 // --- easing functions ---
 
 pub fn ease_out_cubic(p: Phase) -> f32 {
-    1.0 - (1.0 - p.get()).powi(3)
+    easing::out_cubic(p).get()
 }
 
 pub fn ease_out_quint(p: Phase) -> f32 {
-    1.0 - (1.0 - p.get()).powi(5)
+    easing::out_quint(p).get()
 }
 
 pub fn ease_in_out_quint(p: Phase) -> f32 {
-    let x = p.get();
-    if x < 0.5 {
-        16.0 * x.powi(5)
-    } else {
-        1.0 - (-2.0 * x + 2.0).powi(5) * 0.5
-    }
+    easing::in_out_quint(p).get()
 }
 
 pub fn ease_in_out_expo(p: Phase) -> f32 {
-    let x = p.get();
-    if x <= 0.0 {
-        0.0
-    } else if x >= 1.0 {
-        1.0
-    } else if x < 0.5 {
-        2.0_f32.powf(20.0 * x - 10.0) * 0.5
-    } else {
-        (2.0 - 2.0_f32.powf(-20.0 * x + 10.0)) * 0.5
-    }
+    easing::in_out_expo(p).get()
 }
 
 pub fn ease_in_back(p: Phase) -> f32 {
-    let x = p.get();
-    let c1 = 1.70158;
-    let c3 = c1 + 1.0;
-    c3 * x.powi(3) - c1 * x.powi(2)
+    easing::in_back(p)
 }
 
 pub fn ease_out_elastic(p: Phase) -> f32 {
-    let x = p.get();
-    if x <= 0.0 {
-        0.0
-    } else if x >= 1.0 {
-        1.0
-    } else {
-        let c4 = (2.0 * PI) / 3.0;
-        2.0_f32.powf(-10.0 * x) * ((x * 10.0 - 0.75) * c4).sin() + 1.0
-    }
+    easing::out_elastic(p)
 }
 
 pub fn wave<T: Time>(time: T, period: f32, offset: f32) -> f32 {

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -12,6 +12,7 @@
 //! `Aabb` alias for `geometry::Rect`.
 
 use std::f32::consts::TAU;
+use std::ops::Range;
 
 use tellur_core::builder::VectorBuilderPlacement;
 use tellur_core::color::Color;
@@ -54,6 +55,12 @@ pub fn lerp(from: f32, to: f32, p: f32) -> f32 {
 
 pub fn wave<T: Time>(time: T, period: f32, offset: f32) -> f32 {
     ((time.seconds() / period + offset) * TAU).sin()
+}
+
+pub fn sub_secs(phase: Phase, range: Range<f32>) -> Phase {
+    phase
+        .sub_secs(range)
+        .expect("demo sub-phase should fit inside its source window")
 }
 
 // Rise-fall hat envelope `4x(1-x)`: peaks at 1 when value is 0.5, returns to

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -52,10 +52,7 @@ pub fn solid(color: Color) -> Paint {
 }
 
 pub fn alpha(color: Color, value: f32) -> Color {
-    Color {
-        a: value.clamp(0.0, 1.0),
-        ..color
-    }
+    color.with_alpha(value)
 }
 
 pub fn lerp(from: f32, to: f32, p: f32) -> f32 {

--- a/tellur-live/examples/demo_scene/common.rs
+++ b/tellur-live/examples/demo_scene/common.rs
@@ -56,7 +56,18 @@ pub fn wave<T: Time>(time: T, period: f32, offset: f32) -> f32 {
     ((time.seconds() / period + offset) * TAU).sin()
 }
 
+// Rise-fall hat envelope `4x(1-x)`: peaks at 1 when value is 0.5, returns to
+// 0 at both endpoints. Used by the transition wipes (OVERTURE→FIELD,
+// FIELD→SCAN, SCAN→RESOLVE) so the sweep stripe is brightest mid-screen.
+// Expects `s ∈ [0, 1]`; callers feed an already-eased sweep factor.
+pub fn peak(s: f32) -> f32 {
+    4.0 * s * (1.0 - s)
+}
+
 // Time-bracketed envelope: rises with `rise`, holds, falls with `fall`.
+// Each callback applies an ease to its window's Phase, producing the
+// fade-in / fade-out factor in [0, 1]. The composed envelope is
+// `rise * (1 - fall)`, clamped to [0, 1].
 pub fn envelope<T: Time, R, F>(
     time: T,
     rise_span: (f32, f32),

--- a/tellur-live/examples/demo_scene/field.rs
+++ b/tellur-live/examples/demo_scene/field.rs
@@ -26,8 +26,8 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         time,
         (1.9, 2.25),
         (3.2, 3.55),
-        ease_in_out_expo,
-        ease_in_out_expo,
+        |p| p.ease_in_out_expo().get(),
+        |p| p.ease_in_out_expo().get(),
     );
 
     VectorLayer::builder()
@@ -41,8 +41,13 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 let dx = (c as f32 - (COLS as f32 - 1.0) * 0.5) * SPACING_X;
                 let dy = (r as f32 - (ROWS as f32 - 1.0) * 0.5) * SPACING_Y;
                 let stagger = c as f32 * 0.05 + r as f32 * 0.025;
-                let pop = ease_out_cubic(time.phase(1.95 + stagger, 2.45 + stagger));
-                let collapse = ease_in_back(time.phase(3.05 + stagger * 0.4, 3.5 + stagger * 0.4));
+                let pop = time
+                    .phase(1.95 + stagger, 2.45 + stagger)
+                    .ease_out_cubic()
+                    .get();
+                let collapse = time
+                    .phase(3.05 + stagger * 0.4, 3.5 + stagger * 0.4)
+                    .ease_in_back_between(0.0, 1.0);
                 let s = (pop * (1.0 - collapse)).clamp(0.0, 1.0);
 
                 let breathe = 1.0 + wave(time, 1.6, stagger) * 0.15;
@@ -63,7 +68,10 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     // the frame.
                     .maybe_child(
                         ((r == 0 || r == ROWS - 1) && (c == 0 || c == COLS - 1)).then(|| {
-                            let ring_in = ease_out_cubic(time.phase(2.4 + stagger, 2.9 + stagger));
+                            let ring_in = time
+                                .phase(2.4 + stagger, 2.9 + stagger)
+                                .ease_out_cubic()
+                                .get();
                             Circle::builder()
                                 .center(Vec2(cx, cy))
                                 .radius(26.0 * ring_in * s)
@@ -79,9 +87,11 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // just dots. Fade in with the grid itself.
         .children((0..ROWS).map(move |r| {
             let dy = (r as f32 - (ROWS as f32 - 1.0) * 0.5) * SPACING_Y;
-            let label_in =
-                ease_out_cubic(time.phase(2.1 + r as f32 * 0.04, 2.55 + r as f32 * 0.04));
-            let label_out = ease_in_back(time.phase(3.1, 3.5));
+            let label_in = time
+                .phase(2.1 + r as f32 * 0.04, 2.55 + r as f32 * 0.04)
+                .ease_out_cubic()
+                .get();
+            let label_out = time.phase(3.1, 3.5).ease_in_back_between(0.0, 1.0);
             let row_alpha = (label_in * (1.0 - label_out)).clamp(0.0, 1.0) * life * 0.55;
             Fragment::builder()
                 .maybe_child((row_alpha > 0.0).then(|| {
@@ -99,9 +109,11 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // the grid reads as a proper coordinate field.
         .children((0..COLS).map(move |c| {
             let dx = (c as f32 - (COLS as f32 - 1.0) * 0.5) * SPACING_X;
-            let label_in =
-                ease_out_cubic(time.phase(2.05 + c as f32 * 0.04, 2.5 + c as f32 * 0.04));
-            let label_out = ease_in_back(time.phase(3.1, 3.5));
+            let label_in = time
+                .phase(2.05 + c as f32 * 0.04, 2.5 + c as f32 * 0.04)
+                .ease_out_cubic()
+                .get();
+            let label_out = time.phase(3.1, 3.5).ease_in_back_between(0.0, 1.0);
             let col_alpha = (label_in * (1.0 - label_out)).clamp(0.0, 1.0) * life * 0.55;
             Fragment::builder()
                 .maybe_child((col_alpha > 0.0).then(|| {
@@ -122,7 +134,7 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // head + dimmer trailing wash, with a small "SCAN" data tag at the top
         // and a running-position readout at the bottom.
         .maybe_child({
-            let sweep = ease_in_out_expo(time.phase(2.35, 3.0));
+            let sweep = time.phase(2.35, 3.0).ease_in_out_expo().get();
             (sweep > 0.0 && sweep < 1.0)
                 .then(|| ScanLine::builder().palette(p).life(life).sweep(sweep))
         })

--- a/tellur-live/examples/demo_scene/field.rs
+++ b/tellur-live/examples/demo_scene/field.rs
@@ -26,8 +26,8 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         time,
         (1.9, 2.25),
         (3.2, 3.55),
-        |p| p.ease_in_out_expo().get(),
-        |p| p.ease_in_out_expo().get(),
+        |p| p.ease_in_out_expo(0.0, 1.0),
+        |p| p.ease_in_out_expo(0.0, 1.0),
     );
 
     VectorLayer::builder()
@@ -43,11 +43,12 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 let stagger = c as f32 * 0.05 + r as f32 * 0.025;
                 let pop = time
                     .phase(1.95 + stagger, 2.45 + stagger)
-                    .ease_out_cubic()
-                    .get();
+                    .ease_out_cubic(0.0, 1.0);
+                // `ease_in_back` overshoots — the compound visibility `s`
+                // is plain f32 arithmetic clamped at the leaf.
                 let collapse = time
                     .phase(3.05 + stagger * 0.4, 3.5 + stagger * 0.4)
-                    .ease_in_back_between(0.0, 1.0);
+                    .ease_in_back(0.0, 1.0);
                 let s = (pop * (1.0 - collapse)).clamp(0.0, 1.0);
 
                 let breathe = 1.0 + wave(time, 1.6, stagger) * 0.15;
@@ -70,8 +71,7 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         ((r == 0 || r == ROWS - 1) && (c == 0 || c == COLS - 1)).then(|| {
                             let ring_in = time
                                 .phase(2.4 + stagger, 2.9 + stagger)
-                                .ease_out_cubic()
-                                .get();
+                                .ease_out_cubic(0.0, 1.0);
                             Circle::builder()
                                 .center(Vec2(cx, cy))
                                 .radius(26.0 * ring_in * s)
@@ -89,9 +89,8 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             let dy = (r as f32 - (ROWS as f32 - 1.0) * 0.5) * SPACING_Y;
             let label_in = time
                 .phase(2.1 + r as f32 * 0.04, 2.55 + r as f32 * 0.04)
-                .ease_out_cubic()
-                .get();
-            let label_out = time.phase(3.1, 3.5).ease_in_back_between(0.0, 1.0);
+                .ease_out_cubic(0.0, 1.0);
+            let label_out = time.phase(3.1, 3.5).ease_in_back(0.0, 1.0);
             let row_alpha = (label_in * (1.0 - label_out)).clamp(0.0, 1.0) * life * 0.55;
             Fragment::builder()
                 .maybe_child((row_alpha > 0.0).then(|| {
@@ -111,9 +110,8 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             let dx = (c as f32 - (COLS as f32 - 1.0) * 0.5) * SPACING_X;
             let label_in = time
                 .phase(2.05 + c as f32 * 0.04, 2.5 + c as f32 * 0.04)
-                .ease_out_cubic()
-                .get();
-            let label_out = time.phase(3.1, 3.5).ease_in_back_between(0.0, 1.0);
+                .ease_out_cubic(0.0, 1.0);
+            let label_out = time.phase(3.1, 3.5).ease_in_back(0.0, 1.0);
             let col_alpha = (label_in * (1.0 - label_out)).clamp(0.0, 1.0) * life * 0.55;
             Fragment::builder()
                 .maybe_child((col_alpha > 0.0).then(|| {
@@ -134,7 +132,7 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // head + dimmer trailing wash, with a small "SCAN" data tag at the top
         // and a running-position readout at the bottom.
         .maybe_child({
-            let sweep = time.phase(2.35, 3.0).ease_in_out_expo().get();
+            let sweep = time.phase(2.35, 3.0).ease_in_out_expo(0.0, 1.0);
             (sweep > 0.0 && sweep < 1.0)
                 .then(|| ScanLine::builder().palette(p).life(life).sweep(sweep))
         })
@@ -148,7 +146,9 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
 fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
     let p = palette;
     let x = lerp(CX - 580.0, CX + 580.0, sweep);
-    let visibility = 4.0 * sweep * (1.0 - sweep);
+    // Hat-shaped visibility curve `4x(1-x)` peaks at 1 when sweep = 0.5 and
+    // is 0 at both ends.
+    let visibility = peak(sweep);
     let height = (ROWS as f32 + 0.3) * SPACING_Y * 0.5 * 2.0;
     let top_y = CY - height * 0.5;
     let bottom_y = top_y + height;
@@ -159,35 +159,36 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
     let inner_trail_w = 32.0;
     let pct = (sweep * 100.0) as i32;
     let pct_text = format!("{:03}%", pct);
+    let head_alpha = visibility * life;
 
     Fragment::builder()
         .child(
             Rect::builder()
                 .position(Vec2(x - trail_w, top_y))
                 .size(Vec2(trail_w, height))
-                .color(p.pink.with_alpha(visibility * life * 0.14)),
+                .color(p.pink.with_alpha(head_alpha * 0.14)),
         )
         // Inner brighter trail.
         .child(
             Rect::builder()
                 .position(Vec2(x - inner_trail_w, top_y))
                 .size(Vec2(inner_trail_w, height))
-                .color(p.pink.with_alpha(visibility * life * 0.22)),
+                .color(p.pink.with_alpha(head_alpha * 0.22)),
         )
         // The crisp leading line.
         .child(
             Rect::builder()
                 .position(Vec2(x - 2.0, top_y))
                 .size(Vec2(4.0, height))
-                .color(p.pink.with_alpha(visibility * life * 0.95)),
+                .color(p.pink.with_alpha(head_alpha * 0.95)),
         )
         // Bright head dot at the top of the sweep — like a phosphor pixel.
         .child(
             Circle::builder()
                 .center(Vec2(x, top_y))
                 .radius(7.0)
-                .fill(p.paper.with_alpha(visibility * life))
-                .stroke(p.pink.with_alpha(visibility * life))
+                .fill(p.paper.with_alpha(head_alpha))
+                .stroke(p.pink.with_alpha(head_alpha))
                 .stroke_width(2.0),
         )
         // Mirror head dot at the bottom for symmetry.
@@ -195,8 +196,8 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
             Circle::builder()
                 .center(Vec2(x, bottom_y))
                 .radius(7.0)
-                .fill(p.paper.with_alpha(visibility * life))
-                .stroke(p.pink.with_alpha(visibility * life))
+                .fill(p.paper.with_alpha(head_alpha))
+                .stroke(p.pink.with_alpha(head_alpha))
                 .stroke_width(2.0),
         )
         // Top tag.
@@ -206,7 +207,7 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
                 .anchor(Anchor::BOTTOM_LEFT)
                 .text("SCAN →")
                 .size(14.0)
-                .color(p.pink.with_alpha(visibility * life))
+                .color(p.pink.with_alpha(head_alpha))
                 .weight(Weight::BOLD),
         )
         // Bottom percentage readout — "treats this as data" cue.
@@ -216,7 +217,7 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
                 .anchor(Anchor::TOP_LEFT)
                 .text(pct_text)
                 .size(13.0)
-                .color(p.paper.with_alpha(visibility * life * 0.95))
+                .color(p.paper.with_alpha(head_alpha * 0.95))
                 .weight(Weight::BOLD),
         )
         .build()

--- a/tellur-live/examples/demo_scene/field.rs
+++ b/tellur-live/examples/demo_scene/field.rs
@@ -61,7 +61,7 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         Circle::builder()
                             .center(Vec2(cx, cy))
                             .radius(14.0 * breathe * s)
-                            .fill(alpha(color, life * 0.92)),
+                            .fill(color.with_alpha(life * 0.92)),
                     )
                     // The four corner dots get an accent outline ring — that
                     // small hierarchy cue costs nothing and pulls the eye to
@@ -75,7 +75,7 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             Circle::builder()
                                 .center(Vec2(cx, cy))
                                 .radius(26.0 * ring_in * s)
-                                .stroke(alpha(color, life * 0.55))
+                                .stroke(color.with_alpha(life * 0.55))
                                 .stroke_width(2.0)
                         }),
                     )
@@ -100,7 +100,7 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         .anchor(Anchor::CENTER_RIGHT)
                         .text(format!("R{:02}", r))
                         .size(12.0)
-                        .color(alpha(p.paper, row_alpha))
+                        .color(p.paper.with_alpha(row_alpha))
                         .weight(Weight::NORMAL)
                 }))
                 .build()
@@ -125,7 +125,7 @@ pub fn Field(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         .anchor(Anchor::BOTTOM_CENTER)
                         .text(format!("C{:02}", c))
                         .size(12.0)
-                        .color(alpha(p.paper, col_alpha))
+                        .color(p.paper.with_alpha(col_alpha))
                         .weight(Weight::NORMAL)
                 }))
                 .build()
@@ -165,29 +165,29 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
             Rect::builder()
                 .position(Vec2(x - trail_w, top_y))
                 .size(Vec2(trail_w, height))
-                .color(alpha(p.pink, visibility * life * 0.14)),
+                .color(p.pink.with_alpha(visibility * life * 0.14)),
         )
         // Inner brighter trail.
         .child(
             Rect::builder()
                 .position(Vec2(x - inner_trail_w, top_y))
                 .size(Vec2(inner_trail_w, height))
-                .color(alpha(p.pink, visibility * life * 0.22)),
+                .color(p.pink.with_alpha(visibility * life * 0.22)),
         )
         // The crisp leading line.
         .child(
             Rect::builder()
                 .position(Vec2(x - 2.0, top_y))
                 .size(Vec2(4.0, height))
-                .color(alpha(p.pink, visibility * life * 0.95)),
+                .color(p.pink.with_alpha(visibility * life * 0.95)),
         )
         // Bright head dot at the top of the sweep — like a phosphor pixel.
         .child(
             Circle::builder()
                 .center(Vec2(x, top_y))
                 .radius(7.0)
-                .fill(alpha(p.paper, visibility * life))
-                .stroke(alpha(p.pink, visibility * life))
+                .fill(p.paper.with_alpha(visibility * life))
+                .stroke(p.pink.with_alpha(visibility * life))
                 .stroke_width(2.0),
         )
         // Mirror head dot at the bottom for symmetry.
@@ -195,8 +195,8 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
             Circle::builder()
                 .center(Vec2(x, bottom_y))
                 .radius(7.0)
-                .fill(alpha(p.paper, visibility * life))
-                .stroke(alpha(p.pink, visibility * life))
+                .fill(p.paper.with_alpha(visibility * life))
+                .stroke(p.pink.with_alpha(visibility * life))
                 .stroke_width(2.0),
         )
         // Top tag.
@@ -206,7 +206,7 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
                 .anchor(Anchor::BOTTOM_LEFT)
                 .text("SCAN →")
                 .size(14.0)
-                .color(alpha(p.pink, visibility * life))
+                .color(p.pink.with_alpha(visibility * life))
                 .weight(Weight::BOLD),
         )
         // Bottom percentage readout — "treats this as data" cue.
@@ -216,7 +216,7 @@ fn ScanLine(palette: Palette, life: f32, sweep: f32) -> impl VectorComponent {
                 .anchor(Anchor::TOP_LEFT)
                 .text(pct_text)
                 .size(13.0)
-                .color(alpha(p.paper, visibility * life * 0.95))
+                .color(p.paper.with_alpha(visibility * life * 0.95))
                 .weight(Weight::BOLD),
         )
         .build()

--- a/tellur-live/examples/demo_scene/hud.rs
+++ b/tellur-live/examples/demo_scene/hud.rs
@@ -88,8 +88,10 @@ impl Hud {
         let intro_t = self.intro.get() * HUD_INTRO_WIDTH;
         let outro_t = self.outro.get() * HUD_OUTRO_WIDTH;
 
-        let alpha_in = ease_in_out_expo(local_phase(intro_t, 0.0, 0.4));
-        let alpha_out = ease_in_out_expo(local_phase(outro_t, 0.0, HUD_OUTRO_WIDTH));
+        let alpha_in = local_phase(intro_t, 0.0, 0.4).ease_in_out_expo().get();
+        let alpha_out = local_phase(outro_t, 0.0, HUD_OUTRO_WIDTH)
+            .ease_in_out_expo()
+            .get();
         let life = (alpha_in * (1.0 - alpha_out)).clamp(0.0, 1.0);
         if life <= 0.0 {
             return VectorLayer::builder().size(size).build();
@@ -100,7 +102,7 @@ impl Hud {
         let inset = 96.0_f32;
         let bracket_len = 92.0_f32;
 
-        let label_in = ease_in_out_expo(local_phase(intro_t, 0.4, 0.8));
+        let label_in = local_phase(intro_t, 0.4, 0.8).ease_in_out_expo().get();
         let label_alpha = 0.95 * life * label_in;
         let (idx_text, idx_color) = section_marker(self.section, p);
         let marker_x = SCENE_SIZE.0 - inset;
@@ -121,8 +123,9 @@ impl Hud {
                     .enumerate()
                     .map(move |(i, (ax, ay, dx, dy))| {
                         let stagger = i as f32 * 0.05;
-                        let pop =
-                            ease_out_cubic(local_phase(intro_t, 0.1 + stagger, 0.6 + stagger));
+                        let pop = local_phase(intro_t, 0.1 + stagger, 0.6 + stagger)
+                            .ease_out_cubic()
+                            .get();
                         let len = bracket_len * pop;
                         let color = alpha(p.paper, 0.55 * life);
                         let hx = if dx > 0.0 { ax } else { ax - len };
@@ -193,7 +196,9 @@ impl Hud {
             // Bottom edge tick ruler — every 4th tick is taller.
             .children((0..17).map(move |i| {
                 let stagger = i as f32 * 0.018;
-                let pop = ease_out_cubic(local_phase(intro_t, 0.3 + stagger, 0.8 + stagger));
+                let pop = local_phase(intro_t, 0.3 + stagger, 0.8 + stagger)
+                    .ease_out_cubic()
+                    .get();
                 let bar_left = inset + 24.0;
                 let bar_right = SCENE_SIZE.0 - inset - 24.0;
                 let tick_y_top = SCENE_SIZE.1 - inset + 28.0;
@@ -211,7 +216,9 @@ impl Hud {
             // instrument frame so the scaffold reads as a full HUD.
             .children((0..11).map(move |i| {
                 let stagger = i as f32 * 0.02;
-                let pop = ease_out_cubic(local_phase(intro_t, 0.55 + stagger, 1.0 + stagger));
+                let pop = local_phase(intro_t, 0.55 + stagger, 1.0 + stagger)
+                    .ease_out_cubic()
+                    .get();
                 let v_bar_top = inset + 60.0;
                 let v_bar_bottom = SCENE_SIZE.1 - inset - 60.0;
                 let frac = i as f32 / 10.0;

--- a/tellur-live/examples/demo_scene/hud.rs
+++ b/tellur-live/examples/demo_scene/hud.rs
@@ -3,7 +3,7 @@
 //!
 //! Implemented as a `VectorComponent` whose state is reduced to three small,
 //! stable values: a `Palette`, two `Phase`s, and a `section` discriminator.
-//! Once the intro phase saturates to 1.0 (after ~1.24s), and as long as
+//! Once the intro phase saturates to 1.0 (after ~1.35s), and as long as
 //! `section` hasn't ticked over, the struct hashes and compares equal across
 //! frames — so wrapping `Hud` in `.rasterize()` lets `CachingRenderContext`
 //! reuse the rasterized image for the full steady-state span instead of
@@ -23,7 +23,7 @@ use super::common::*;
 // the intro window expressed via `Phase::sub_secs`; everything saturates by
 // `INTRO_END` and the component becomes byte-identical between frames.
 pub const HUD_INTRO_START: f32 = 0.15;
-pub const HUD_INTRO_END: f32 = 1.24;
+pub const HUD_INTRO_END: f32 = 1.35;
 pub const HUD_OUTRO_START: f32 = 7.1;
 pub const HUD_OUTRO_END: f32 = 7.55;
 
@@ -76,7 +76,7 @@ impl Hud {
         // already interpolated into their target range (here `(0, 1)` for
         // alpha) via the uniform `ease_*(from, to)` shape.
         let intro = self.intro;
-        let alpha_in = intro.sub_secs(0.0..0.4).ease_in_out_expo(0.0, 1.0);
+        let alpha_in = sub_secs(intro, 0.0..0.4).ease_in_out_expo(0.0, 1.0);
         let alpha_remain = self.outro.ease_in_out_expo(1.0, 0.0);
         let life = alpha_in * alpha_remain;
         if life <= 0.0 {
@@ -88,7 +88,7 @@ impl Hud {
         let inset = 96.0_f32;
         let bracket_len = 92.0_f32;
 
-        let label_in = intro.sub_secs(0.4..0.8).ease_in_out_expo(0.0, 1.0);
+        let label_in = sub_secs(intro, 0.4..0.8).ease_in_out_expo(0.0, 1.0);
         let label_alpha = 0.95 * life * label_in;
         let (idx_text, idx_color) = section_marker(self.section, p);
         let marker_x = SCENE_SIZE.0 - inset;
@@ -109,8 +109,7 @@ impl Hud {
                     .enumerate()
                     .map(move |(i, (ax, ay, dx, dy))| {
                         let stagger = i as f32 * 0.05;
-                        let pop = intro
-                            .sub_secs((0.1 + stagger)..(0.6 + stagger))
+                        let pop = sub_secs(intro, (0.1 + stagger)..(0.6 + stagger))
                             .ease_out_cubic(0.0, 1.0);
                         let len = pop * bracket_len;
                         let color = p.paper.with_alpha(life * 0.55);
@@ -182,9 +181,8 @@ impl Hud {
             // Bottom edge tick ruler — every 4th tick is taller.
             .children((0..17).map(move |i| {
                 let stagger = i as f32 * 0.018;
-                let pop = intro
-                    .sub_secs((0.3 + stagger)..(0.8 + stagger))
-                    .ease_out_cubic(0.0, 1.0);
+                let pop =
+                    sub_secs(intro, (0.3 + stagger)..(0.8 + stagger)).ease_out_cubic(0.0, 1.0);
                 let bar_left = inset + 24.0;
                 let bar_right = SCENE_SIZE.0 - inset - 24.0;
                 let tick_y_top = SCENE_SIZE.1 - inset + 28.0;
@@ -202,9 +200,8 @@ impl Hud {
             // instrument frame so the scaffold reads as a full HUD.
             .children((0..11).map(move |i| {
                 let stagger = i as f32 * 0.02;
-                let pop = intro
-                    .sub_secs((0.55 + stagger)..(1.0 + stagger))
-                    .ease_out_cubic(0.0, 1.0);
+                let pop =
+                    sub_secs(intro, (0.55 + stagger)..(1.0 + stagger)).ease_out_cubic(0.0, 1.0);
                 let v_bar_top = inset + 60.0;
                 let v_bar_bottom = SCENE_SIZE.1 - inset - 60.0;
                 let frac = i as f32 / 10.0;

--- a/tellur-live/examples/demo_scene/hud.rs
+++ b/tellur-live/examples/demo_scene/hud.rs
@@ -20,14 +20,12 @@ use tellur_core::vector::{VectorComponent, VectorGraphic};
 use super::common::*;
 
 // HUD intro/outro time windows. All bracket/tick/label staggers fit inside
-// `INTRO`; everything saturates by `INTRO_END` and the component becomes
-// byte-identical between frames.
+// the intro window expressed via `Phase::sub_secs`; everything saturates by
+// `INTRO_END` and the component becomes byte-identical between frames.
 pub const HUD_INTRO_START: f32 = 0.15;
 pub const HUD_INTRO_END: f32 = 1.24;
 pub const HUD_OUTRO_START: f32 = 7.1;
 pub const HUD_OUTRO_END: f32 = 7.55;
-const HUD_INTRO_WIDTH: f32 = HUD_INTRO_END - HUD_INTRO_START;
-const HUD_OUTRO_WIDTH: f32 = HUD_OUTRO_END - HUD_OUTRO_START;
 
 fn section_marker(section: u8, p: Palette) -> (&'static str, Color) {
     match section {
@@ -48,13 +46,6 @@ pub fn section_index_at(t: f32) -> u8 {
     } else {
         3
     }
-}
-
-// Phase-local helper: returns the sub-phase reached at virtual time
-// `virtual_t` (measured from the intro/outro start) for an event spanning
-// `[start, end]` in that same virtual frame.
-fn local_phase(virtual_t: f32, start: f32, end: f32) -> Phase {
-    Phase::saturating((virtual_t - start) / (end - start))
 }
 
 #[derive(Clone, Copy, PartialEq, Hash)]
@@ -80,19 +71,14 @@ impl VectorComponent for Hud {
 
 impl Hud {
     fn layer(&self, size: Vec2) -> VectorLayer {
-        // `intro_t` / `outro_t` are virtual elapsed seconds inside the intro
-        // / outro window. Each sub-event below is expressed relative to that
-        // virtual frame — so when `intro = 1.0` (saturated), every sub-phase
-        // is also fully saturated, and the resulting `VectorLayer` is
-        // structurally identical to last frame's.
-        let intro_t = self.intro.get() * HUD_INTRO_WIDTH;
-        let outro_t = self.outro.get() * HUD_OUTRO_WIDTH;
-
-        let alpha_in = local_phase(intro_t, 0.0, 0.4).ease_in_out_expo().get();
-        let alpha_out = local_phase(outro_t, 0.0, HUD_OUTRO_WIDTH)
-            .ease_in_out_expo()
-            .get();
-        let life = (alpha_in * (1.0 - alpha_out)).clamp(0.0, 1.0);
+        // Each sub-event below carves a window-local seconds slice out of
+        // `intro` via `Phase::sub_secs`. The eased factors come out as f32
+        // already interpolated into their target range (here `(0, 1)` for
+        // alpha) via the uniform `ease_*(from, to)` shape.
+        let intro = self.intro;
+        let alpha_in = intro.sub_secs(0.0..0.4).ease_in_out_expo(0.0, 1.0);
+        let alpha_remain = self.outro.ease_in_out_expo(1.0, 0.0);
+        let life = alpha_in * alpha_remain;
         if life <= 0.0 {
             return VectorLayer::builder().size(size).build();
         }
@@ -102,7 +88,7 @@ impl Hud {
         let inset = 96.0_f32;
         let bracket_len = 92.0_f32;
 
-        let label_in = local_phase(intro_t, 0.4, 0.8).ease_in_out_expo().get();
+        let label_in = intro.sub_secs(0.4..0.8).ease_in_out_expo(0.0, 1.0);
         let label_alpha = 0.95 * life * label_in;
         let (idx_text, idx_color) = section_marker(self.section, p);
         let marker_x = SCENE_SIZE.0 - inset;
@@ -123,11 +109,11 @@ impl Hud {
                     .enumerate()
                     .map(move |(i, (ax, ay, dx, dy))| {
                         let stagger = i as f32 * 0.05;
-                        let pop = local_phase(intro_t, 0.1 + stagger, 0.6 + stagger)
-                            .ease_out_cubic()
-                            .get();
-                        let len = bracket_len * pop;
-                        let color = p.paper.with_alpha(0.55 * life);
+                        let pop = intro
+                            .sub_secs((0.1 + stagger)..(0.6 + stagger))
+                            .ease_out_cubic(0.0, 1.0);
+                        let len = pop * bracket_len;
+                        let color = p.paper.with_alpha(life * 0.55);
                         let hx = if dx > 0.0 { ax } else { ax - len };
                         let vy = if dy > 0.0 { ay } else { ay - len };
                         Fragment::builder()
@@ -196,9 +182,9 @@ impl Hud {
             // Bottom edge tick ruler — every 4th tick is taller.
             .children((0..17).map(move |i| {
                 let stagger = i as f32 * 0.018;
-                let pop = local_phase(intro_t, 0.3 + stagger, 0.8 + stagger)
-                    .ease_out_cubic()
-                    .get();
+                let pop = intro
+                    .sub_secs((0.3 + stagger)..(0.8 + stagger))
+                    .ease_out_cubic(0.0, 1.0);
                 let bar_left = inset + 24.0;
                 let bar_right = SCENE_SIZE.0 - inset - 24.0;
                 let tick_y_top = SCENE_SIZE.1 - inset + 28.0;
@@ -216,9 +202,9 @@ impl Hud {
             // instrument frame so the scaffold reads as a full HUD.
             .children((0..11).map(move |i| {
                 let stagger = i as f32 * 0.02;
-                let pop = local_phase(intro_t, 0.55 + stagger, 1.0 + stagger)
-                    .ease_out_cubic()
-                    .get();
+                let pop = intro
+                    .sub_secs((0.55 + stagger)..(1.0 + stagger))
+                    .ease_out_cubic(0.0, 1.0);
                 let v_bar_top = inset + 60.0;
                 let v_bar_bottom = SCENE_SIZE.1 - inset - 60.0;
                 let frac = i as f32 / 10.0;

--- a/tellur-live/examples/demo_scene/hud.rs
+++ b/tellur-live/examples/demo_scene/hud.rs
@@ -127,7 +127,7 @@ impl Hud {
                             .ease_out_cubic()
                             .get();
                         let len = bracket_len * pop;
-                        let color = alpha(p.paper, 0.55 * life);
+                        let color = p.paper.with_alpha(0.55 * life);
                         let hx = if dx > 0.0 { ax } else { ax - len };
                         let vy = if dy > 0.0 { ay } else { ay - len };
                         Fragment::builder()
@@ -153,7 +153,7 @@ impl Hud {
                     .anchor(Anchor::BOTTOM_LEFT)
                     .text("TELLUR")
                     .size(20.0)
-                    .color(alpha(p.paper, label_alpha))
+                    .color(p.paper.with_alpha(label_alpha))
                     .weight(Weight::BOLD),
             )
             .child(
@@ -162,7 +162,7 @@ impl Hud {
                     .anchor(Anchor::BOTTOM_LEFT)
                     .text("kinetic-motion · 7.6s")
                     .size(13.0)
-                    .color(alpha(p.paper, 0.5 * life * label_in))
+                    .color(p.paper.with_alpha(0.5 * life * label_in))
                     .weight(Weight::NORMAL),
             )
             // Top-right section marker + accent dot.
@@ -172,14 +172,14 @@ impl Hud {
                     .anchor(Anchor::BOTTOM_RIGHT)
                     .text(idx_text)
                     .size(14.0)
-                    .color(alpha(p.paper, 0.75 * life * label_in))
+                    .color(p.paper.with_alpha(0.75 * life * label_in))
                     .weight(Weight::NORMAL),
             )
             .child(
                 Circle::builder()
                     .center(Vec2(marker_x - 128.0, inset - 28.0))
                     .radius(4.5 * label_in)
-                    .fill(alpha(idx_color, life * label_in)),
+                    .fill(idx_color.with_alpha(life * label_in)),
             )
             // Static "OBS" badge below the section marker — reads as a "live
             // observation" tag without animating per frame (so it stays inside
@@ -190,7 +190,7 @@ impl Hud {
                     .anchor(Anchor::TOP_RIGHT)
                     .text("OBS · TELLUR-04")
                     .size(11.0)
-                    .color(alpha(p.paper, 0.4 * life * label_in))
+                    .color(p.paper.with_alpha(0.4 * life * label_in))
                     .weight(Weight::NORMAL),
             )
             // Bottom edge tick ruler — every 4th tick is taller.
@@ -206,7 +206,7 @@ impl Hud {
                 let x = lerp(bar_left, bar_right, frac);
                 let major = i % 4 == 0;
                 let height = if major { 18.0 } else { 8.0 };
-                let color = alpha(p.paper, if major { 0.55 } else { 0.35 } * life);
+                let color = p.paper.with_alpha(if major { 0.55 } else { 0.35 } * life);
                 Rect::builder()
                     .position(Vec2(x - 1.0, tick_y_top))
                     .size(Vec2(2.0, height * pop))
@@ -225,7 +225,7 @@ impl Hud {
                 let y = lerp(v_bar_top, v_bar_bottom, frac);
                 let major = i % 5 == 0;
                 let width = if major { 16.0 } else { 7.0 };
-                let color = alpha(p.paper, if major { 0.5 } else { 0.3 } * life);
+                let color = p.paper.with_alpha(if major { 0.5 } else { 0.3 } * life);
                 Fragment::builder()
                     // Left side ticks point inward.
                     .maybe_child((pop > 0.0).then(|| {
@@ -250,7 +250,7 @@ impl Hud {
                     .anchor(Anchor::TOP_LEFT)
                     .text("RUNTIME 7600MS · 60FPS")
                     .size(12.0)
-                    .color(alpha(p.paper, 0.45 * life * label_in))
+                    .color(p.paper.with_alpha(0.45 * life * label_in))
                     .weight(Weight::NORMAL),
             )
             .child(
@@ -259,7 +259,7 @@ impl Hud {
                     .anchor(Anchor::TOP_RIGHT)
                     .text("1920 × 1080 · RGBA")
                     .size(12.0)
-                    .color(alpha(p.paper, 0.45 * life * label_in))
+                    .color(p.paper.with_alpha(0.45 * life * label_in))
                     .weight(Weight::NORMAL),
             )
             .build()

--- a/tellur-live/examples/demo_scene/mod.rs
+++ b/tellur-live/examples/demo_scene/mod.rs
@@ -46,7 +46,7 @@ use tellur_core::timeline_component::{Arrangement, Clock, TimedBuilder, Timeline
 use tellur_core::timeline_container::Timeline;
 use tellur_renderer::{DropShadow, Rasterizable, RasterizableBuilder};
 
-use common::{alpha, Palette, DURATION, SCENE_SIZE};
+use common::{Palette, DURATION, SCENE_SIZE};
 use hud::{Hud, HUD_INTRO_END, HUD_INTRO_START, HUD_OUTRO_END, HUD_OUTRO_START};
 
 use backdrop::{Backdrop, BACKDROP_REVEAL_END, BACKDROP_REVEAL_START};
@@ -153,7 +153,7 @@ impl Scene {
                                 DropShadow::builder()
                                     // offset omitted → Vec2::ZERO (ambient halo)
                                     .blur(18.0)
-                                    .color(alpha(palette.paper, 0.26)),
+                                    .color(palette.paper.with_alpha(0.26)),
                             )
                             .effect(
                                 DropShadow::builder()

--- a/tellur-live/examples/demo_scene/overlay.rs
+++ b/tellur-live/examples/demo_scene/overlay.rs
@@ -52,16 +52,12 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
             // is exactly 0.5, so this round-trips the original `time` bit-for-
             // bit; sub-events are then expressed in window-local coordinates.
             let t = boot.get() * OVERLAY_BOOT_WIDTH;
-            let boot_in = ease_in_out_expo(local_phase(
-                t,
-                0.05 - OVERLAY_BOOT_START,
-                0.18 - OVERLAY_BOOT_START,
-            ));
-            let boot_out = ease_in_out_expo(local_phase(
-                t,
-                0.32 - OVERLAY_BOOT_START,
-                0.55 - OVERLAY_BOOT_START,
-            ));
+            let boot_in = local_phase(t, 0.05 - OVERLAY_BOOT_START, 0.18 - OVERLAY_BOOT_START)
+                .ease_in_out_expo()
+                .get();
+            let boot_out = local_phase(t, 0.32 - OVERLAY_BOOT_START, 0.55 - OVERLAY_BOOT_START)
+                .ease_in_out_expo()
+                .get();
             let boot_life = (boot_in * (1.0 - boot_out)).clamp(0.0, 1.0);
             (boot_life > 0.0).then(|| {
                 Fragment::builder()
@@ -98,16 +94,13 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
         // foreground shadow pass.
         .maybe_child({
             let t = flash.get() * OVERLAY_FLASH_WIDTH;
-            let flash = ease_out_quint(local_phase(
-                t,
-                4.9 - OVERLAY_FLASH_START,
-                5.05 - OVERLAY_FLASH_START,
-            )) * (1.0
-                - ease_in_out_expo(local_phase(
-                    t,
-                    5.05 - OVERLAY_FLASH_START,
-                    5.35 - OVERLAY_FLASH_START,
-                )));
+            let flash = local_phase(t, 4.9 - OVERLAY_FLASH_START, 5.05 - OVERLAY_FLASH_START)
+                .ease_out_quint()
+                .get()
+                * (1.0
+                    - local_phase(t, 5.05 - OVERLAY_FLASH_START, 5.35 - OVERLAY_FLASH_START)
+                        .ease_in_out_expo()
+                        .get());
             (flash > 0.0).then(|| {
                 Rect::builder()
                     .position(Vec2::ZERO)
@@ -118,7 +111,7 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
         // Exit fade — gentle quint ease into the bg color. The `fade` phase
         // already spans the whole window, so it drives the ease directly.
         .maybe_child({
-            let fade = ease_in_out_quint(fade);
+            let fade = fade.ease_in_out_quint().get();
             (fade > 0.0).then(|| {
                 Rect::builder()
                     .position(Vec2::ZERO)

--- a/tellur-live/examples/demo_scene/overlay.rs
+++ b/tellur-live/examples/demo_scene/overlay.rs
@@ -39,14 +39,18 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
         // finished assembling. Reads as a system startup flash.
         .maybe_child({
             // Sub-events are addressed in window-local seconds via
-            // `boot.sub_secs`, so the original absolute starts are shifted
+            // `sub_secs(boot, ...)`, so the original absolute starts are shifted
             // into the window's frame here.
-            let boot_in = boot
-                .sub_secs((0.05 - OVERLAY_BOOT_START)..(0.18 - OVERLAY_BOOT_START))
-                .ease_in_out_expo(0.0, 1.0);
-            let boot_out = boot
-                .sub_secs((0.32 - OVERLAY_BOOT_START)..(0.55 - OVERLAY_BOOT_START))
-                .ease_in_out_expo(1.0, 0.0);
+            let boot_in = sub_secs(
+                boot,
+                (0.05 - OVERLAY_BOOT_START)..(0.18 - OVERLAY_BOOT_START),
+            )
+            .ease_in_out_expo(0.0, 1.0);
+            let boot_out = sub_secs(
+                boot,
+                (0.32 - OVERLAY_BOOT_START)..(0.55 - OVERLAY_BOOT_START),
+            )
+            .ease_in_out_expo(1.0, 0.0);
             let boot_life = boot_in * boot_out;
             (boot_life > 0.0).then(|| {
                 Fragment::builder()
@@ -82,12 +86,16 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
         // unshadowed overlay so it doesn't smear into a grey haze through the
         // foreground shadow pass.
         .maybe_child({
-            let flash_in = flash
-                .sub_secs((4.9 - OVERLAY_FLASH_START)..(5.05 - OVERLAY_FLASH_START))
-                .ease_out_quint(0.0, 1.0);
-            let flash_out = flash
-                .sub_secs((5.05 - OVERLAY_FLASH_START)..(5.35 - OVERLAY_FLASH_START))
-                .ease_in_out_expo(1.0, 0.0);
+            let flash_in = sub_secs(
+                flash,
+                (4.9 - OVERLAY_FLASH_START)..(5.05 - OVERLAY_FLASH_START),
+            )
+            .ease_out_quint(0.0, 1.0);
+            let flash_out = sub_secs(
+                flash,
+                (5.05 - OVERLAY_FLASH_START)..(5.35 - OVERLAY_FLASH_START),
+            )
+            .ease_in_out_expo(1.0, 0.0);
             let flash = flash_in * flash_out;
             (flash > 0.0).then(|| {
                 Rect::builder()

--- a/tellur-live/examples/demo_scene/overlay.rs
+++ b/tellur-live/examples/demo_scene/overlay.rs
@@ -67,7 +67,7 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
                             .anchor(Anchor::BOTTOM_CENTER)
                             .text("TELLUR")
                             .size(42.0)
-                            .color(alpha(p.paper, boot_life * 0.95))
+                            .color(p.paper.with_alpha(boot_life * 0.95))
                             .weight(Weight::BOLD),
                     )
                     .child(
@@ -76,7 +76,7 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
                             .anchor(Anchor::TOP_CENTER)
                             .text("00:00:00.000 · INIT")
                             .size(13.0)
-                            .color(alpha(p.paper, boot_life * 0.7))
+                            .color(p.paper.with_alpha(boot_life * 0.7))
                             .weight(Weight::NORMAL),
                     )
                     // A tiny pink underline dash to the right of "INIT".
@@ -84,7 +84,7 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
                         Rect::builder()
                             .position(Vec2(CX + 88.0, CY + 18.0))
                             .size(Vec2(20.0 * boot_in, 2.0))
-                            .color(alpha(p.pink, boot_life)),
+                            .color(p.pink.with_alpha(boot_life)),
                     )
                     .build()
             })
@@ -105,7 +105,7 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
                 Rect::builder()
                     .position(Vec2::ZERO)
                     .size(SCENE_SIZE)
-                    .color(alpha(p.paper, flash * 0.22))
+                    .color(p.paper.with_alpha(flash * 0.22))
             })
         })
         // Exit fade — gentle quint ease into the bg color. The `fade` phase
@@ -116,7 +116,7 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
                 Rect::builder()
                     .position(Vec2::ZERO)
                     .size(SCENE_SIZE)
-                    .color(alpha(p.bg, fade))
+                    .color(p.bg.with_alpha(fade))
             })
         })
         .build()

--- a/tellur-live/examples/demo_scene/overlay.rs
+++ b/tellur-live/examples/demo_scene/overlay.rs
@@ -29,16 +29,6 @@ pub const OVERLAY_FLASH_END: f32 = 5.35;
 pub const OVERLAY_FADE_START: f32 = 7.25;
 // The fade runs to the end of the timeline, so its window end is `DURATION`.
 
-const OVERLAY_BOOT_WIDTH: f32 = OVERLAY_BOOT_END - OVERLAY_BOOT_START;
-const OVERLAY_FLASH_WIDTH: f32 = OVERLAY_FLASH_END - OVERLAY_FLASH_START;
-
-// Sub-phase of an event spanning `[start, end]` (both absolute, but shifted
-// into the window-local frame by the caller) at virtual elapsed time `t`.
-// Mirrors `hud::local_phase` / `backdrop::local_phase`.
-fn local_phase(virtual_t: f32, start: f32, end: f32) -> Phase {
-    Phase::saturating((virtual_t - start) / (end - start))
-}
-
 #[tellur_core::component(vector)]
 pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl VectorComponent {
     let p = palette;
@@ -48,17 +38,16 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
         // subtitle briefly appears at center then fades, before the HUD has
         // finished assembling. Reads as a system startup flash.
         .maybe_child({
-            // Virtual elapsed seconds inside the boot window. The window width
-            // is exactly 0.5, so this round-trips the original `time` bit-for-
-            // bit; sub-events are then expressed in window-local coordinates.
-            let t = boot.get() * OVERLAY_BOOT_WIDTH;
-            let boot_in = local_phase(t, 0.05 - OVERLAY_BOOT_START, 0.18 - OVERLAY_BOOT_START)
-                .ease_in_out_expo()
-                .get();
-            let boot_out = local_phase(t, 0.32 - OVERLAY_BOOT_START, 0.55 - OVERLAY_BOOT_START)
-                .ease_in_out_expo()
-                .get();
-            let boot_life = (boot_in * (1.0 - boot_out)).clamp(0.0, 1.0);
+            // Sub-events are addressed in window-local seconds via
+            // `boot.sub_secs`, so the original absolute starts are shifted
+            // into the window's frame here.
+            let boot_in = boot
+                .sub_secs((0.05 - OVERLAY_BOOT_START)..(0.18 - OVERLAY_BOOT_START))
+                .ease_in_out_expo(0.0, 1.0);
+            let boot_out = boot
+                .sub_secs((0.32 - OVERLAY_BOOT_START)..(0.55 - OVERLAY_BOOT_START))
+                .ease_in_out_expo(1.0, 0.0);
+            let boot_life = boot_in * boot_out;
             (boot_life > 0.0).then(|| {
                 Fragment::builder()
                     .child(
@@ -93,14 +82,13 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
         // unshadowed overlay so it doesn't smear into a grey haze through the
         // foreground shadow pass.
         .maybe_child({
-            let t = flash.get() * OVERLAY_FLASH_WIDTH;
-            let flash = local_phase(t, 4.9 - OVERLAY_FLASH_START, 5.05 - OVERLAY_FLASH_START)
-                .ease_out_quint()
-                .get()
-                * (1.0
-                    - local_phase(t, 5.05 - OVERLAY_FLASH_START, 5.35 - OVERLAY_FLASH_START)
-                        .ease_in_out_expo()
-                        .get());
+            let flash_in = flash
+                .sub_secs((4.9 - OVERLAY_FLASH_START)..(5.05 - OVERLAY_FLASH_START))
+                .ease_out_quint(0.0, 1.0);
+            let flash_out = flash
+                .sub_secs((5.05 - OVERLAY_FLASH_START)..(5.35 - OVERLAY_FLASH_START))
+                .ease_in_out_expo(1.0, 0.0);
+            let flash = flash_in * flash_out;
             (flash > 0.0).then(|| {
                 Rect::builder()
                     .position(Vec2::ZERO)
@@ -111,7 +99,7 @@ pub fn Overlay(boot: Phase, flash: Phase, fade: Phase, palette: Palette) -> impl
         // Exit fade — gentle quint ease into the bg color. The `fade` phase
         // already spans the whole window, so it drives the ease directly.
         .maybe_child({
-            let fade = fade.ease_in_out_quint().get();
+            let fade = fade.ease_in_out_quint(0.0, 1.0);
             (fade > 0.0).then(|| {
                 Rect::builder()
                     .position(Vec2::ZERO)

--- a/tellur-live/examples/demo_scene/overture.rs
+++ b/tellur-live/examples/demo_scene/overture.rs
@@ -33,7 +33,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
     // a center ring + gap dashes) plus four small corner dots, all painted
     // in the bg color so they read as "cut into the paper". They rotate
     // with the square via the same `spin`.
-    let mark_color = alpha(p.bg, hero_life * 0.55);
+    let mark_color = p.bg.with_alpha(hero_life * 0.55);
     let cross_arm = 38.0 * s_clamped;
     let arm_inner_gap = 8.0 * s_clamped;
     let arm_outer = cross_arm;
@@ -112,7 +112,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                                                 y_center - cap_h * 0.5,
                                             ))
                                             .size(Vec2(cap_w, cap_h * cap_pop))
-                                            .color(alpha(color, alpha_factor))
+                                            .color(color.with_alpha(alpha_factor))
                                     })
                                 })
                                 .into_iter()
@@ -135,7 +135,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 .center(Vec2(CX, CY))
                 .size(Vec2(420.0, 420.0))
                 .angle(-spin * 0.4)
-                .color(alpha(p.pink, hero_life * 0.82))
+                .color(p.pink.with_alpha(hero_life * 0.82))
                 .opacity(1.0)
                 .scale(Vec2(s_clamped, s_clamped))
                 .width(3.0),
@@ -220,7 +220,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     .center(mid)
                     .size(Vec2(1.5, length))
                     .angle(a + PI * 0.5)
-                    .color(alpha(p.paper, hero_life * 0.45))
+                    .color(p.paper.with_alpha(hero_life * 0.45))
                     .opacity(1.0)
                     .scale(Vec2(1.0, 1.0))
             });
@@ -255,7 +255,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     .anchor(anchor)
                     .text(format!("0{}", s + 1))
                     .size(10.0)
-                    .color(alpha(p.paper, label_alpha.clamp(0.0, 1.0)))
+                    .color(p.paper.with_alpha(label_alpha.clamp(0.0, 1.0)))
                     .weight(Weight::NORMAL)
             });
 
@@ -265,7 +265,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     Circle::builder()
                         .center(pos)
                         .radius(6.0 * hero_life)
-                        .fill(alpha(if s % 2 == 0 { p.pink } else { p.cyan }, hero_life)),
+                        .fill((if s % 2 == 0 { p.pink } else { p.cyan }).with_alpha(hero_life)),
                 )
                 .maybe_child(tag)
                 .build()
@@ -286,7 +286,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             Rect::builder()
                 .position(Vec2(0.0, y - 3.0))
                 .size(Vec2(SCENE_SIZE.0, 6.0))
-                .color(alpha(p.pink, visibility * 0.88))
+                .color(p.pink.with_alpha(visibility * 0.88))
         }))
         .build()
 }
@@ -304,19 +304,19 @@ fn LengthTag(palette: Palette, hero_life: f32, tag_in: f32) -> impl VectorCompon
             Rect::builder()
                 .position(Vec2(CX - half_span - 1.0, y - tick_h * 0.5))
                 .size(Vec2(2.0, tick_h))
-                .color(alpha(p.paper, hero_life * tag_in * 0.65)),
+                .color(p.paper.with_alpha(hero_life * tag_in * 0.65)),
         )
         .child(
             Rect::builder()
                 .position(Vec2(CX + half_span - 1.0, y - tick_h * 0.5))
                 .size(Vec2(2.0, tick_h))
-                .color(alpha(p.paper, hero_life * tag_in * 0.65)),
+                .color(p.paper.with_alpha(hero_life * tag_in * 0.65)),
         )
         .child(
             Rect::builder()
                 .position(Vec2(CX - half_span * tag_in, y - 1.0))
                 .size(Vec2(half_span * 2.0 * tag_in, 2.0))
-                .color(alpha(p.paper, hero_life * tag_in * 0.55)),
+                .color(p.paper.with_alpha(hero_life * tag_in * 0.55)),
         )
         .child(
             Label::builder()
@@ -324,7 +324,7 @@ fn LengthTag(palette: Palette, hero_life: f32, tag_in: f32) -> impl VectorCompon
                 .anchor(Anchor::TOP_CENTER)
                 .text("L = 280 PX")
                 .size(12.0)
-                .color(alpha(p.paper, hero_life * tag_in * 0.75))
+                .color(p.paper.with_alpha(hero_life * tag_in * 0.75))
                 .weight(Weight::NORMAL),
         )
         .build()

--- a/tellur-live/examples/demo_scene/overture.rs
+++ b/tellur-live/examples/demo_scene/overture.rs
@@ -22,8 +22,8 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
 
     // Hero square: controlled ease_out_cubic pop (no rubbery elastic),
     // a slow drift-spin, and an ease_in_back dismissal.
-    let hero_in = ease_out_cubic(time.phase(0.55, 1.2));
-    let hero_out = ease_in_back(time.phase(1.7, 2.15));
+    let hero_in = time.phase(0.55, 1.2).ease_out_cubic().get();
+    let hero_out = time.phase(1.7, 2.15).ease_in_back_between(0.0, 1.0);
     let hero_life = (hero_in * (1.0 - hero_out)).clamp(0.0, 1.0);
     let spin = time.seconds() * 0.35 + PI * 0.25;
     let scale = (0.55 + hero_in * 0.45) * (1.0 - hero_out);
@@ -45,10 +45,10 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
     let cs = spin.cos();
     let sn = spin.sin();
 
-    let ray_in = ease_out_cubic(time.phase(0.85, 1.4)) * (1.0 - hero_out);
-    let tag_in =
-        ease_in_out_expo(time.phase(0.95, 1.35)) * (1.0 - ease_in_out_expo(time.phase(1.55, 2.0)));
-    let sweep = ease_in_out_expo(time.phase(1.45, 2.0));
+    let ray_in = time.phase(0.85, 1.4).ease_out_cubic().get() * (1.0 - hero_out);
+    let tag_in = time.phase(0.95, 1.35).ease_in_out_expo().get()
+        * (1.0 - time.phase(1.55, 2.0).ease_in_out_expo().get());
+    let sweep = time.phase(1.45, 2.0).ease_in_out_expo().get();
 
     // Two clamp bars — one cyan above, one pink below — that frame the
     // central hero. Snappy ease_in_out_expo in, ease_in_back out (lifts off
@@ -65,9 +65,13 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 .enumerate()
                 .map(move |(i, (dy, side, color))| {
                     let stagger = i as f32 * 0.06;
-                    let enter = ease_in_out_expo(time.phase(0.32 + stagger, 0.92 + stagger));
-                    let leave =
-                        ease_in_back(time.phase(1.55 + stagger * 0.5, 2.05 + stagger * 0.5));
+                    let enter = time
+                        .phase(0.32 + stagger, 0.92 + stagger)
+                        .ease_in_out_expo()
+                        .get();
+                    let leave = time
+                        .phase(1.55 + stagger * 0.5, 2.05 + stagger * 0.5)
+                        .ease_in_back_between(0.0, 1.0);
                     let bar_x = lerp(side * 2400.0 + CX, CX, enter);
                     let exit_dy = leave * if side > 0.0 { 320.0 } else { -320.0 };
                     let alpha_factor = (enter * (1.0 - leave)).clamp(0.0, 1.0) * 0.92;
@@ -76,9 +80,14 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     // End-cap mini brackets at each bar end — small perpendicular
                     // ticks that turn the bar into a clear measurement span. Same color
                     // as the bar; staggered tiny so they "arrive" with the bar.
-                    let cap_pop = ease_out_cubic(time.phase(0.65 + stagger, 1.05 + stagger))
+                    let cap_pop = time
+                        .phase(0.65 + stagger, 1.05 + stagger)
+                        .ease_out_cubic()
+                        .get()
                         * (1.0
-                            - ease_in_back(time.phase(1.55 + stagger * 0.5, 1.95 + stagger * 0.5)));
+                            - time
+                                .phase(1.55 + stagger * 0.5, 1.95 + stagger * 0.5)
+                                .ease_in_back_between(0.0, 1.0));
 
                     Fragment::builder()
                         .child(
@@ -218,9 +227,14 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
 
             // Small index tag next to each outside dot. The tag follows the
             // dot's rotated position so it always reads on the outside.
-            let label_in = ease_out_cubic(time.phase(1.0 + s as f32 * 0.04, 1.4 + s as f32 * 0.04));
-            let label_alpha =
-                hero_life * label_in * (1.0 - ease_in_back(time.phase(1.7, 2.05))) * 0.6;
+            let label_in = time
+                .phase(1.0 + s as f32 * 0.04, 1.4 + s as f32 * 0.04)
+                .ease_out_cubic()
+                .get();
+            let label_alpha = hero_life
+                * label_in
+                * (1.0 - time.phase(1.7, 2.05).ease_in_back_between(0.0, 1.0))
+                * 0.6;
             let tag = (label_alpha > 0.0).then(|| {
                 let label_r = r + 18.0;
                 let lpos = Vec2(CX + a.cos() * label_r, CY + a.sin() * label_r);

--- a/tellur-live/examples/demo_scene/overture.rs
+++ b/tellur-live/examples/demo_scene/overture.rs
@@ -22,11 +22,11 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
 
     // Hero square: controlled ease_out_cubic pop (no rubbery elastic),
     // a slow drift-spin, and an ease_in_back dismissal.
-    let hero_in = time.phase(0.55, 1.2).ease_out_cubic().get();
-    let hero_out = time.phase(1.7, 2.15).ease_in_back_between(0.0, 1.0);
-    let hero_life = (hero_in * (1.0 - hero_out)).clamp(0.0, 1.0);
+    let hero_in = time.phase(0.55, 1.2).ease_out_cubic(0.0, 1.0);
+    let hero_remain = time.phase(1.7, 2.15).ease_in_back(1.0, 0.0);
+    let hero_life = (hero_in * hero_remain).clamp(0.0, 1.0);
     let spin = time.seconds() * 0.35 + PI * 0.25;
-    let scale = (0.55 + hero_in * 0.45) * (1.0 - hero_out);
+    let scale = lerp(0.55, 1.0, hero_in) * hero_remain;
     let s_clamped = scale.max(0.001);
 
     // Registration markings inside the hero square — a reticle (cross arms +
@@ -45,10 +45,10 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
     let cs = spin.cos();
     let sn = spin.sin();
 
-    let ray_in = time.phase(0.85, 1.4).ease_out_cubic().get() * (1.0 - hero_out);
-    let tag_in = time.phase(0.95, 1.35).ease_in_out_expo().get()
-        * (1.0 - time.phase(1.55, 2.0).ease_in_out_expo().get());
-    let sweep = time.phase(1.45, 2.0).ease_in_out_expo().get();
+    let ray_in = time.phase(0.85, 1.4).ease_out_cubic(0.0, 1.0) * hero_remain;
+    let tag_in = time.phase(0.95, 1.35).ease_in_out_expo(0.0, 1.0)
+        * time.phase(1.55, 2.0).ease_in_out_expo(1.0, 0.0);
+    let sweep = time.phase(1.45, 2.0).ease_in_out_expo(0.0, 1.0);
 
     // Two clamp bars — one cyan above, one pink below — that frame the
     // central hero. Snappy ease_in_out_expo in, ease_in_back out (lifts off
@@ -67,11 +67,10 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     let stagger = i as f32 * 0.06;
                     let enter = time
                         .phase(0.32 + stagger, 0.92 + stagger)
-                        .ease_in_out_expo()
-                        .get();
+                        .ease_in_out_expo(0.0, 1.0);
                     let leave = time
                         .phase(1.55 + stagger * 0.5, 2.05 + stagger * 0.5)
-                        .ease_in_back_between(0.0, 1.0);
+                        .ease_in_back(0.0, 1.0);
                     let bar_x = lerp(side * 2400.0 + CX, CX, enter);
                     let exit_dy = leave * if side > 0.0 { 320.0 } else { -320.0 };
                     let alpha_factor = (enter * (1.0 - leave)).clamp(0.0, 1.0) * 0.92;
@@ -82,12 +81,10 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     // as the bar; staggered tiny so they "arrive" with the bar.
                     let cap_pop = time
                         .phase(0.65 + stagger, 1.05 + stagger)
-                        .ease_out_cubic()
-                        .get()
-                        * (1.0
-                            - time
-                                .phase(1.55 + stagger * 0.5, 1.95 + stagger * 0.5)
-                                .ease_in_back_between(0.0, 1.0));
+                        .ease_out_cubic(0.0, 1.0)
+                        * time
+                            .phase(1.55 + stagger * 0.5, 1.95 + stagger * 0.5)
+                            .ease_in_back(1.0, 0.0);
 
                     Fragment::builder()
                         .child(
@@ -229,12 +226,9 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             // dot's rotated position so it always reads on the outside.
             let label_in = time
                 .phase(1.0 + s as f32 * 0.04, 1.4 + s as f32 * 0.04)
-                .ease_out_cubic()
-                .get();
-            let label_alpha = hero_life
-                * label_in
-                * (1.0 - time.phase(1.7, 2.05).ease_in_back_between(0.0, 1.0))
-                * 0.6;
+                .ease_out_cubic(0.0, 1.0);
+            let label_alpha =
+                hero_life * label_in * time.phase(1.7, 2.05).ease_in_back(1.0, 0.0) * 0.6;
             let tag = (label_alpha > 0.0).then(|| {
                 let label_r = r + 18.0;
                 let lpos = Vec2(CX + a.cos() * label_r, CY + a.sin() * label_r);
@@ -282,7 +276,7 @@ pub fn Overture(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // a transition wipe that hands the frame off to FIELD.
         .maybe_child((sweep > 0.0 && sweep < 1.0).then(|| {
             let y = lerp(-80.0, SCENE_SIZE.1 + 80.0, sweep);
-            let visibility = 4.0 * sweep * (1.0 - sweep);
+            let visibility = peak(sweep);
             Rect::builder()
                 .position(Vec2(0.0, y - 3.0))
                 .size(Vec2(SCENE_SIZE.0, 6.0))

--- a/tellur-live/examples/demo_scene/resolve.rs
+++ b/tellur-live/examples/demo_scene/resolve.rs
@@ -19,18 +19,18 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         return VectorLayer::builder().size(SCENE_SIZE).build();
     }
 
-    let life = ease_in_out_expo(time.phase(5.05, 5.5));
+    let life = time.phase(5.05, 5.5).ease_in_out_expo().get();
 
     // Phase 1: contracting hero ring (same R=300 that SCAN ended on).
-    let contract = ease_in_out_expo(time.phase(5.2, 6.3));
+    let contract = time.phase(5.2, 6.3).ease_in_out_expo().get();
     let ring_r = lerp(300.0, 22.0, contract);
     let ring_alpha = (1.0 - contract * 0.55) * life;
 
     // Phase 2 inputs. `cluster_spin` is shared by the satellites and the
     // surviving central mark's rays / field hash marks.
-    let sats_in = ease_in_out_expo(time.phase(5.25, 6.35));
+    let sats_in = time.phase(5.25, 6.35).ease_in_out_expo().get();
     let cluster_spin =
-        ease_out_cubic(time.phase(6.35, 7.0)) * (time.seconds() - 6.35).max(0.0) * 0.18;
+        time.phase(6.35, 7.0).ease_out_cubic().get() * (time.seconds() - 6.35).max(0.0) * 0.18;
 
     VectorLayer::builder()
         .size(SCENE_SIZE)
@@ -68,8 +68,11 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             [(5.55_f32, 230.0_f32), (5.85, 160.0), (6.12, 95.0)]
                 .into_iter()
                 .filter_map(move |(start, r)| {
-                    let ghost_in = ease_out_cubic(time.phase(start, start + 0.08));
-                    let ghost_out = ease_in_out_expo(time.phase(start + 0.25, start + 1.3));
+                    let ghost_in = time.phase(start, start + 0.08).ease_out_cubic().get();
+                    let ghost_out = time
+                        .phase(start + 0.25, start + 1.3)
+                        .ease_in_out_expo()
+                        .get();
                     let ghost = (ghost_in * (1.0 - ghost_out)).clamp(0.0, 1.0);
                     (ghost > 0.0).then(|| {
                         Circle::builder()
@@ -84,8 +87,8 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Phase 4: the singularity flash — a brief paper bloom at the moment
         // everything collapses to the center.
         .maybe_child({
-            let sing = ease_out_quint(time.phase(6.2, 6.32))
-                * (1.0 - ease_in_out_expo(time.phase(6.32, 6.62)));
+            let sing = time.phase(6.2, 6.32).ease_out_quint().get()
+                * (1.0 - time.phase(6.32, 6.62).ease_in_out_expo().get());
             (sing > 0.0).then(|| {
                 Circle::builder()
                     .center(Vec2(CX, CY))
@@ -96,8 +99,8 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // 16 short radial shards — emit-then-fade exactly at the singularity.
         // Length peaks then collapses inward as they vanish.
         .maybe_child({
-            let shard_kick = ease_out_quint(time.phase(6.22, 6.36));
-            let shard_fade = ease_in_out_expo(time.phase(6.36, 6.6));
+            let shard_kick = time.phase(6.22, 6.36).ease_out_quint().get();
+            let shard_fade = time.phase(6.36, 6.6).ease_in_out_expo().get();
             let shard_life = (shard_kick * (1.0 - shard_fade)).clamp(0.0, 1.0);
             (shard_life > 0.0).then(|| {
                 (0..16)
@@ -123,10 +126,13 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // ring kicks out from center with an elastic-eased launch, then a
         // quint-eased growth carries it past the edge.
         .maybe_child({
-            let pulse_kick = ease_out_elastic(time.phase(6.22, 6.55)).max(0.0);
-            let pulse_grow = ease_out_quint(time.phase(6.3, 7.15));
-            let pulse_fade = 1.0 - ease_in_out_expo(time.phase(6.7, 7.25));
-            let pulse_r = pulse_kick * 600.0 * (0.05 + pulse_grow * 0.95);
+            let pulse_kick = time
+                .phase(6.22, 6.55)
+                .ease_out_elastic_between(0.0, 600.0)
+                .max(0.0);
+            let pulse_grow = time.phase(6.3, 7.15).ease_out_quint().get();
+            let pulse_fade = 1.0 - time.phase(6.7, 7.25).ease_in_out_expo().get();
+            let pulse_r = pulse_kick * (0.05 + pulse_grow * 0.95);
             (pulse_r > 12.0 && pulse_fade > 0.0).then(|| {
                 Circle::builder()
                     .center(Vec2(CX, CY))
@@ -137,8 +143,8 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         })
         // Secondary, smaller, delayed ripple in pink for rhythm.
         .maybe_child({
-            let pulse2_grow = ease_out_quint(time.phase(6.6, 7.3));
-            let pulse2_fade = 1.0 - ease_in_out_expo(time.phase(6.95, 7.4));
+            let pulse2_grow = time.phase(6.6, 7.3).ease_out_quint().get();
+            let pulse2_fade = 1.0 - time.phase(6.95, 7.4).ease_in_out_expo().get();
             let pulse2_r = pulse2_grow * 420.0;
             (pulse2_r > 12.0 && pulse2_fade > 0.0).then(|| {
                 Circle::builder()
@@ -152,7 +158,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // mark. Hub + pink hairline collar + 4 axis rays + a dim outer field
         // ring with hash marks + an orbiting scan dot.
         .maybe_child({
-            let comp_in = ease_out_cubic(time.phase(6.27, 6.7));
+            let comp_in = time.phase(6.27, 6.7).ease_out_cubic().get();
             (comp_in > 0.0).then(|| {
                 CentralMark::builder()
                     .time(time)
@@ -165,7 +171,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Four alignment ticks at the cardinals just outside the field ring,
         // making the central mark a fully four-way-symmetric axis indicator.
         .maybe_child({
-            let tick_in = ease_out_cubic(time.phase(6.85, 7.15));
+            let tick_in = time.phase(6.85, 7.15).ease_out_cubic().get();
             (tick_in > 0.0).then(|| {
                 let tick_alpha = alpha(p.paper, life * 0.5);
                 let arm_len = 22.0 * tick_in;
@@ -218,8 +224,8 @@ fn CentralMark(
 ) -> impl VectorComponent {
     let p = palette;
     let breath = 1.0 + wave(time, 1.4, 0.0) * 0.06;
-    let ray_in = ease_out_cubic(time.phase(6.5, 6.95));
-    let field_in = ease_out_cubic(time.phase(6.65, 7.1));
+    let ray_in = time.phase(6.5, 6.95).ease_out_cubic().get();
+    let field_in = time.phase(6.65, 7.1).ease_out_cubic().get();
 
     Fragment::builder()
         // (a) the hub: a filled cyan core.
@@ -260,7 +266,7 @@ fn CentralMark(
         // (d) outer "field" ring with 12 micro-hash-marks + (e) orbiting dot.
         .maybe_child((field_in > 0.0).then(|| {
             let field_r = 78.0 + (1.0 - breath) * 4.0;
-            let orbit_in = ease_out_cubic(time.phase(6.8, 7.2));
+            let orbit_in = time.phase(6.8, 7.2).ease_out_cubic().get();
             Fragment::builder()
                 .child(
                     Circle::builder()

--- a/tellur-live/examples/demo_scene/resolve.rs
+++ b/tellur-live/examples/demo_scene/resolve.rs
@@ -19,18 +19,21 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         return VectorLayer::builder().size(SCENE_SIZE).build();
     }
 
-    let life = time.phase(5.05, 5.5).ease_in_out_expo().get();
+    let life = time.phase(5.05, 5.5).ease_in_out_expo(0.0, 1.0);
 
     // Phase 1: contracting hero ring (same R=300 that SCAN ended on).
-    let contract = time.phase(5.2, 6.3).ease_in_out_expo().get();
+    let contract = time.phase(5.2, 6.3).ease_in_out_expo(0.0, 1.0);
     let ring_r = lerp(300.0, 22.0, contract);
-    let ring_alpha = (1.0 - contract * 0.55) * life;
+    // Fade ring from full to 45% as it contracts.
+    let ring_alpha = lerp(1.0, 0.45, contract) * life;
 
     // Phase 2 inputs. `cluster_spin` is shared by the satellites and the
-    // surviving central mark's rays / field hash marks.
-    let sats_in = time.phase(5.25, 6.35).ease_in_out_expo().get();
-    let cluster_spin =
-        time.phase(6.35, 7.0).ease_out_cubic().get() * (time.seconds() - 6.35).max(0.0) * 0.18;
+    // surviving central mark's rays / field hash marks. The cluster `Window`
+    // ties the ease-in envelope (`phase()`) and the unbounded post-anchor
+    // angular sweep (`elapsed()`) to one declared `[6.35, 7.0)` interval.
+    let sats_in = time.phase(5.25, 6.35).ease_in_out_expo(0.0, 1.0);
+    let cluster = time.window(6.35, 7.0);
+    let cluster_spin = cluster.phase().ease_out_cubic(0.0, 1.0) * cluster.elapsed() * 0.18;
 
     VectorLayer::builder()
         .size(SCENE_SIZE)
@@ -55,7 +58,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             let pos = Vec2(CX + a.cos() * target_r, CY + a.sin() * target_r);
             let color = if cardinal { p.pink } else { p.cyan };
             let size = lerp(12.0, if cardinal { 6.0 } else { 4.5 }, sats_in);
-            let sat_alpha = (1.0 - sats_in * 0.4) * life;
+            let sat_alpha = lerp(1.0, 0.6, sats_in) * life;
             Circle::builder()
                 .center(pos)
                 .radius(size)
@@ -68,12 +71,11 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             [(5.55_f32, 230.0_f32), (5.85, 160.0), (6.12, 95.0)]
                 .into_iter()
                 .filter_map(move |(start, r)| {
-                    let ghost_in = time.phase(start, start + 0.08).ease_out_cubic().get();
-                    let ghost_out = time
+                    let ghost_in = time.phase(start, start + 0.08).ease_out_cubic(0.0, 1.0);
+                    let ghost_remain = time
                         .phase(start + 0.25, start + 1.3)
-                        .ease_in_out_expo()
-                        .get();
-                    let ghost = (ghost_in * (1.0 - ghost_out)).clamp(0.0, 1.0);
+                        .ease_in_out_expo(1.0, 0.0);
+                    let ghost = (ghost_in * ghost_remain).clamp(0.0, 1.0);
                     (ghost > 0.0).then(|| {
                         Circle::builder()
                             .center(Vec2(CX, CY))
@@ -87,8 +89,8 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Phase 4: the singularity flash — a brief paper bloom at the moment
         // everything collapses to the center.
         .maybe_child({
-            let sing = time.phase(6.2, 6.32).ease_out_quint().get()
-                * (1.0 - time.phase(6.32, 6.62).ease_in_out_expo().get());
+            let sing = time.phase(6.2, 6.32).ease_out_quint(0.0, 1.0)
+                * time.phase(6.32, 6.62).ease_in_out_expo(1.0, 0.0);
             (sing > 0.0).then(|| {
                 Circle::builder()
                     .center(Vec2(CX, CY))
@@ -99,9 +101,9 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // 16 short radial shards — emit-then-fade exactly at the singularity.
         // Length peaks then collapses inward as they vanish.
         .maybe_child({
-            let shard_kick = time.phase(6.22, 6.36).ease_out_quint().get();
-            let shard_fade = time.phase(6.36, 6.6).ease_in_out_expo().get();
-            let shard_life = (shard_kick * (1.0 - shard_fade)).clamp(0.0, 1.0);
+            let shard_kick = time.phase(6.22, 6.36).ease_out_quint(0.0, 1.0);
+            let shard_fade = time.phase(6.36, 6.6).ease_in_out_expo(1.0, 0.0);
+            let shard_life = (shard_kick * shard_fade).clamp(0.0, 1.0);
             (shard_life > 0.0).then(|| {
                 (0..16)
                     .map(move |i| {
@@ -126,12 +128,9 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // ring kicks out from center with an elastic-eased launch, then a
         // quint-eased growth carries it past the edge.
         .maybe_child({
-            let pulse_kick = time
-                .phase(6.22, 6.55)
-                .ease_out_elastic_between(0.0, 600.0)
-                .max(0.0);
-            let pulse_grow = time.phase(6.3, 7.15).ease_out_quint().get();
-            let pulse_fade = 1.0 - time.phase(6.7, 7.25).ease_in_out_expo().get();
+            let pulse_kick = time.phase(6.22, 6.55).ease_out_elastic(0.0, 600.0).max(0.0);
+            let pulse_grow = time.phase(6.3, 7.15).ease_out_quint(0.0, 1.0);
+            let pulse_fade = time.phase(6.7, 7.25).ease_in_out_expo(1.0, 0.0);
             let pulse_r = pulse_kick * (0.05 + pulse_grow * 0.95);
             (pulse_r > 12.0 && pulse_fade > 0.0).then(|| {
                 Circle::builder()
@@ -143,8 +142,8 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         })
         // Secondary, smaller, delayed ripple in pink for rhythm.
         .maybe_child({
-            let pulse2_grow = time.phase(6.6, 7.3).ease_out_quint().get();
-            let pulse2_fade = 1.0 - time.phase(6.95, 7.4).ease_in_out_expo().get();
+            let pulse2_grow = time.phase(6.6, 7.3).ease_out_quint(0.0, 1.0);
+            let pulse2_fade = time.phase(6.95, 7.4).ease_in_out_expo(1.0, 0.0);
             let pulse2_r = pulse2_grow * 420.0;
             (pulse2_r > 12.0 && pulse2_fade > 0.0).then(|| {
                 Circle::builder()
@@ -158,7 +157,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // mark. Hub + pink hairline collar + 4 axis rays + a dim outer field
         // ring with hash marks + an orbiting scan dot.
         .maybe_child({
-            let comp_in = time.phase(6.27, 6.7).ease_out_cubic().get();
+            let comp_in = time.phase(6.27, 6.7).ease_out_cubic(0.0, 1.0);
             (comp_in > 0.0).then(|| {
                 CentralMark::builder()
                     .time(time)
@@ -171,7 +170,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Four alignment ticks at the cardinals just outside the field ring,
         // making the central mark a fully four-way-symmetric axis indicator.
         .maybe_child({
-            let tick_in = time.phase(6.85, 7.15).ease_out_cubic().get();
+            let tick_in = time.phase(6.85, 7.15).ease_out_cubic(0.0, 1.0);
             (tick_in > 0.0).then(|| {
                 let tick_alpha = p.paper.with_alpha(life * 0.5);
                 let arm_len = 22.0 * tick_in;
@@ -224,8 +223,8 @@ fn CentralMark(
 ) -> impl VectorComponent {
     let p = palette;
     let breath = 1.0 + wave(time, 1.4, 0.0) * 0.06;
-    let ray_in = time.phase(6.5, 6.95).ease_out_cubic().get();
-    let field_in = time.phase(6.65, 7.1).ease_out_cubic().get();
+    let ray_in = time.phase(6.5, 6.95).ease_out_cubic(0.0, 1.0);
+    let field_in = time.phase(6.65, 7.1).ease_out_cubic(0.0, 1.0);
 
     Fragment::builder()
         // (a) the hub: a filled cyan core.
@@ -266,7 +265,12 @@ fn CentralMark(
         // (d) outer "field" ring with 12 micro-hash-marks + (e) orbiting dot.
         .maybe_child((field_in > 0.0).then(|| {
             let field_r = 78.0 + (1.0 - breath) * 4.0;
-            let orbit_in = time.phase(6.8, 7.2).ease_out_cubic().get();
+            // The orbit `Window` pairs the dot's ease-in (`phase()`) with the
+            // continuously-advancing orbital angle (`elapsed()`) — both
+            // anchored at 6.8s, so the dot fades in while the orbit is
+            // already accruing angle.
+            let orbit = time.window(6.8, 7.2);
+            let orbit_in = orbit.phase().ease_out_cubic(0.0, 1.0);
             Fragment::builder()
                 .child(
                     Circle::builder()
@@ -293,7 +297,7 @@ fn CentralMark(
                 // (e) a single small "scan dot" orbiting the field ring.
                 .maybe_child((orbit_in > 0.0).then(|| {
                     let orbit_period = 3.6;
-                    let orbit_a = (time.seconds() - 6.8).max(0.0) * (TAU / orbit_period) - PI_HALF;
+                    let orbit_a = orbit.elapsed() * (TAU / orbit_period) - PI_HALF;
                     let orbit_pos =
                         Vec2(CX + orbit_a.cos() * field_r, CY + orbit_a.sin() * field_r);
                     let trail_count = 4_i32;

--- a/tellur-live/examples/demo_scene/resolve.rs
+++ b/tellur-live/examples/demo_scene/resolve.rs
@@ -39,7 +39,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             Circle::builder()
                 .center(Vec2(CX, CY))
                 .radius(ring_r)
-                .stroke(alpha(p.cyan, ring_alpha * 0.9))
+                .stroke(p.cyan.with_alpha(ring_alpha * 0.9))
                 .stroke_width(3.5)
         }))
         // Phase 2: 8 satellites slide along their angular rays toward center.
@@ -59,7 +59,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             Circle::builder()
                 .center(pos)
                 .radius(size)
-                .fill(alpha(color, sat_alpha))
+                .fill(color.with_alpha(sat_alpha))
         }))
         // Phase 3: "memory" rings — ghosts of where the contracting ring used
         // to be. Three after-images spawn as the ring sweeps inward, each
@@ -78,7 +78,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         Circle::builder()
                             .center(Vec2(CX, CY))
                             .radius(r)
-                            .stroke(alpha(p.cyan, life * ghost * 0.32))
+                            .stroke(p.cyan.with_alpha(life * ghost * 0.32))
                             .stroke_width(1.8)
                     })
                 })
@@ -93,7 +93,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 Circle::builder()
                     .center(Vec2(CX, CY))
                     .radius(46.0 + sing * 20.0)
-                    .fill(alpha(p.paper, sing * life * 0.95))
+                    .fill(p.paper.with_alpha(sing * life * 0.95))
             })
         })
         // 16 short radial shards — emit-then-fade exactly at the singularity.
@@ -115,7 +115,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .center(mid)
                             .size(Vec2(2.0, length))
                             .angle(a + PI_HALF)
-                            .color(alpha(color, life * shard_life * 0.9))
+                            .color(color.with_alpha(life * shard_life * 0.9))
                             .opacity(1.0)
                             .scale(Vec2(1.0, 1.0))
                     })
@@ -137,7 +137,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 Circle::builder()
                     .center(Vec2(CX, CY))
                     .radius(pulse_r)
-                    .stroke(alpha(p.cyan, life * pulse_fade * 0.9))
+                    .stroke(p.cyan.with_alpha(life * pulse_fade * 0.9))
                     .stroke_width(3.5)
             })
         })
@@ -150,7 +150,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 Circle::builder()
                     .center(Vec2(CX, CY))
                     .radius(pulse2_r)
-                    .stroke(alpha(p.pink, life * pulse2_fade * 0.55))
+                    .stroke(p.pink.with_alpha(life * pulse2_fade * 0.55))
                     .stroke_width(2.0)
             })
         })
@@ -173,7 +173,7 @@ pub fn Resolve(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         .maybe_child({
             let tick_in = time.phase(6.85, 7.15).ease_out_cubic().get();
             (tick_in > 0.0).then(|| {
-                let tick_alpha = alpha(p.paper, life * 0.5);
+                let tick_alpha = p.paper.with_alpha(life * 0.5);
                 let arm_len = 22.0 * tick_in;
                 let offset = 96.0;
                 Fragment::builder()
@@ -233,14 +233,14 @@ fn CentralMark(
             Circle::builder()
                 .center(Vec2(CX, CY))
                 .radius(7.5 * comp_in * breath)
-                .fill(alpha(p.cyan, life)),
+                .fill(p.cyan.with_alpha(life)),
         )
         // (b) pink hairline collar one step out from the hub.
         .child(
             Circle::builder()
                 .center(Vec2(CX, CY))
                 .radius(14.0 * comp_in)
-                .stroke(alpha(p.pink, life * 0.9))
+                .stroke(p.pink.with_alpha(life * 0.9))
                 .stroke_width(1.6),
         )
         // (c) four axis rays at the cardinals, rotating with the cluster.
@@ -257,7 +257,7 @@ fn CentralMark(
                         .center(mid)
                         .size(Vec2(1.5, length))
                         .angle(a + PI_HALF)
-                        .color(alpha(p.paper, life * 0.55))
+                        .color(p.paper.with_alpha(life * 0.55))
                         .opacity(1.0)
                         .scale(Vec2(1.0, 1.0))
                 })
@@ -272,7 +272,7 @@ fn CentralMark(
                     Circle::builder()
                         .center(Vec2(CX, CY))
                         .radius(field_r * field_in)
-                        .stroke(alpha(p.paper, life * 0.25))
+                        .stroke(p.paper.with_alpha(life * 0.25))
                         .stroke_width(1.0),
                 )
                 .children((0..12).map(move |k| {
@@ -286,7 +286,7 @@ fn CentralMark(
                         .center(mid)
                         .size(Vec2(if major { 2.0 } else { 1.2 }, 8.0 * field_in))
                         .angle(a + PI_HALF)
-                        .color(alpha(p.paper, life * if major { 0.6 } else { 0.35 }))
+                        .color(p.paper.with_alpha(life * if major { 0.6 } else { 0.35 }))
                         .opacity(1.0)
                         .scale(Vec2(1.0, 1.0))
                 }))
@@ -303,7 +303,7 @@ fn CentralMark(
                             Circle::builder()
                                 .center(orbit_pos)
                                 .radius(3.0 * orbit_in)
-                                .fill(alpha(p.cyan, life * orbit_in)),
+                                .fill(p.cyan.with_alpha(life * orbit_in)),
                         )
                         // Tiny leading whisker — a 1px hairline behind the dot.
                         .children((1..=trail_count).map(move |j| {
@@ -314,7 +314,7 @@ fn CentralMark(
                             Circle::builder()
                                 .center(pos)
                                 .radius(1.5 * orbit_in)
-                                .fill(alpha(p.cyan, life * orbit_in * fade * 0.5))
+                                .fill(p.cyan.with_alpha(life * orbit_in * fade * 0.5))
                         }))
                         .build()
                 }))

--- a/tellur-live/examples/demo_scene/scan.rs
+++ b/tellur-live/examples/demo_scene/scan.rs
@@ -29,17 +29,16 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         time,
         (3.4, 3.8),
         (5.05, 5.45),
-        ease_in_out_expo,
-        ease_in_out_expo,
+        |p| p.ease_in_out_expo().get(),
+        |p| p.ease_in_out_expo().get(),
     );
 
     // Center reticle: a small crosshair + cyan dot.
-    let reticle = ease_out_cubic(time.phase(3.5, 3.95));
+    let reticle = time.phase(3.5, 3.95).ease_out_cubic().get();
     let cross_arm = 64.0 * reticle;
 
     // Single hero ring — this is the scene's one elastic moment.
-    let ring_pop = ease_out_elastic(time.phase(3.6, 4.4)).max(0.0);
-    let ring_r = lerp(80.0, 300.0, ring_pop);
+    let ring_r = time.phase(3.6, 4.4).ease_out_elastic_between(80.0, 300.0);
 
     VectorLayer::builder()
         .size(SCENE_SIZE)
@@ -47,7 +46,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // transition wipe between FIELD and SCAN. Echoes the pink stripe at
         // the OVERTURE→FIELD handoff so the structure rhymes.
         .maybe_child({
-            let intro_sweep = ease_in_out_expo(time.phase(3.35, 3.85));
+            let intro_sweep = time.phase(3.35, 3.85).ease_in_out_expo().get();
             (intro_sweep > 0.0 && intro_sweep < 1.0).then(|| {
                 let y = lerp(-80.0, SCENE_SIZE.1 + 80.0, intro_sweep);
                 let visibility = 4.0 * intro_sweep * (1.0 - intro_sweep);
@@ -88,7 +87,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Inner secondary reticle — a thinner cyan ring at ~120 + 4 cardinal
         // mini-ticks. Layers visual depth between the crosshair and the hero ring.
         .maybe_child({
-            let inner_ring_in = ease_out_cubic(time.phase(3.7, 4.15));
+            let inner_ring_in = time.phase(3.7, 4.15).ease_out_cubic().get();
             (inner_ring_in > 0.0).then(|| {
                 let inner_r2 = 116.0;
                 Fragment::builder()
@@ -119,7 +118,10 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             let angle_label = ANGLE_LABELS[i];
             let a = i as f32 / 12.0 * TAU - PI * 0.5;
             let stagger = i as f32 * 0.025;
-            let tk = ease_out_cubic(time.phase(3.85 + stagger, 4.3 + stagger));
+            let tk = time
+                .phase(3.85 + stagger, 4.3 + stagger)
+                .ease_out_cubic()
+                .get();
             let major = i % 3 == 0;
             let inner_off = if major { 22.0 } else { 12.0 };
             let outer_off = if major { 22.0 } else { 12.0 };
@@ -145,10 +147,12 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             // i=9 (270°) — dedicated `θ = NNN°` readout sits there.
             let numeral = (tk > 0.0 && major && i != 3 && i != 9)
                 .then(|| {
-                    let label_in =
-                        ease_out_cubic(time.phase(4.1 + i as f32 * 0.012, 4.5 + i as f32 * 0.012));
+                    let label_in = time
+                        .phase(4.1 + i as f32 * 0.012, 4.5 + i as f32 * 0.012)
+                        .ease_out_cubic()
+                        .get();
                     let label_alpha =
-                        life * label_in * (1.0 - ease_in_out_expo(time.phase(5.0, 5.35)));
+                        life * label_in * (1.0 - time.phase(5.0, 5.35).ease_in_out_expo().get());
                     (label_alpha > 0.0).then(|| {
                         let label_r = outer_r + 32.0;
                         Label::builder()
@@ -170,12 +174,15 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // 8 satellites at the cardinal / intercardinal points on the ring,
         // each tagged with a tiny zero-padded index — "01..08".
         .children({
-            let sat_label_in = ease_in_out_expo(time.phase(4.35, 4.75))
-                * (1.0 - ease_in_out_expo(time.phase(4.9, 5.2)));
+            let sat_label_in = time.phase(4.35, 4.75).ease_in_out_expo().get()
+                * (1.0 - time.phase(4.9, 5.2).ease_in_out_expo().get());
             (0..8).map(move |i| {
                 let a = i as f32 / 8.0 * TAU - PI * 0.5;
                 let stagger = i as f32 * 0.04;
-                let sp = ease_out_cubic(time.phase(4.05 + stagger, 4.55 + stagger));
+                let sp = time
+                    .phase(4.05 + stagger, 4.55 + stagger)
+                    .ease_out_cubic()
+                    .get();
                 let pos = Vec2(CX + a.cos() * ring_r, CY + a.sin() * ring_r);
                 let color = if i % 2 == 0 { p.pink } else { p.cyan };
 
@@ -225,8 +232,8 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Radar-style angular sweep: a fan of N narrowing rectangles whose
         // leading edge sweeps clockwise once, fading along its trail.
         .maybe_child({
-            let sweep_in = ease_in_out_expo(time.phase(3.9, 4.2));
-            let sweep_out = ease_in_out_expo(time.phase(5.05, 5.4));
+            let sweep_in = time.phase(3.9, 4.2).ease_in_out_expo().get();
+            let sweep_out = time.phase(5.05, 5.4).ease_in_out_expo().get();
             let sweep_life = (sweep_in * (1.0 - sweep_out)).clamp(0.0, 1.0);
             (sweep_life > 0.0).then(|| {
                 // Slower rotation (~2.4s per full revolution) with a wider,
@@ -255,8 +262,8 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         })
         // Single numeric annotation, attached to the ring at 0°.
         .maybe_child({
-            let annot = ease_in_out_expo(time.phase(4.15, 4.5))
-                * (1.0 - ease_in_out_expo(time.phase(4.85, 5.2)));
+            let annot = time.phase(4.15, 4.5).ease_in_out_expo().get()
+                * (1.0 - time.phase(4.85, 5.2).ease_in_out_expo().get());
             (annot > 0.0).then(|| {
                 Fragment::builder()
                     // Mini connector tick from the ring to the label.
@@ -291,9 +298,9 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // "θ" readout in the 270° direction. Tracks the radar sweep's current
         // angle so the SCAN scene has a live data feel.
         .maybe_child({
-            let theta_in = ease_in_out_expo(time.phase(4.2, 4.55))
-                * (1.0 - ease_in_out_expo(time.phase(4.95, 5.25)));
-            let sweep_in = ease_in_out_expo(time.phase(3.9, 4.2));
+            let theta_in = time.phase(4.2, 4.55).ease_in_out_expo().get()
+                * (1.0 - time.phase(4.95, 5.25).ease_in_out_expo().get());
+            let sweep_in = time.phase(3.9, 4.2).ease_in_out_expo().get();
             let sweep_active = sweep_in > 0.05;
             (theta_in > 0.0 && sweep_active).then(|| {
                 let base_angle = (time.seconds() - 3.95).max(0.0) * (TAU / 2.4);
@@ -321,8 +328,8 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // SCAN's exit burst — 24 short radial spokes shoot outward from the
         // hero ring just as the scene flashes white into RESOLVE.
         .maybe_child({
-            let burst_kick = ease_out_quint(time.phase(4.88, 5.02));
-            let burst_fade = ease_in_out_expo(time.phase(5.05, 5.25));
+            let burst_kick = time.phase(4.88, 5.02).ease_out_quint().get();
+            let burst_fade = time.phase(5.05, 5.25).ease_in_out_expo().get();
             let burst_life = (burst_kick * (1.0 - burst_fade)).clamp(0.0, 1.0);
             (burst_life > 0.0).then(|| {
                 (0..24)

--- a/tellur-live/examples/demo_scene/scan.rs
+++ b/tellur-live/examples/demo_scene/scan.rs
@@ -29,16 +29,22 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         time,
         (3.4, 3.8),
         (5.05, 5.45),
-        |p| p.ease_in_out_expo().get(),
-        |p| p.ease_in_out_expo().get(),
+        |p| p.ease_in_out_expo(0.0, 1.0),
+        |p| p.ease_in_out_expo(0.0, 1.0),
     );
 
     // Center reticle: a small crosshair + cyan dot.
-    let reticle = time.phase(3.5, 3.95).ease_out_cubic().get();
+    let reticle = time.phase(3.5, 3.95).ease_out_cubic(0.0, 1.0);
     let cross_arm = 64.0 * reticle;
 
     // Single hero ring — this is the scene's one elastic moment.
-    let ring_r = time.phase(3.6, 4.4).ease_out_elastic_between(80.0, 300.0);
+    let ring_r = time.phase(3.6, 4.4).ease_out_elastic(80.0, 300.0);
+
+    // Radar window: spins from 3.95 (just after the reticle settles) until
+    // the sweep-out finishes at 5.4. `elapsed()` drives the continuously-
+    // accruing rotation angle; the same window is reused by the θ readout
+    // below so both readouts speak in the same radar time-frame.
+    let radar = time.window(3.95, 5.4);
 
     VectorLayer::builder()
         .size(SCENE_SIZE)
@@ -46,10 +52,10 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // transition wipe between FIELD and SCAN. Echoes the pink stripe at
         // the OVERTURE→FIELD handoff so the structure rhymes.
         .maybe_child({
-            let intro_sweep = time.phase(3.35, 3.85).ease_in_out_expo().get();
+            let intro_sweep = time.phase(3.35, 3.85).ease_in_out_expo(0.0, 1.0);
             (intro_sweep > 0.0 && intro_sweep < 1.0).then(|| {
                 let y = lerp(-80.0, SCENE_SIZE.1 + 80.0, intro_sweep);
-                let visibility = 4.0 * intro_sweep * (1.0 - intro_sweep);
+                let visibility = peak(intro_sweep);
                 Rect::builder()
                     .position(Vec2(0.0, y - 3.0))
                     .size(Vec2(SCENE_SIZE.0, 6.0))
@@ -87,7 +93,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Inner secondary reticle — a thinner cyan ring at ~120 + 4 cardinal
         // mini-ticks. Layers visual depth between the crosshair and the hero ring.
         .maybe_child({
-            let inner_ring_in = time.phase(3.7, 4.15).ease_out_cubic().get();
+            let inner_ring_in = time.phase(3.7, 4.15).ease_out_cubic(0.0, 1.0);
             (inner_ring_in > 0.0).then(|| {
                 let inner_r2 = 116.0;
                 Fragment::builder()
@@ -120,8 +126,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             let stagger = i as f32 * 0.025;
             let tk = time
                 .phase(3.85 + stagger, 4.3 + stagger)
-                .ease_out_cubic()
-                .get();
+                .ease_out_cubic(0.0, 1.0);
             let major = i % 3 == 0;
             let inner_off = if major { 22.0 } else { 12.0 };
             let outer_off = if major { 22.0 } else { 12.0 };
@@ -149,10 +154,9 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 .then(|| {
                     let label_in = time
                         .phase(4.1 + i as f32 * 0.012, 4.5 + i as f32 * 0.012)
-                        .ease_out_cubic()
-                        .get();
+                        .ease_out_cubic(0.0, 1.0);
                     let label_alpha =
-                        life * label_in * (1.0 - time.phase(5.0, 5.35).ease_in_out_expo().get());
+                        life * label_in * time.phase(5.0, 5.35).ease_in_out_expo(1.0, 0.0);
                     (label_alpha > 0.0).then(|| {
                         let label_r = outer_r + 32.0;
                         Label::builder()
@@ -174,15 +178,14 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // 8 satellites at the cardinal / intercardinal points on the ring,
         // each tagged with a tiny zero-padded index — "01..08".
         .children({
-            let sat_label_in = time.phase(4.35, 4.75).ease_in_out_expo().get()
-                * (1.0 - time.phase(4.9, 5.2).ease_in_out_expo().get());
+            let sat_label_in = time.phase(4.35, 4.75).ease_in_out_expo(0.0, 1.0)
+                * time.phase(4.9, 5.2).ease_in_out_expo(1.0, 0.0);
             (0..8).map(move |i| {
                 let a = i as f32 / 8.0 * TAU - PI * 0.5;
                 let stagger = i as f32 * 0.04;
                 let sp = time
                     .phase(4.05 + stagger, 4.55 + stagger)
-                    .ease_out_cubic()
-                    .get();
+                    .ease_out_cubic(0.0, 1.0);
                 let pos = Vec2(CX + a.cos() * ring_r, CY + a.sin() * ring_r);
                 let color = if i % 2 == 0 { p.pink } else { p.cyan };
 
@@ -232,14 +235,14 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // Radar-style angular sweep: a fan of N narrowing rectangles whose
         // leading edge sweeps clockwise once, fading along its trail.
         .maybe_child({
-            let sweep_in = time.phase(3.9, 4.2).ease_in_out_expo().get();
-            let sweep_out = time.phase(5.05, 5.4).ease_in_out_expo().get();
-            let sweep_life = (sweep_in * (1.0 - sweep_out)).clamp(0.0, 1.0);
+            let sweep_in = time.phase(3.9, 4.2).ease_in_out_expo(0.0, 1.0);
+            let sweep_out = time.phase(5.05, 5.4).ease_in_out_expo(1.0, 0.0);
+            let sweep_life = sweep_in * sweep_out;
             (sweep_life > 0.0).then(|| {
                 // Slower rotation (~2.4s per full revolution) with a wider,
                 // longer trail so the sweep reads as deliberate observation
                 // rather than a quick flyby.
-                let base_angle = (time.seconds() - 3.95).max(0.0) * (TAU / 2.4) - PI * 0.5;
+                let base_angle = radar.elapsed() * (TAU / 2.4) - PI * 0.5;
                 let trail_count = 32_i32;
                 let trail_span = PI * 0.75;
                 (0..trail_count)
@@ -262,8 +265,8 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         })
         // Single numeric annotation, attached to the ring at 0°.
         .maybe_child({
-            let annot = time.phase(4.15, 4.5).ease_in_out_expo().get()
-                * (1.0 - time.phase(4.85, 5.2).ease_in_out_expo().get());
+            let annot = time.phase(4.15, 4.5).ease_in_out_expo(0.0, 1.0)
+                * time.phase(4.85, 5.2).ease_in_out_expo(1.0, 0.0);
             (annot > 0.0).then(|| {
                 Fragment::builder()
                     // Mini connector tick from the ring to the label.
@@ -298,12 +301,12 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // "θ" readout in the 270° direction. Tracks the radar sweep's current
         // angle so the SCAN scene has a live data feel.
         .maybe_child({
-            let theta_in = time.phase(4.2, 4.55).ease_in_out_expo().get()
-                * (1.0 - time.phase(4.95, 5.25).ease_in_out_expo().get());
-            let sweep_in = time.phase(3.9, 4.2).ease_in_out_expo().get();
+            let theta_in = time.phase(4.2, 4.55).ease_in_out_expo(0.0, 1.0)
+                * time.phase(4.95, 5.25).ease_in_out_expo(1.0, 0.0);
+            let sweep_in = time.phase(3.9, 4.2).ease_in_out_expo(0.0, 1.0);
             let sweep_active = sweep_in > 0.05;
             (theta_in > 0.0 && sweep_active).then(|| {
-                let base_angle = (time.seconds() - 3.95).max(0.0) * (TAU / 2.4);
+                let base_angle = radar.elapsed() * (TAU / 2.4);
                 // Convert to degrees and wrap to [0, 360).
                 let deg = (base_angle.to_degrees().rem_euclid(360.0)) as i32;
                 Fragment::builder()
@@ -328,9 +331,9 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
         // SCAN's exit burst — 24 short radial spokes shoot outward from the
         // hero ring just as the scene flashes white into RESOLVE.
         .maybe_child({
-            let burst_kick = time.phase(4.88, 5.02).ease_out_quint().get();
-            let burst_fade = time.phase(5.05, 5.25).ease_in_out_expo().get();
-            let burst_life = (burst_kick * (1.0 - burst_fade)).clamp(0.0, 1.0);
+            let burst_kick = time.phase(4.88, 5.02).ease_out_quint(0.0, 1.0);
+            let burst_fade = time.phase(5.05, 5.25).ease_in_out_expo(1.0, 0.0);
+            let burst_life = burst_kick * burst_fade;
             (burst_life > 0.0).then(|| {
                 (0..24)
                     .map(move |i| {

--- a/tellur-live/examples/demo_scene/scan.rs
+++ b/tellur-live/examples/demo_scene/scan.rs
@@ -53,7 +53,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                 Rect::builder()
                     .position(Vec2(0.0, y - 3.0))
                     .size(Vec2(SCENE_SIZE.0, 6.0))
-                    .color(alpha(p.cyan, visibility * 0.88))
+                    .color(p.cyan.with_alpha(visibility * 0.88))
             })
         })
         // Center reticle: crosshair arms + cyan dot. Reads as "this is the
@@ -62,26 +62,26 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
             Rect::builder()
                 .position(Vec2(CX - cross_arm, CY - 1.0))
                 .size(Vec2(cross_arm * 2.0, 2.0))
-                .color(alpha(p.paper, life * 0.7)),
+                .color(p.paper.with_alpha(life * 0.7)),
         )
         .child(
             Rect::builder()
                 .position(Vec2(CX - 1.0, CY - cross_arm))
                 .size(Vec2(2.0, cross_arm * 2.0))
-                .color(alpha(p.paper, life * 0.7)),
+                .color(p.paper.with_alpha(life * 0.7)),
         )
         .child(
             Circle::builder()
                 .center(Vec2(CX, CY))
                 .radius(9.0 * reticle)
-                .fill(alpha(p.cyan, life)),
+                .fill(p.cyan.with_alpha(life)),
         )
         // Single hero ring.
         .child(
             Circle::builder()
                 .center(Vec2(CX, CY))
                 .radius(ring_r)
-                .stroke(alpha(p.cyan, life * 0.75))
+                .stroke(p.cyan.with_alpha(life * 0.75))
                 .stroke_width(3.5),
         )
         // Inner secondary reticle — a thinner cyan ring at ~120 + 4 cardinal
@@ -95,7 +95,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         Circle::builder()
                             .center(Vec2(CX, CY))
                             .radius(inner_r2 * inner_ring_in)
-                            .stroke(alpha(p.cyan, life * 0.35))
+                            .stroke(p.cyan.with_alpha(life * 0.35))
                             .stroke_width(1.5),
                     )
                     .children((0..4).map(move |i| {
@@ -106,7 +106,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .center(mid)
                             .size(Vec2(2.0, 10.0 * inner_ring_in))
                             .angle(a + PI * 0.5)
-                            .color(alpha(p.paper, life * 0.45))
+                            .color(p.paper.with_alpha(life * 0.45))
                             .opacity(1.0)
                             .scale(Vec2(1.0, 1.0))
                     }))
@@ -136,7 +136,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                     .center(mid)
                     .size(Vec2(if major { 3.0 } else { 2.0 }, length * tk))
                     .angle(a + PI * 0.5)
-                    .color(alpha(p.paper, life * if major { 0.85 } else { 0.55 }))
+                    .color(p.paper.with_alpha(life * if major { 0.85 } else { 0.55 }))
                     .opacity(1.0)
                     .scale(Vec2(1.0, 1.0))
             });
@@ -160,7 +160,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .anchor(Anchor::CENTER)
                             .text(angle_label)
                             .size(11.0)
-                            .color(alpha(p.paper, label_alpha * 0.7))
+                            .color(p.paper.with_alpha(label_alpha * 0.7))
                             .weight(Weight::NORMAL)
                     })
                 })
@@ -214,7 +214,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         .anchor(anchor)
                         .text(format!("0{}", i + 1))
                         .size(10.0)
-                        .color(alpha(p.paper, life * sat_label_in * 0.55))
+                        .color(p.paper.with_alpha(life * sat_label_in * 0.55))
                         .weight(Weight::NORMAL)
                 });
 
@@ -223,7 +223,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         Circle::builder()
                             .center(pos)
                             .radius(12.0 * sp)
-                            .fill(alpha(color, life)),
+                            .fill(color.with_alpha(life)),
                     )
                     .maybe_child(tag)
                     .build()
@@ -253,7 +253,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .center(mid)
                             .size(Vec2(4.0, r))
                             .angle(a + PI * 0.5)
-                            .color(alpha(p.pink, life * sweep_life * fade * 0.6))
+                            .color(p.pink.with_alpha(life * sweep_life * fade * 0.6))
                             .opacity(1.0)
                             .scale(Vec2(1.0, 1.0))
                     })
@@ -271,7 +271,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         Rect::builder()
                             .position(Vec2(CX + ring_r, CY - 1.0))
                             .size(Vec2(28.0, 2.0))
-                            .color(alpha(p.paper, life * annot * 0.7)),
+                            .color(p.paper.with_alpha(life * annot * 0.7)),
                     )
                     .child(
                         Label::builder()
@@ -279,7 +279,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .anchor(Anchor::CENTER_LEFT)
                             .text("R = 300 PX")
                             .size(13.0)
-                            .color(alpha(p.paper, life * annot * 0.85))
+                            .color(p.paper.with_alpha(life * annot * 0.85))
                             .weight(Weight::NORMAL),
                     )
                     // Sub-label one line down (smaller, dimmer).
@@ -289,7 +289,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .anchor(Anchor::CENTER_LEFT)
                             .text("NODES = 08")
                             .size(11.0)
-                            .color(alpha(p.paper, life * annot * 0.55))
+                            .color(p.paper.with_alpha(life * annot * 0.55))
                             .weight(Weight::NORMAL),
                     )
                     .build()
@@ -311,7 +311,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                         Rect::builder()
                             .position(Vec2(CX - ring_r - 28.0, CY - 1.0))
                             .size(Vec2(28.0, 2.0))
-                            .color(alpha(p.paper, life * theta_in * 0.7)),
+                            .color(p.paper.with_alpha(life * theta_in * 0.7)),
                     )
                     .child(
                         Label::builder()
@@ -319,7 +319,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .anchor(Anchor::CENTER_RIGHT)
                             .text(format!("θ = {:03}°", deg))
                             .size(13.0)
-                            .color(alpha(p.paper, life * theta_in * 0.85))
+                            .color(p.paper.with_alpha(life * theta_in * 0.85))
                             .weight(Weight::NORMAL),
                     )
                     .build()
@@ -344,7 +344,7 @@ pub fn Scan(time: TimelineTime, palette: Palette) -> impl VectorComponent {
                             .center(mid)
                             .size(Vec2(2.5, length))
                             .angle(a + PI * 0.5)
-                            .color(alpha(color, life * burst_life * 0.9))
+                            .color(color.with_alpha(life * burst_life * 0.9))
                             .opacity(1.0)
                             .scale(Vec2(1.0, 1.0))
                     })

--- a/tellur-live/examples/timeline_showcase.rs
+++ b/tellur-live/examples/timeline_showcase.rs
@@ -86,12 +86,12 @@ fn fade(c: Color, a: f32) -> Color {
 
 /// Smoothstep easing for `[0,1]` progress (eases in AND out).
 fn ease(p: f32) -> f32 {
-    easing::smoothstep(Phase::saturating(p)).get()
+    easing::smoothstep(Phase::saturating(p), 0.0, 1.0)
 }
 
 /// Cubic ease-out: fast start, gentle settle — a satisfying "snap into place".
 fn ease_out(p: f32) -> f32 {
-    easing::out_cubic(Phase::saturating(p)).get()
+    easing::out_cubic(Phase::saturating(p), 0.0, 1.0)
 }
 
 /// The per-chapter enter/exit transition, shared by every windowed element so

--- a/tellur-live/examples/timeline_showcase.rs
+++ b/tellur-live/examples/timeline_showcase.rs
@@ -25,8 +25,10 @@ use std::f32::consts::{PI, TAU};
 
 use tellur_core::builder::{RasterEffect, VectorBuilderPlacement};
 use tellur_core::color::Color;
+use tellur_core::easing;
 use tellur_core::geometry::{Anchor, Vec2};
 use tellur_core::layer::{Layer, VectorLayer};
+use tellur_core::phase::Phase;
 use tellur_core::placement::raster::Positioned as RasterPositioned;
 use tellur_core::placement::{Positioned, RasterPlacement};
 use tellur_core::shapes::{Circle, Rectangle};
@@ -87,14 +89,12 @@ fn fade(c: Color, a: f32) -> Color {
 
 /// Smoothstep easing for `[0,1]` progress (eases in AND out).
 fn ease(p: f32) -> f32 {
-    let p = p.clamp(0.0, 1.0);
-    p * p * (3.0 - 2.0 * p)
+    easing::smoothstep(Phase::saturating(p)).get()
 }
 
 /// Cubic ease-out: fast start, gentle settle — a satisfying "snap into place".
 fn ease_out(p: f32) -> f32 {
-    let p = p.clamp(0.0, 1.0);
-    1.0 - (1.0 - p).powi(3)
+    easing::out_cubic(Phase::saturating(p)).get()
 }
 
 /// The per-chapter enter/exit transition, shared by every windowed element so

--- a/tellur-live/examples/timeline_showcase.rs
+++ b/tellur-live/examples/timeline_showcase.rs
@@ -81,10 +81,7 @@ const HOLE: Color = Color::rgb_u8(15, 17, 25); // sprocket holes
 /// Multiplies a color's alpha (used to thread an envelope's opacity through a
 /// whole shape tree).
 fn fade(c: Color, a: f32) -> Color {
-    Color {
-        a: c.a * a.clamp(0.0, 1.0),
-        ..c
-    }
+    c.multiply_alpha(a)
 }
 
 /// Smoothstep easing for `[0,1]` progress (eases in AND out).

--- a/tellur-live/examples/timeline_showcase.rs
+++ b/tellur-live/examples/timeline_showcase.rs
@@ -25,7 +25,7 @@ use std::f32::consts::{PI, TAU};
 
 use tellur_core::builder::{RasterEffect, VectorBuilderPlacement};
 use tellur_core::color::Color;
-use tellur_core::easing;
+use tellur_core::easing::PhaseEasing;
 use tellur_core::geometry::{Anchor, Vec2};
 use tellur_core::layer::{Layer, VectorLayer};
 use tellur_core::phase::Phase;
@@ -86,12 +86,12 @@ fn fade(c: Color, a: f32) -> Color {
 
 /// Smoothstep easing for `[0,1]` progress (eases in AND out).
 fn ease(p: f32) -> f32 {
-    easing::smoothstep(Phase::saturating(p), 0.0, 1.0)
+    Phase::saturating(p).ease_smoothstep(0.0, 1.0)
 }
 
 /// Cubic ease-out: fast start, gentle settle — a satisfying "snap into place".
 fn ease_out(p: f32) -> f32 {
-    easing::out_cubic(Phase::saturating(p), 0.0, 1.0)
+    Phase::saturating(p).ease_out_cubic(0.0, 1.0)
 }
 
 /// The per-chapter enter/exit transition, shared by every windowed element so

--- a/tellur-renderer/examples/memoization_benchmark.rs
+++ b/tellur-renderer/examples/memoization_benchmark.rs
@@ -14,6 +14,7 @@ use std::time::Instant;
 use tellur_core::builder::RasterEffect;
 use tellur_core::color::Color;
 use tellur_core::component;
+use tellur_core::easing::PhaseEasing;
 use tellur_core::geometry::{Anchor, EdgeInsets, Vec2};
 use tellur_core::layout::raster::{DecoratedBox, Frame, Padding, Stack};
 use tellur_core::layout::{Axis, CrossAlign, MainAlign, SizeMode};
@@ -28,7 +29,7 @@ use tellur_renderer::{CachingRenderContext, DropShadow, RasterizableBuilder};
 #[component(raster)]
 fn BouncingDot(#[builder(into)] t: LocalTime) -> impl RasterComponent {
     let (phase, _) = t.bounce(2.5);
-    let rx = phase.interpolate(0.0, 1.0);
+    let rx = phase.linear(0.0, 1.0);
     Frame::builder()
         .width(SizeMode::Fill)
         .height(SizeMode::Fixed(60.0))

--- a/tellur-renderer/examples/timeline_to_mp4.rs
+++ b/tellur-renderer/examples/timeline_to_mp4.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 use tellur_core::builder::RasterEffect;
 use tellur_core::color::Color;
 use tellur_core::component;
+use tellur_core::easing::PhaseEasing;
 use tellur_core::geometry::{Anchor, EdgeInsets, Vec2};
 use tellur_core::layout::raster::{DecoratedBox, Frame, Padding, Stack};
 use tellur_core::layout::{Axis, CrossAlign, MainAlign, SizeMode};
@@ -42,7 +43,7 @@ use tellur_renderer::{DropShadow, FfmpegEncoder, Outline, RasterizableBuilder};
 #[component(raster)]
 fn BouncingDot(#[builder(into)] t: LocalTime) -> impl RasterComponent {
     let (phase, _) = t.bounce(2.5);
-    let rx = phase.interpolate(0.0, 1.0);
+    let rx = phase.linear(0.0, 1.0);
     Frame::builder()
         .width(SizeMode::Fill)
         .height(SizeMode::Fixed(60.0))

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -981,6 +981,25 @@ fn encode_vello_node(
                 scene.pop_layer();
             }
         }
+        Node::SingleGroup(group) => {
+            let opacity = group.opacity.clamp(0.0, 1.0);
+            if opacity <= 0.0 {
+                return Some(());
+            }
+            let transform = concat_transform(transform, group.transform);
+            if opacity < 1.0 {
+                scene.push_layer(
+                    vello::peniko::BlendMode::default(),
+                    opacity,
+                    Affine::IDENTITY,
+                    clip,
+                );
+            }
+            encode_vello_node(scene, &group.child, transform, clip)?;
+            if opacity < 1.0 {
+                scene.pop_layer();
+            }
+        }
         Node::Path(path) => encode_vello_path(scene, path, transform)?,
     }
     Some(())

--- a/tellur-renderer/src/rasterize.rs
+++ b/tellur-renderer/src/rasterize.rs
@@ -137,6 +137,28 @@ fn render_node(pixmap: &mut tiny_skia::Pixmap, node: &Node, parent_xform: tiny_s
             }
             // opacity <= 0.0: skip the group entirely.
         }
+        Node::SingleGroup(group) => {
+            let xform = parent_xform.pre_concat(to_skia_transform(&group.transform));
+            if group.opacity >= 1.0 {
+                render_node(pixmap, &group.child, xform);
+            } else if group.opacity > 0.0 {
+                let mut layer = tiny_skia::Pixmap::new(pixmap.width(), pixmap.height())
+                    .expect("pixmap dimensions must be non-zero");
+                render_node(&mut layer, &group.child, xform);
+                let pp = tiny_skia::PixmapPaint {
+                    opacity: group.opacity,
+                    ..Default::default()
+                };
+                pixmap.draw_pixmap(
+                    0,
+                    0,
+                    layer.as_ref(),
+                    &pp,
+                    tiny_skia::Transform::identity(),
+                    None,
+                );
+            }
+        }
         Node::Path(path) => {
             let xform = parent_xform.pre_concat(to_skia_transform(&path.transform));
             render_path(pixmap, path, xform);


### PR DESCRIPTION
Adds reusable timing, easing, color, and vector primitives to `tellur-core`, then migrates the demo scene and examples onto those APIs so fewer motion helpers live in `demo_scene/common.rs`. The branch adds `Phase` width/sub-windowing, `Window`, `PhaseEasing`, color alpha and paint conversions, layout-neutral vector transforms, and renderer support for single-child transform groups; it also hardens paint-bound handling so transformed vectors do not shrink their layout box. 26 files (+1.7k / -0.5k) across `tellur-core`, `tellur-renderer`, and `tellur-live` examples.

## Timing and easing primitives
- `Phase` carries optional source-window width, supports `sub_secs` / `sub_ratio`, endpoint predicates, and hashes/equality include the width metadata.
- `Window` exposes past-saturation timing helpers (`elapsed`, `before`, `after`, `phase`, `raw_progress`, `remaining`) with finite increasing-span invariants.
- `PhaseEasing` centralizes easing curves as uniform `(from, to) -> f32` APIs, replacing demo-local easing free functions and updating `timeline_showcase`.

## Vector and color primitives
- `Color::with_alpha` / `multiply_alpha` and `clamp_unit` normalize opacity handling, including NaN-to-zero clamping.
- `Paint::solid` plus `From<Color>` conversions for `Paint`, `Fill`, `Stroke`, and their optional forms remove demo-local paint wrappers.
- `Transformed` / `VectorTransform` provide layout-neutral vector transforms with `Node::SingleGroup` support in CPU and GPU renderers.
- Shape paint bounds and view boxes now include stroke outset consistently.

## Demo migration and visual hardening
- `demo_scene/common.rs` keeps only demo-specific primitives while the section files use core alpha, paint, easing, sub-window, and transform APIs.
- The scan timeline regression around 4s12f is fixed by keeping transformed paint bounds from shrinking the layout box.
- `timeline_showcase` and renderer examples are updated to the new easing/alpha surfaces.

## Verification
- `cargo fmt --all -- --check`
- `nix develop -c cargo check -p tellur-live --examples`
- `nix develop -c cargo test -p tellur-core -p tellur-renderer`
- Spot-checked the demo timeline frame around 4s12f after the transformed-bounds fix.
