### PR TITLE
feat: add a MotionBlur timeline component with GPU temporal averaging

### DIFF
--- a/tellur-core/src/raster.rs
+++ b/tellur-core/src/raster.rs
@@ -61,6 +61,30 @@ impl RasterImage {
             Self::Gpu(_) => Err(self),
         }
     }
+
+    /// Whether two images share the same backing storage (one `Bytes`
+    /// allocation / one GPU handle).
+    ///
+    /// A cheap identity check, not a pixel comparison: a caching render
+    /// context hands out clones of one cache entry, so shared storage ⇒
+    /// pixel-identical images. `false` carries no information — equal
+    /// pixels in distinct buffers also compare `false`.
+    pub fn shares_storage(&self, other: &RasterImage) -> bool {
+        match (self, other) {
+            (Self::Cpu(a), Self::Cpu(b)) => {
+                a.pixels.len() == b.pixels.len() && a.pixels.as_ptr() == b.pixels.as_ptr()
+            }
+            (Self::Gpu(a), Self::Gpu(b)) => {
+                // Compare the Arc data pointers as thin pointers so the
+                // (non-unique) trait-object vtable half never participates.
+                std::ptr::eq(
+                    Arc::as_ptr(&a.handle) as *const (),
+                    Arc::as_ptr(&b.handle) as *const (),
+                )
+            }
+            _ => false,
+        }
+    }
 }
 
 impl From<CpuRasterImage> for RasterImage {

--- a/tellur-core/src/render_context.rs
+++ b/tellur-core/src/render_context.rs
@@ -86,6 +86,17 @@ pub trait RenderContext {
         None
     }
 
+    /// Whether temporal effects should sample and average across their
+    /// shutter window this frame.
+    ///
+    /// A policy signal like [`gpu_preference`](Self::gpu_preference): a
+    /// preview host can switch it off to trade motion blur for cheaper
+    /// frames, and a temporal effect must then degrade to its unblurred
+    /// child render. Defaults to `true` so offline exports stay exact.
+    fn motion_blur_enabled(&self) -> bool {
+        true
+    }
+
     /// Renders `component` at the given logical `size` into a
     /// `target`-sized pixel buffer, possibly returning a cached result
     /// from a previous identical request.
@@ -168,6 +179,21 @@ pub trait GpuRasterBackend {
     /// Lets solid-color leaves (backgrounds, transparent spacers) start
     /// life on the GPU instead of being CPU-filled and uploaded.
     fn solid_fill(&mut self, target: Resolution, color: Color) -> Option<RasterImage>;
+
+    /// Averages `frames` over `total` shutter samples into one
+    /// `target`-sized image (a motion-blur accumulate).
+    ///
+    /// Every frame must already be `target`-sized; samples beyond
+    /// `frames.len()` count as fully transparent, so a child that
+    /// contributed no frame for part of the shutter fades out instead of
+    /// brightening. The average is computed in premultiplied integer
+    /// space and must match the CPU fallback byte-for-byte.
+    fn temporal_average(
+        &mut self,
+        target: Resolution,
+        frames: &[&RasterImage],
+        total: u32,
+    ) -> Option<RasterImage>;
 
     fn readback(&mut self, image: RasterImage) -> Option<CpuRasterImage>;
 }

--- a/tellur-core/src/timeline_component/clock.rs
+++ b/tellur-core/src/timeline_component/clock.rs
@@ -94,6 +94,25 @@ impl<'a> Clock<'a> {
         self.global
     }
 
+    /// Shifts BOTH time axes by `dt` seconds, evaluating the subtree as it
+    /// was (or will be) `dt` away from this frame. The window length and the
+    /// trigger table are untouched: the component still lives in the same
+    /// resolved slot, only the cursor moves.
+    ///
+    /// This is the sampling primitive for temporal effects: a motion-blur
+    /// shutter evaluates its child at several `shifted(-dt)` clocks and
+    /// averages the frames. Shifting `global` together with `local` keeps
+    /// [`Event`]-driven animation consistent with local-phase animation
+    /// under the shifted clock.
+    pub fn shifted(&self, dt: f32) -> Clock<'a> {
+        Clock {
+            global: TimelineTime::new(self.global.seconds() + dt),
+            local: LocalTime::new(self.local.seconds() + dt),
+            triggers: self.triggers,
+            window: self.window,
+        }
+    }
+
     /// The resolved LOCAL window as a [`Window`] over the local axis —
     /// `[0, length)` with the cursor at [`local`](Self::local) — or `None`
     /// for an open-ended placement (`.fill()`, a bare timeless point, the

--- a/tellur-live/examples/demo_scene/mod.rs
+++ b/tellur-live/examples/demo_scene/mod.rs
@@ -26,6 +26,7 @@ mod overlay;
 mod overture;
 mod resolve;
 mod scan;
+mod streak;
 
 use tellur_core::builder::{RasterEffect, VectorBuilderPlacement};
 use tellur_core::color::Color;
@@ -34,7 +35,7 @@ use tellur_core::layer::VectorLayer;
 use tellur_core::time::Time;
 use tellur_core::timeline_component::{Clock, TimedBuilder, TimelineComponent};
 use tellur_core::timeline_container::Timeline;
-use tellur_renderer::{DropShadow, Rasterizable, RasterizableBuilder};
+use tellur_renderer::{DropShadow, MotionBlur, Rasterizable, RasterizableBuilder};
 
 use common::{Palette, DURATION, SCENE_SIZE};
 use hud::{Hud, HUD_INTRO_END, HUD_INTRO_START, HUD_OUTRO_END, HUD_OUTRO_START};
@@ -48,6 +49,7 @@ use overlay::{
 use overture::Overture;
 use resolve::Resolve;
 use scan::Scan;
+use streak::{Streak, STREAK_SAMPLES, STREAK_SHUTTER};
 
 // The scene palette. Constant, so it is hoisted out of the per-frame body.
 const PALETTE: Palette = Palette {
@@ -67,6 +69,16 @@ fn KineticMotion() -> impl TimelineComponent {
         // overlay's length — every other child is a `.fill()`, and an
         // all-fill overlay has no length anchor and would collapse to 0.
         .child(Foreground::builder().at(0.0..DURATION))
+        // The motion-blur showcase: the wrapper goes INSIDE the placement
+        // verb (`MotionBlur` around the section, then `.fill()`) so the
+        // container still sees the `Placed` and can resolve the fill.
+        .child(
+            MotionBlur::builder()
+                .shutter(STREAK_SHUTTER)
+                .samples(STREAK_SAMPLES)
+                .child(StreakSection::builder().build())
+                .fill(),
+        )
         .child(HudSection::builder().fill())
         .child(OverlaySection::builder().fill())
         .build()
@@ -153,6 +165,17 @@ fn HudSection(#[clock] clock: Clock) -> impl TimelineComponent {
         section: hud::section_index_at(t.seconds()),
     }
     .rasterize()
+}
+
+/// The comet pass, rasterized as its own layer so the wrapping
+/// [`MotionBlur`] samples just this subtree across its shutter. While a
+/// dash runs, each shutter sample bakes a different comet position (its own
+/// cache entry); during the rests every sample collapses to one entry and
+/// the blur short-circuits.
+#[tellur_core::component(timeline, name = "Streak")]
+fn StreakSection(#[clock] clock: Clock) -> impl TimelineComponent {
+    let t = clock.local();
+    Streak::builder().time(t).palette(PALETTE).rasterize()
 }
 
 /// The unshadowed overlay pass: boot flash, transition flash, exit fade.

--- a/tellur-live/examples/demo_scene/streak.rs
+++ b/tellur-live/examples/demo_scene/streak.rs
@@ -1,0 +1,74 @@
+//! STREAK — the motion-blur showcase: a comet that rests on the lower band,
+//! darts across the frame, rests, and darts back.
+//!
+//! The element is deliberately bursty: the dashes are fast enough that the
+//! wrapping `MotionBlur` draws a visible trail, and the rests in between
+//! saturate every phase so the rasterized layer collapses back to one
+//! cached entry (the blur's static short-circuit) — the same frame both
+//! shows off the effect and exercises its cache behavior.
+
+use tellur_core::geometry::Vec2;
+use tellur_core::layer::VectorLayer;
+use tellur_core::time::{LocalTime, Time};
+
+use super::common::*;
+
+/// Trailing shutter for the comet, in seconds. One 60 fps frame: the
+/// dash's eased midpoint peaks around 14 000 logical px/s, so even this
+/// short shutter draws a ~240 px trail; 16 samples keep the dots
+/// overlapping into a continuous streak.
+pub const STREAK_SHUTTER: f32 = 1.0 / 60.0;
+
+/// Sample count matched to [`STREAK_SHUTTER`] (see above).
+pub const STREAK_SAMPLES: u32 = 16;
+
+const FADE_IN_START: f32 = 1.7;
+const FADE_IN_END: f32 = 2.0;
+const FADE_OUT_START: f32 = 6.9;
+const FADE_OUT_END: f32 = 7.3;
+
+const DASH_LTR_START: f32 = 2.3;
+const DASH_LTR_END: f32 = 2.8;
+const DASH_RTL_START: f32 = 4.7;
+const DASH_RTL_END: f32 = 5.2;
+
+const X_REST: f32 = 250.0;
+const X_SPAN: f32 = 1420.0;
+const STREAK_Y: f32 = 924.0;
+const CORE_RADIUS: f32 = 9.0;
+const GLOW_RADIUS: f32 = 17.0;
+
+#[tellur_core::component(vector)]
+pub fn Streak(time: LocalTime, palette: Palette) -> impl VectorComponent {
+    let p = palette;
+    let visible = time.phase(FADE_IN_START, FADE_IN_END).get()
+        * (1.0 - time.phase(FADE_OUT_START, FADE_OUT_END).get());
+
+    // Two eased dashes share one axis: `fwd - back` rises 0 → 1 on the
+    // left-to-right dash and falls back 1 → 0 on the return. Both phases
+    // saturate outside their windows, so the baked position is constant
+    // during every rest.
+    let fwd = time
+        .phase(DASH_LTR_START, DASH_LTR_END)
+        .eased(Easing::InOutQuint);
+    let back = time
+        .phase(DASH_RTL_START, DASH_RTL_END)
+        .eased(Easing::InOutQuint);
+    let x = X_REST + (fwd.get() - back.get()) * X_SPAN;
+
+    VectorLayer::builder()
+        .size(SCENE_SIZE)
+        .child(
+            Circle::builder()
+                .radius(GLOW_RADIUS)
+                .fill(p.pink.with_alpha(0.22 * visible))
+                .place_at(Vec2(x - GLOW_RADIUS, STREAK_Y - GLOW_RADIUS)),
+        )
+        .child(
+            Circle::builder()
+                .radius(CORE_RADIUS)
+                .fill(p.cyan.with_alpha(visible))
+                .place_at(Vec2(x - CORE_RADIUS, STREAK_Y - CORE_RADIUS)),
+        )
+        .build()
+}

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -383,6 +383,9 @@ impl PreviewApp {
             q.insert("time".to_owned(), seconds.to_string());
             q.insert("width".to_owned(), resolution.width.to_string());
             q.insert("height".to_owned(), resolution.height.to_string());
+            if let Some(motion_blur) = query.get("motion_blur") {
+                q.insert("motion_blur".to_owned(), motion_blur.clone());
+            }
             if let Some(id) = &timeline_id {
                 q.insert("timeline".to_owned(), id.clone());
             }
@@ -441,6 +444,9 @@ impl PreviewApp {
             q.insert("format".to_owned(), "rgba".to_owned());
             q.insert("width".to_owned(), resolution.width.to_string());
             q.insert("height".to_owned(), resolution.height.to_string());
+            if let Some(motion_blur) = query.get("motion_blur") {
+                q.insert("motion_blur".to_owned(), motion_blur.clone());
+            }
             if let Some(id) = &timeline_id {
                 q.insert("timeline".to_owned(), id.clone());
             }
@@ -460,7 +466,9 @@ impl PreviewApp {
         timeline_id: &str,
         seconds: f32,
         resolution: Resolution,
+        motion_blur: bool,
     ) -> Result<VideoFrame, Box<dyn Error>> {
+        self.ctx.set_motion_blur_enabled(motion_blur);
         let before = self.ctx.metrics();
         let render_start = Instant::now();
         let image = self
@@ -559,6 +567,7 @@ impl PreviewApp {
         // instead of erroring with `timeline did not produce a frame`.
         let seconds = clamp_to_renderable(seconds, info.duration, fps);
         let resolution = request_resolution(query, self.resolution);
+        self.ctx.set_motion_blur_enabled(request_motion_blur(query));
 
         let before = self.ctx.metrics();
         let render_start = Instant::now();
@@ -609,6 +618,7 @@ struct VideoStreamSetup {
     resolution: Resolution,
     gop: u32,
     crf: u8,
+    motion_blur: bool,
     start_seconds: f32,
     cache_control: &'static str,
     realtime: bool,
@@ -729,6 +739,7 @@ fn handle_video_stream(
             resolution,
             gop,
             crf,
+            motion_blur: request_motion_blur(&query),
             start_seconds,
             cache_control: if cacheable {
                 "public, max-age=31536000, immutable"
@@ -961,7 +972,12 @@ fn handle_video_stream(
             let mut app = app
                 .lock()
                 .map_err(|_| -> Box<dyn Error> { "preview app lock poisoned".into() })?;
-            let frame = app.render_video_rgba(&setup.timeline_id, seconds, setup.resolution)?;
+            let frame = app.render_video_rgba(
+                &setup.timeline_id,
+                seconds,
+                setup.resolution,
+                setup.motion_blur,
+            )?;
             if app.verbose {
                 println!(
                     "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_available={} gpu_ops={} gpu_readbacks={}",
@@ -1126,6 +1142,14 @@ fn request_fps(query: &HashMap<String, String>, default_fps: u32) -> u32 {
         .and_then(|v| v.parse::<u32>().ok())
         .filter(|fps| *fps > 0)
         .unwrap_or(default_fps.max(1))
+}
+
+/// The preview's motion-blur toggle; on unless the request says otherwise.
+fn request_motion_blur(query: &HashMap<String, String>) -> bool {
+    !matches!(
+        query.get("motion_blur").map(String::as_str),
+        Some("0") | Some("false")
+    )
 }
 
 fn request_resolution(query: &HashMap<String, String>, default: Resolution) -> Resolution {

--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -50,6 +50,7 @@ export function App() {
     DEFAULT_PREVIEW_RESOLUTION,
   );
   const [fps, setFps] = useState(30);
+  const [motionBlur, setMotionBlur] = useState(true);
   const [timelineViewport, setTimelineViewport] = useState<TimelineViewport>({
     start: 0,
     zoom: DEFAULT_TIMELINE_ZOOM,
@@ -124,6 +125,7 @@ export function App() {
     timeline,
     resolution,
     fps,
+    motionBlur,
   });
 
   useEffect(() => {
@@ -263,12 +265,14 @@ export function App() {
               measuredFps={preview.state.playing ? measuredFps : fps}
               resolution={resolution}
               resolutionOptions={resolutionOptions}
+              motionBlur={motionBlur}
               playing={preview.state.playing}
               onTogglePlay={preview.togglePlay}
               onStep={preview.stepFrame}
               onRewind={preview.rewindToStart}
               onResolutionChange={changeResolution}
               onFpsChange={setFps}
+              onMotionBlurChange={setMotionBlur}
             />
           </section>
           <Inspector node={selectedNode} fps={fps} />

--- a/tellur-live/web/src/api.ts
+++ b/tellur-live/web/src/api.ts
@@ -33,6 +33,7 @@ export interface FrameRequestParams {
   width: number;
   height: number;
   fps: number;
+  motionBlur: boolean;
   cacheKey: string;
 }
 
@@ -43,6 +44,7 @@ export function frameUrl(params: FrameRequestParams): string {
     width: String(params.width),
     height: String(params.height),
     fps: String(params.fps),
+    motion_blur: params.motionBlur ? "1" : "0",
     format: "png",
     v: params.cacheKey,
   });
@@ -62,6 +64,7 @@ export function videoUrl(params: VideoRequestParams): string {
     width: String(params.width),
     height: String(params.height),
     fps: String(params.fps),
+    motion_blur: params.motionBlur ? "1" : "0",
     gop: String(params.gop),
     crf: String(params.crf),
     v: params.cacheKey,

--- a/tellur-live/web/src/components/Transport.tsx
+++ b/tellur-live/web/src/components/Transport.tsx
@@ -13,12 +13,14 @@ interface TransportProps {
   measuredFps: number;
   resolution: PreviewResolution;
   resolutionOptions: ResolutionOption[];
+  motionBlur: boolean;
   playing: boolean;
   onTogglePlay: () => void;
   onStep: (delta: number) => void;
   onRewind: () => void;
   onResolutionChange: (resolution: PreviewResolution) => void;
   onFpsChange: (fps: number) => void;
+  onMotionBlurChange: (motionBlur: boolean) => void;
 }
 
 const FPS_OPTIONS = [60, 30, 24, 15, 12];
@@ -31,12 +33,14 @@ export function Transport(props: TransportProps) {
     measuredFps,
     resolution,
     resolutionOptions,
+    motionBlur,
     playing,
     onTogglePlay,
     onStep,
     onRewind,
     onResolutionChange,
     onFpsChange,
+    onMotionBlurChange,
   } = props;
   const selectedResolutionKey = resolutionKey(resolution);
 
@@ -98,6 +102,25 @@ export function Transport(props: TransportProps) {
         </button>
       </div>
       <div className="transport__right">
+        <button
+          type="button"
+          className={
+            motionBlur
+              ? "transport__toggle transport__toggle--on"
+              : "transport__toggle"
+          }
+          aria-pressed={motionBlur}
+          aria-label={motionBlur ? "Disable motion blur" : "Enable motion blur"}
+          // Blur after activation so focus doesn't stay on the button and
+          // swallow the global Space/arrow keyboard shortcuts.
+          onClick={(e) => {
+            onMotionBlurChange(!motionBlur);
+            e.currentTarget.blur();
+          }}
+        >
+          <span className="transport__toggle-dot" />
+          Motion Blur
+        </button>
         <label className="transport__control">
           <select
             value={fps}

--- a/tellur-live/web/src/components/Transport.tsx
+++ b/tellur-live/web/src/components/Transport.tsx
@@ -110,7 +110,8 @@ export function Transport(props: TransportProps) {
               : "transport__toggle"
           }
           aria-pressed={motionBlur}
-          aria-label={motionBlur ? "Disable motion blur" : "Enable motion blur"}
+          aria-label="Motion Blur"
+          data-tooltip="Motion Blur"
           // Blur after activation so focus doesn't stay on the button and
           // swallow the global Space/arrow keyboard shortcuts.
           onClick={(e) => {
@@ -118,8 +119,7 @@ export function Transport(props: TransportProps) {
             e.currentTarget.blur();
           }}
         >
-          <span className="transport__toggle-dot" />
-          Motion Blur
+          <MotionBlurIcon size={15} strokeWidth={1.6} />
         </button>
         <label className="transport__control">
           <select
@@ -170,4 +170,28 @@ export function Transport(props: TransportProps) {
 
 function resolutionKey(resolution: PreviewResolution): string {
   return `${resolution.width}x${resolution.height}`;
+}
+
+// Lucide has no motion-blur glyph, so this hand-rolled icon follows the same
+// conventions (24px viewBox, stroked shapes, round caps): a ball with speed
+// trails fading off behind it.
+function MotionBlurIcon(props: { size: number; strokeWidth: number }) {
+  return (
+    <svg
+      width={props.size}
+      height={props.size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={props.strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="15" cy="12" r="6" />
+      <path d="M4 7h3" />
+      <path d="M2 12h4" />
+      <path d="M4 17h3" />
+    </svg>
+  );
 }

--- a/tellur-live/web/src/mediaCache.ts
+++ b/tellur-live/web/src/mediaCache.ts
@@ -67,6 +67,7 @@ export interface ChunkGroupParams {
   width: number;
   height: number;
   fps: number;
+  motionBlur: boolean;
   gop: number;
   crf: number;
 }
@@ -94,6 +95,7 @@ export function groupKeyOf(p: ChunkGroupParams): string {
     p.timelineId,
     `${p.width}x${p.height}`,
     String(p.fps),
+    p.motionBlur ? "mb1" : "mb0",
     String(p.gop),
     String(p.crf),
   ].join("|");

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -40,6 +40,7 @@ export interface PreviewSettings {
   timeline: TimelineInfo | null;
   resolution: PreviewResolution;
   fps: number;
+  motionBlur: boolean;
 }
 
 // Thin React shell over TimelinePlayer (which owns all MSE/cache logic). The hook's
@@ -47,7 +48,7 @@ export interface PreviewSettings {
 // plugin/resolution/fps/timeline "group" changes, mirror the player's events into
 // React state, and fetch the paused/seek PNG still the player asks it to display.
 export function usePreview(settings: PreviewSettings): PreviewControls {
-  const { info, timeline, resolution, fps } = settings;
+  const { info, timeline, resolution, fps, motionBlur } = settings;
   const pluginKey = info?.cacheKey ?? "";
   const timelineId = timeline?.id ?? "";
   const duration = timeline?.duration ?? 0;
@@ -57,8 +58,17 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
 
   const groupKey = useMemo(
     () =>
-      groupKeyOf({ pluginKey, timelineId, width, height, fps, gop, crf: CRF }),
-    [pluginKey, timelineId, width, height, fps, gop],
+      groupKeyOf({
+        pluginKey,
+        timelineId,
+        width,
+        height,
+        fps,
+        motionBlur,
+        gop,
+        crf: CRF,
+      }),
+    [pluginKey, timelineId, width, height, fps, motionBlur, gop],
   );
 
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -104,9 +114,9 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
   }, []);
 
   // (Re)create the player whenever the group identity changes. groupKey folds the
-  // plugin cacheKey, timeline, resolution, fps and encode params — so an unchanged
-  // plugin reload (same cacheKey string from the SSE churn) does NOT recreate it,
-  // while a real plugin/resolution/fps change tears down + rebuilds MSE.
+  // plugin cacheKey, timeline, resolution, fps, motion blur and encode params — so an
+  // unchanged plugin reload (same cacheKey string from the SSE churn) does NOT recreate
+  // it, while a real plugin/resolution/fps/motion-blur change tears down + rebuilds MSE.
   useEffect(() => {
     const video = videoRef.current;
     if (!video || !groupKey || !pluginKey || !timelineId || duration <= 0) {
@@ -124,6 +134,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
         width,
         height,
         fps,
+        motionBlur,
         gop,
         crf: CRF,
         duration: segmentDuration,
@@ -146,6 +157,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
         width,
         height,
         fps,
+        motionBlur,
         cacheKey: pluginKey,
       });
       const token = ++stillTokenRef.current;
@@ -242,7 +254,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
       playerRef.current = null;
       void player?.dispose();
     };
-  }, [groupKey, pluginKey, timelineId, duration, width, height, fps, gop, setSeconds]);
+  }, [groupKey, pluginKey, timelineId, duration, width, height, fps, motionBlur, gop, setSeconds]);
 
   // Revoke the last still URL on unmount.
   useEffect(

--- a/tellur-live/web/src/styles/global.css
+++ b/tellur-live/web/src/styles/global.css
@@ -100,6 +100,44 @@ select option {
   color: var(--text-primary);
 }
 
+/* Generic CSS-only tooltip: any element with a `data-tooltip` attribute grows a
+   small dark pill (same look as the panel heading pills) centered above itself
+   on hover or keyboard focus. Used instead of the native `title` attribute so
+   the styling and show delay match the UI. The pill is click-through and only
+   fades in after a short delay so quick mouse passes don't flash labels. */
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 3px 8px;
+  color: #f2f2f4;
+  background: #3f3f42;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1.4;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.12s, visibility 0.12s;
+  pointer-events: none;
+  z-index: 10;
+}
+
+[data-tooltip]:hover::after,
+[data-tooltip]:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0.3s;
+}
+
 .app {
   display: grid;
   grid-template-rows: var(--header-h) minmax(0, 1fr);
@@ -464,37 +502,29 @@ select option {
   color: var(--text-secondary);
 }
 
-/* On/off toggle button (e.g. Motion Blur) in the right control cluster. Typography
-   matches the bare <select> controls; the small dot carries the on/off state —
-   accent-colored when on, faint when off — with the label dimmed while off. */
+/* Icon-only on/off toggle (e.g. Motion Blur) in the right control cluster. Same
+   geometry as .transport__btn; the state lives in the icon color — accent when
+   on, faint when off (dimmer than plain buttons so "off" reads as a state, not
+   just an idle control). The label is provided by aria-label + data-tooltip. */
 .transport__toggle {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 650;
-  transition: color 0.12s;
+  justify-content: center;
+  width: 20px;
+  height: 24px;
+  color: var(--text-faint);
+  border-radius: 4px;
+  transition: color 0.12s, background 0.12s;
 }
 
 .transport__toggle:hover {
-  color: var(--text-primary);
+  color: var(--text-muted);
+  background: var(--bg-control);
 }
 
-.transport__toggle--on {
-  color: var(--text-secondary);
-}
-
-.transport__toggle-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--text-faint);
-  transition: background 0.12s;
-}
-
-.transport__toggle--on .transport__toggle-dot {
-  background: var(--accent-pink);
+.transport__toggle--on,
+.transport__toggle--on:hover {
+  color: var(--accent-pink);
 }
 
 /* Inspector: a general detail panel for the selected timeline node, sitting to

--- a/tellur-live/web/src/styles/global.css
+++ b/tellur-live/web/src/styles/global.css
@@ -464,6 +464,39 @@ select option {
   color: var(--text-secondary);
 }
 
+/* On/off toggle button (e.g. Motion Blur) in the right control cluster. Typography
+   matches the bare <select> controls; the small dot carries the on/off state —
+   accent-colored when on, faint when off — with the label dimmed while off. */
+.transport__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  transition: color 0.12s;
+}
+
+.transport__toggle:hover {
+  color: var(--text-primary);
+}
+
+.transport__toggle--on {
+  color: var(--text-secondary);
+}
+
+.transport__toggle-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  transition: background 0.12s;
+}
+
+.transport__toggle--on .transport__toggle-dot {
+  background: var(--accent-pink);
+}
+
 /* Inspector: a general detail panel for the selected timeline node, sitting to
    the right of the preview in the top row. Styled to match the other panels
    (panel bg, border, radius) with its own internal padding and a small heading.

--- a/tellur-plugin/src/lib.rs
+++ b/tellur-plugin/src/lib.rs
@@ -37,7 +37,13 @@ pub use tellur_core as __core;
 /// so a stale 2-method `v1` `.so` would dlsym/transmute fine yet hit a
 /// vtable-slot UB at call time. Renaming the symbol makes the lookup fail
 /// cleanly on an old plugin instead.
-pub const ENTRY_SYMBOL: &[u8] = b"tellur_timeline_collection_v2\0";
+///
+/// Bumped to `v3` for motion blur: `RenderContext` (which the host passes
+/// across the boundary as `&mut dyn`) gained the `motion_blur_enabled`
+/// vtable slot and `GpuRasterBackend` gained `temporal_average`, so a `v2`
+/// plugin calling through a `v3` host context would hit the same class of
+/// vtable mismatch.
+pub const ENTRY_SYMBOL: &[u8] = b"tellur_timeline_collection_v3\0";
 
 /// The signature of the [`ENTRY_SYMBOL`] entry point a plugin exports.
 pub type EntryFn = unsafe extern "Rust" fn() -> Box<dyn TimelineCollection>;
@@ -270,14 +276,14 @@ impl<T: Timeline + Send + 'static> TimelineComponent for LegacyTimeline<T> {
 macro_rules! export_timeline {
     ($id:expr, $title:expr, $builder:path) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v2(
+        pub extern "Rust" fn tellur_timeline_collection_v3(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($crate::single_timeline($id, $title, $builder()))
         }
     };
     ($id:expr, $title:expr, $builder:path, canvas = ($w:expr, $h:expr)) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v2(
+        pub extern "Rust" fn tellur_timeline_collection_v3(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($crate::single_timeline_with_canvas(
                 $id,
@@ -301,7 +307,7 @@ macro_rules! export_timeline {
 macro_rules! export_legacy_timeline {
     ($id:expr, $title:expr, $builder:path) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v2(
+        pub extern "Rust" fn tellur_timeline_collection_v3(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($crate::single_timeline(
                 $id,
@@ -317,7 +323,7 @@ macro_rules! export_legacy_timeline {
 macro_rules! export_timeline_collection {
     ($builder:path) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v2(
+        pub extern "Rust" fn tellur_timeline_collection_v3(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($builder())
         }

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -25,6 +25,8 @@ pub struct GpuRenderer {
     outline_pipeline: wgpu::ComputePipeline,
     texture_to_buffer_pipeline: wgpu::ComputePipeline,
     fill_pipeline: wgpu::ComputePipeline,
+    motion_accum_pipeline: wgpu::ComputePipeline,
+    motion_resolve_pipeline: wgpu::ComputePipeline,
     vello_renderer: Option<vello::Renderer>,
     stats: GpuRenderStats,
     // Per-resolution scratch reused across frames instead of reallocated each
@@ -42,12 +44,18 @@ pub struct GpuRenderStats {
     pub outlines: u64,
     pub rasterizes: u64,
     pub fills: u64,
+    pub temporal_averages: u64,
     pub readbacks: u64,
 }
 
 impl GpuRenderStats {
     pub fn total_ops(self) -> u64 {
-        self.composites + self.drop_shadows + self.outlines + self.rasterizes + self.fills
+        self.composites
+            + self.drop_shadows
+            + self.outlines
+            + self.rasterizes
+            + self.fills
+            + self.temporal_averages
     }
 }
 
@@ -146,6 +154,20 @@ struct FillParams {
 unsafe impl bytemuck::Zeroable for FillParams {}
 unsafe impl bytemuck::Pod for FillParams {}
 
+/// Shared by the motion accumulate and resolve passes; the accumulate pass
+/// ignores `total`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct MotionPassParams {
+    width: u32,
+    height: u32,
+    total: u32,
+    _pad0: u32,
+}
+
+unsafe impl bytemuck::Zeroable for MotionPassParams {}
+unsafe impl bytemuck::Pod for MotionPassParams {}
+
 impl GpuRenderer {
     pub fn new() -> Result<Self, String> {
         pollster::block_on(Self::new_async())
@@ -197,6 +219,16 @@ impl GpuRenderer {
                 TEXTURE_TO_BUFFER_SHADER,
             ),
             fill_pipeline: compute_pipeline(&device, "tellur-solid-fill", FILL_SHADER),
+            motion_accum_pipeline: compute_pipeline(
+                &device,
+                "tellur-motion-accum",
+                &format!("{COMMON_WGSL}{MOTION_ACCUM_SHADER}"),
+            ),
+            motion_resolve_pipeline: compute_pipeline(
+                &device,
+                "tellur-motion-resolve",
+                &format!("{COMMON_WGSL}{MOTION_RESOLVE_SHADER}"),
+            ),
             device,
             queue,
             vello_renderer: None,
@@ -767,6 +799,75 @@ impl GpuRasterBackend for GpuRenderer {
         let image = self.filled_image(target, packed);
         self.stats.fills = self.stats.fills.saturating_add(1);
         Some(self.raster_image(image))
+    }
+
+    fn temporal_average(
+        &mut self,
+        target: Resolution,
+        frames: &[&RasterImage],
+        total: u32,
+    ) -> Option<RasterImage> {
+        if total == 0 || frames.is_empty() || frames.len() as u32 > total {
+            return None;
+        }
+        // Resolve every source up front so an unsupported frame bails before
+        // any GPU work is encoded.
+        let mut sources = Vec::with_capacity(frames.len());
+        for frame in frames {
+            if frame.width() != target.width || frame.height() != target.height {
+                return None;
+            }
+            let src = self.image_ref(frame)?;
+            if src.format != PixelFormat::Rgba8 {
+                return None;
+            }
+            sources.push(src);
+        }
+
+        // Premultiplied u32 channel sums, 4 words per pixel. A fresh wgpu
+        // buffer is zero-initialized, so accumulation starts from zero
+        // without an explicit clear pass.
+        let acc_len = (target.width as u64) * (target.height as u64) * 16;
+        let acc = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tellur-gpu-motion-acc"),
+            size: acc_len,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+        let out = self.empty_image(target);
+
+        let params = MotionPassParams {
+            width: target.width,
+            height: target.height,
+            total,
+            _pad0: 0,
+        };
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("tellur-gpu-temporal-average"),
+            });
+        for src in &sources {
+            dispatch_three_buffer(
+                &self.device,
+                &mut encoder,
+                &self.motion_accum_pipeline,
+                [&acc, &src.buffer],
+                &params,
+                DispatchSize::new(target.width, target.height),
+            );
+        }
+        dispatch_three_buffer(
+            &self.device,
+            &mut encoder,
+            &self.motion_resolve_pipeline,
+            [&acc, &out.buffer],
+            &params,
+            DispatchSize::new(target.width, target.height),
+        );
+        self.queue.submit(Some(encoder.finish()));
+        self.stats.temporal_averages = self.stats.temporal_averages.saturating_add(1);
+        Some(self.raster_image(out))
     }
 
     fn readback(&mut self, image: RasterImage) -> Option<CpuRasterImage> {
@@ -1445,6 +1546,76 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
 }
 "#;
 
+// One shutter sample into the premultiplied u32 sums (4 words per pixel).
+// Integer math throughout so the GPU result is byte-identical to the CPU
+// fallback in `motion_blur.rs` — keep the two in lockstep.
+const MOTION_ACCUM_SHADER: &str = r#"
+struct Params {
+    width: u32,
+    height: u32,
+    total: u32,
+    pad0: u32,
+}
+
+@group(0) @binding(0) var<storage, read_write> acc: array<u32>;
+@group(0) @binding(1) var<storage, read> src: array<u32>;
+@group(0) @binding(2) var<storage, read> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let x = id.x;
+    let y = id.y;
+    if (x >= params.width || y >= params.height) {
+        return;
+    }
+    let idx = y * params.width + x;
+    let s = unpack_rgba(src[idx]);
+    let base = idx * 4u;
+    acc[base] = acc[base] + s.x * s.w;
+    acc[base + 1u] = acc[base + 1u] + s.y * s.w;
+    acc[base + 2u] = acc[base + 2u] + s.z * s.w;
+    acc[base + 3u] = acc[base + 3u] + s.w;
+}
+"#;
+
+// Resolve the sums into straight-alpha RGBA8: color = the alpha-weighted
+// average of the straight source colors (rounded), alpha = the mean over
+// ALL `total` shutter samples — missing samples counted as transparent.
+const MOTION_RESOLVE_SHADER: &str = r#"
+struct Params {
+    width: u32,
+    height: u32,
+    total: u32,
+    pad0: u32,
+}
+
+@group(0) @binding(0) var<storage, read> acc: array<u32>;
+@group(0) @binding(1) var<storage, read_write> dst: array<u32>;
+@group(0) @binding(2) var<storage, read> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let x = id.x;
+    let y = id.y;
+    if (x >= params.width || y >= params.height) {
+        return;
+    }
+    let idx = y * params.width + x;
+    let base = idx * 4u;
+    let sum_a = acc[base + 3u];
+    if (sum_a == 0u) {
+        dst[idx] = 0u;
+        return;
+    }
+    let half = sum_a / 2u;
+    let r = min((acc[base] + half) / sum_a, 255u);
+    let g = min((acc[base + 1u] + half) / sum_a, 255u);
+    let b = min((acc[base + 2u] + half) / sum_a, 255u);
+    let a = min((sum_a + params.total / 2u) / params.total, 255u);
+    dst[idx] = pack_rgba(vec4<u32>(r, g, b, a));
+}
+"#;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1471,6 +1642,49 @@ mod tests {
 
     fn readback(gpu: &mut GpuRenderer, image: RasterImage) -> CpuRasterImage {
         GpuRasterBackend::readback(gpu, image).expect("GPU image should read back")
+    }
+
+    #[test]
+    #[ignore = "requires a GPU adapter"]
+    fn temporal_average_matches_cpu_average() {
+        let Some(mut gpu) = gpu_or_skip() else {
+            return;
+        };
+        let target = Resolution::new(2, 2);
+        let a = image(
+            2,
+            2,
+            &[
+                255, 0, 0, 255, //
+                0, 255, 0, 128, //
+                0, 0, 255, 0, //
+                10, 20, 30, 40,
+            ],
+        );
+        let b = image(
+            2,
+            2,
+            &[
+                0, 0, 0, 0, //
+                255, 255, 255, 255, //
+                0, 0, 255, 64, //
+                200, 100, 50, 130,
+            ],
+        );
+        // total = 3 leaves one sample missing, exercising the fade divisor.
+        let total = 3;
+
+        let rendered =
+            GpuRasterBackend::temporal_average(&mut gpu, target, &[&a, &b], total).unwrap();
+        let rendered = readback(&mut gpu, rendered);
+
+        let cpu_frames: Vec<CpuRasterImage> = [&a, &b]
+            .iter()
+            .map(|img| img.as_cpu().expect("test inputs are CPU images").clone())
+            .collect();
+        let expected = crate::motion_blur::average_frames_cpu(&cpu_frames, total, target);
+        let expected = expected.as_cpu().expect("CPU average is a CPU image");
+        assert_eq!(rendered.pixels.as_ref(), expected.pixels.as_ref());
     }
 
     #[test]

--- a/tellur-renderer/src/lib.rs
+++ b/tellur-renderer/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod gpu;
+pub mod motion_blur;
 pub mod outline;
 pub mod rasterize;
 pub mod render_context;
@@ -6,6 +7,7 @@ pub mod shadow;
 pub mod subtitle;
 pub mod video;
 
+pub use motion_blur::MotionBlur;
 pub use outline::Outline;
 pub use rasterize::{Rasterizable, RasterizableBuilder, Rasterize};
 pub use render_context::CachingRenderContext;

--- a/tellur-renderer/src/motion_blur.rs
+++ b/tellur-renderer/src/motion_blur.rs
@@ -1,0 +1,397 @@
+//! Temporal motion blur for timeline components.
+//!
+//! [`MotionBlur`] wraps a [`TimelineComponent`] and, each frame, evaluates it
+//! at `samples` sub-clocks spread across a trailing shutter window
+//! `[t - shutter, t]`, then averages the resulting frames. A frame with
+//! motion blur is a pure function of the scene over the shutter interval —
+//! not of the instant `t` — and this component encodes exactly that: the
+//! per-sample state is baked into the child's raster tree by the shifted
+//! [`Clock`], so every sub-frame memoizes through `ctx.render` under the
+//! existing content-hash cache key with NO cache changes:
+//!
+//! - While the child animates, each sample bakes a different state, so each
+//!   sub-frame earns its own cache entry (and overlapping shutters across
+//!   frames share entries).
+//! - Once the child's animation saturates (every Phase clamped), all samples
+//!   bake the SAME state, every `ctx.render` returns one shared cache entry,
+//!   and the average short-circuits to that entry — a static stretch costs
+//!   the same as having no blur at all.
+//!
+//! The averaging itself happens at the IMAGE layer (like a container's
+//! per-frame composite), so a blurred result can never alias an unblurred
+//! cache entry — which is what makes the preview's motion-blur toggle
+//! ([`RenderContext::motion_blur_enabled`]) safe to flip at any time.
+//!
+//! Apply the wrapper BEFORE the placement verb (`MotionBlur` around the
+//! component, then `.at(..)` / `.fill()`): containers detect `.fill()` by
+//! downcasting their direct child to `Placed`, and an opaque wrapper around
+//! the `Placed` would hide it.
+
+use tellur_core::audio::AudioMix;
+use tellur_core::geometry::Vec2;
+use tellur_core::raster::{CpuRasterImage, PixelFormat, RasterImage, Resolution};
+use tellur_core::render_context::RenderContext;
+use tellur_core::timeline_component::{
+    Arrangement, AudioBuffer, Clock, Cue, ResolveCtx, TimelineComponent,
+};
+use tellur_core::Keyable;
+
+/// Hard cap on the per-frame sample count. Keeps the u32 premultiplied
+/// accumulators (CPU and GPU alike) far from overflow: 64 × 255 × 255 ≈
+/// 4.2M ≪ u32::MAX.
+const MAX_SAMPLES: u32 = 64;
+
+#[tellur_core::component(timeline)]
+#[derive(Keyable)]
+pub struct MotionBlur {
+    /// How long the virtual shutter stays open, in the child's local
+    /// seconds. Samples cover the trailing window `[t - shutter, t]`.
+    pub shutter: f32,
+    /// How many sub-clocks to sample across the shutter (clamped to
+    /// `1..=64`). The current frame is always one of them.
+    #[builder(default = 8)]
+    pub samples: u32,
+    #[builder(into)]
+    pub child: Box<dyn TimelineComponent + Send>,
+}
+
+impl TimelineComponent for MotionBlur {
+    fn duration(&self) -> Option<f32> {
+        self.child.duration()
+    }
+
+    fn measure(&self) -> Option<f32> {
+        self.child.measure()
+    }
+
+    fn resolve(&self, abs_start: f32, out: &mut ResolveCtx) -> f32 {
+        self.child.resolve(abs_start, out)
+    }
+
+    fn frame(
+        &self,
+        clock: Clock<'_>,
+        canvas: Vec2,
+        target: Resolution,
+        ctx: &mut dyn RenderContext,
+    ) -> Option<RasterImage> {
+        let total = self.samples.clamp(1, MAX_SAMPLES);
+        if total == 1 || self.shutter <= 0.0 || !ctx.motion_blur_enabled() {
+            return self.child.frame(clock, canvas, target, ctx);
+        }
+
+        // Trailing shutter: sample 0 is the current frame, sample `total-1`
+        // reaches back the full shutter. Offsets are derived from the two
+        // baked params only, so sampling is deterministic.
+        let frames: Vec<Option<RasterImage>> = (0..total)
+            .map(|i| {
+                let dt = -self.shutter * (i as f32 / (total - 1) as f32);
+                self.child.frame(clock.shifted(dt), canvas, target, ctx)
+            })
+            .collect();
+
+        let present: Vec<&RasterImage> = frames.iter().flatten().collect();
+        // The child contributed nothing anywhere in the shutter window.
+        if present.is_empty() {
+            return None;
+        }
+
+        // Static short-circuit: when every sample resolved to one shared
+        // cache entry, the average IS that entry — skip the accumulate so a
+        // saturated stretch costs the same as no blur. (Shared storage is a
+        // sufficient identity check; samples rendered into distinct buffers
+        // just take the full path.)
+        if present.len() == frames.len()
+            && present.iter().all(|frame| frame.shares_storage(present[0]))
+        {
+            return frames.into_iter().next().unwrap();
+        }
+
+        // Every present frame must be a target-sized RGBA8 image (the frame
+        // contract). If a child violates that, degrade to the unblurred
+        // current sample instead of mis-compositing.
+        if present.iter().any(|frame| {
+            frame.width() != target.width
+                || frame.height() != target.height
+                || frame.format() != PixelFormat::Rgba8
+        }) {
+            return frames.into_iter().next().unwrap();
+        }
+
+        if ctx.prefers_gpu() {
+            if let Some(gpu) = ctx.gpu_backend() {
+                if let Some(image) = gpu.temporal_average(target, &present, total) {
+                    return Some(image);
+                }
+            }
+        }
+
+        drop(present);
+        let cpu_frames: Vec<CpuRasterImage> = frames
+            .into_iter()
+            .flatten()
+            .map(|frame| ctx.readback(frame))
+            .collect();
+        Some(average_frames_cpu(&cpu_frames, total, target))
+    }
+
+    fn samples(&self, clock: Clock<'_>, window: f32) -> Option<AudioBuffer> {
+        // Audio is never temporally averaged; forward both channels intact.
+        self.child.samples(clock, window)
+    }
+
+    fn mix_into(&self, mix: &mut AudioMix, start_secs: f32, speed: f32) {
+        self.child.mix_into(mix, start_secs, speed);
+    }
+
+    fn cues(&self, offset: f32) -> Vec<Cue> {
+        self.child.cues(offset)
+    }
+
+    fn arrangement(&self, offset: f32) -> Arrangement {
+        // Transparent in the live panel: the wrapper adds no tree level.
+        self.child.arrangement(offset)
+    }
+}
+
+/// CPU twin of the GPU accumulate/resolve pair in `gpu.rs` — premultiplied
+/// u32 channel sums, then color = the alpha-weighted average of the straight
+/// source colors and alpha = the mean over ALL `total` shutter samples
+/// (missing samples counted as transparent). Integer math throughout so the
+/// two paths stay byte-identical; change them in lockstep.
+pub(crate) fn average_frames_cpu(
+    frames: &[CpuRasterImage],
+    total: u32,
+    target: Resolution,
+) -> RasterImage {
+    let px = (target.width as usize) * (target.height as usize);
+    let mut acc = vec![0u32; px * 4];
+    for frame in frames {
+        debug_assert_eq!(frame.format, PixelFormat::Rgba8);
+        for (i, p) in frame.pixels.chunks_exact(4).enumerate().take(px) {
+            let a = p[3] as u32;
+            let base = i * 4;
+            acc[base] += p[0] as u32 * a;
+            acc[base + 1] += p[1] as u32 * a;
+            acc[base + 2] += p[2] as u32 * a;
+            acc[base + 3] += a;
+        }
+    }
+    let mut out = vec![0u8; px * 4];
+    for i in 0..px {
+        let base = i * 4;
+        let sum_a = acc[base + 3];
+        if sum_a == 0 {
+            continue;
+        }
+        let half = sum_a / 2;
+        out[base] = ((acc[base] + half) / sum_a).min(255) as u8;
+        out[base + 1] = ((acc[base + 1] + half) / sum_a).min(255) as u8;
+        out[base + 2] = ((acc[base + 2] + half) / sum_a).min(255) as u8;
+        out[base + 3] = ((sum_a + total / 2) / total).min(255) as u8;
+    }
+    RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tellur_core::geometry::Constraints;
+    use tellur_core::raster::RasterComponent;
+    use tellur_core::render_context::{GpuPreference, PassThrough};
+    use tellur_core::time::{LocalTime, Time, TimelineTime};
+    use tellur_core::timeline_component::{NodeKind, TriggerTable};
+
+    use crate::render_context::CachingRenderContext;
+
+    /// A timed leaf that paints one opaque white pixel at
+    /// `x = round(local seconds)` of a `target`-wide strip, and nothing at
+    /// all before `appear_at`. Fresh buffer every call (a timeline leaf is
+    /// never memoized), so it exercises the full averaging path.
+    #[derive(PartialEq, Hash)]
+    struct MovingDot {
+        appear_at_ms: i64,
+    }
+
+    impl TimelineComponent for MovingDot {
+        fn duration(&self) -> Option<f32> {
+            Some(10.0)
+        }
+
+        fn frame(
+            &self,
+            clock: Clock<'_>,
+            _canvas: Vec2,
+            target: Resolution,
+            _ctx: &mut dyn RenderContext,
+        ) -> Option<RasterImage> {
+            let t = clock.local().seconds();
+            if t < self.appear_at_ms as f32 / 1000.0 {
+                return None;
+            }
+            let mut pixels = vec![0u8; (target.width * target.height * 4) as usize];
+            let x = t.round() as i64;
+            if (0..target.width as i64).contains(&x) {
+                let base = (x as usize) * 4;
+                pixels[base..base + 4].copy_from_slice(&[255, 255, 255, 255]);
+            }
+            Some(RasterImage::cpu(
+                target.width,
+                target.height,
+                PixelFormat::Rgba8,
+                pixels,
+            ))
+        }
+
+        fn arrangement(&self, offset: f32) -> Arrangement {
+            Arrangement {
+                kind: NodeKind::Video,
+                label: String::new(),
+                name: None,
+                source: None,
+                start: offset,
+                end: offset + 10.0,
+                trim: None,
+                triggers: Vec::new(),
+                children: Vec::new(),
+            }
+        }
+    }
+
+    fn clock_at(table: &TriggerTable, t: f32) -> Clock<'_> {
+        Clock::new(TimelineTime::new(t), LocalTime::new(t), table)
+    }
+
+    fn blur(shutter: f32, samples: u32, appear_at_ms: i64) -> MotionBlur {
+        MotionBlur {
+            shutter,
+            samples,
+            child: Box::new(MovingDot { appear_at_ms }),
+        }
+    }
+
+    #[test]
+    fn averages_across_the_shutter() {
+        let table = TriggerTable::new();
+        let mut ctx = PassThrough;
+        // Two samples one second apart land the dot on x=1 (current) and
+        // x=0 (one shutter back): each position is lit by 1 of 2 samples,
+        // so both come out white at alpha (255 + 1) / 2 = 128.
+        let image = blur(1.0, 2, 0)
+            .frame(
+                clock_at(&table, 1.0),
+                Vec2(3.0, 1.0),
+                Resolution::new(3, 1),
+                &mut ctx,
+            )
+            .expect("dot is visible");
+        let cpu = ctx.readback(image);
+        assert_eq!(
+            cpu.pixels.as_ref(),
+            &[255, 255, 255, 128, 255, 255, 255, 128, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn missing_samples_fade_instead_of_brightening() {
+        let table = TriggerTable::new();
+        let mut ctx = PassThrough;
+        // The dot appears at t=0.5, so the t=0.0 sample contributes nothing:
+        // the lone present sample still divides by total=2.
+        let image = blur(1.0, 2, 500)
+            .frame(
+                clock_at(&table, 1.0),
+                Vec2(3.0, 1.0),
+                Resolution::new(3, 1),
+                &mut ctx,
+            )
+            .expect("dot is visible at the current sample");
+        let cpu = ctx.readback(image);
+        assert_eq!(
+            cpu.pixels.as_ref(),
+            &[0, 0, 0, 0, 255, 255, 255, 128, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn fully_absent_shutter_returns_none() {
+        let table = TriggerTable::new();
+        let mut ctx = PassThrough;
+        assert!(blur(1.0, 2, 5_000)
+            .frame(
+                clock_at(&table, 1.0),
+                Vec2(3.0, 1.0),
+                Resolution::new(3, 1),
+                &mut ctx
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn disabled_context_renders_the_unblurred_frame() {
+        let table = TriggerTable::new();
+        let mut ctx = CachingRenderContext::new().with_gpu_preference(GpuPreference::Disabled);
+        ctx.set_motion_blur_enabled(false);
+        let image = blur(1.0, 2, 0)
+            .frame(
+                clock_at(&table, 1.0),
+                Vec2(3.0, 1.0),
+                Resolution::new(3, 1),
+                &mut ctx,
+            )
+            .expect("dot is visible");
+        let cpu = ctx.readback(image);
+        // Only the current sample, at full alpha — no shutter trail.
+        assert_eq!(
+            cpu.pixels.as_ref(),
+            &[0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 0]
+        );
+    }
+
+    /// A timeless raster leaf: routed through `ctx.render` by the blanket
+    /// `RasterComponent → TimelineComponent` impl, so identical samples
+    /// resolve to one shared cache entry.
+    #[derive(PartialEq, Hash)]
+    struct StaticSquare;
+
+    impl RasterComponent for StaticSquare {
+        fn layout(&self, _constraints: Constraints) -> Vec2 {
+            Vec2(2.0, 2.0)
+        }
+
+        fn render(
+            &self,
+            _size: Vec2,
+            target: Resolution,
+            _ctx: &mut dyn RenderContext,
+        ) -> RasterImage {
+            let pixels = vec![200u8; (target.width * target.height * 4) as usize];
+            RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, pixels)
+        }
+    }
+
+    #[test]
+    fn static_subtree_short_circuits_to_the_cache_entry() {
+        let table = TriggerTable::new();
+        let mut ctx = CachingRenderContext::new().with_gpu_preference(GpuPreference::Disabled);
+        let blurred = MotionBlur {
+            shutter: 1.0,
+            samples: 4,
+            child: Box::new(StaticSquare),
+        };
+        let size = Vec2(2.0, 2.0);
+        let target = Resolution::new(2, 2);
+        let first = blurred
+            .frame(clock_at(&table, 1.0), size, target, &mut ctx)
+            .expect("visible");
+        let second = blurred
+            .frame(clock_at(&table, 5.0), size, target, &mut ctx)
+            .expect("visible");
+        // Both frames are the SAME cache entry: the average short-circuited
+        // instead of re-accumulating (an averaged copy would live in a fresh
+        // buffer and alpha-divide cleanly, hiding the regression).
+        assert!(first.shares_storage(&second));
+        let cpu = ctx.readback(first);
+        assert_eq!(cpu.pixels.as_ref(), &[200u8; 2 * 2 * 4]);
+    }
+}

--- a/tellur-renderer/src/render_context.rs
+++ b/tellur-renderer/src/render_context.rs
@@ -172,7 +172,7 @@ impl fmt::Display for CacheMetrics {
         )?;
         writeln!(
             f,
-            "GPU    preference={:?}, attempted={}, available={}, ops={} (composite {}, shadow {}, outline {}, rasterize {}, fill {}, readback {})",
+            "GPU    preference={:?}, attempted={}, available={}, ops={} (composite {}, shadow {}, outline {}, rasterize {}, fill {}, temporal_avg {}, readback {})",
             self.gpu_preference,
             self.gpu_init_attempted,
             self.gpu_available,
@@ -182,6 +182,7 @@ impl fmt::Display for CacheMetrics {
             self.gpu.outlines,
             self.gpu.rasterizes,
             self.gpu.fills,
+            self.gpu.temporal_averages,
             self.gpu.readbacks,
         )?;
         if !self.per_type.is_empty() {
@@ -266,6 +267,7 @@ pub struct CachingRenderContext {
     gpu_preference: GpuPreference,
     gpu: Option<GpuRenderer>,
     gpu_init_attempted: bool,
+    motion_blur_enabled: bool,
     // Running total of every `ctx.render` call's inclusive duration.
     // A `render` invocation snapshots this on entry and re-reads it on
     // exit to derive how much time was spent inside nested child
@@ -296,6 +298,7 @@ impl CachingRenderContext {
             gpu_preference: GpuPreference::Auto,
             gpu: None,
             gpu_init_attempted: false,
+            motion_blur_enabled: true,
             total_render_time: Duration::ZERO,
         }
     }
@@ -307,6 +310,16 @@ impl CachingRenderContext {
 
     pub fn set_gpu_preference(&mut self, gpu_preference: GpuPreference) {
         self.gpu_preference = gpu_preference;
+    }
+
+    /// Toggles the [`RenderContext::motion_blur_enabled`] policy signal.
+    ///
+    /// Cache-safe in either direction: temporal effects average their child
+    /// frames at the IMAGE layer (never through a `ctx.render` cache slot),
+    /// so flipping the toggle changes which sub-frames get rendered but
+    /// never aliases a blurred result with an unblurred cache entry.
+    pub fn set_motion_blur_enabled(&mut self, enabled: bool) {
+        self.motion_blur_enabled = enabled;
     }
 
     fn gpu_backend_mut(&mut self) -> Option<&mut GpuRenderer> {
@@ -448,6 +461,10 @@ impl RenderContext for CachingRenderContext {
     fn gpu_backend(&mut self) -> Option<&mut dyn GpuRasterBackend> {
         self.gpu_backend_mut()
             .map(|gpu| gpu as &mut dyn GpuRasterBackend)
+    }
+
+    fn motion_blur_enabled(&self) -> bool {
+        self.motion_blur_enabled
     }
 
     fn render(


### PR DESCRIPTION
Adds temporal motion blur as a `MotionBlur` timeline component: each frame, the child is evaluated at N sub-clocks across a trailing shutter window `[t − shutter, t]` and the resulting frames are averaged on the GPU. A blurred frame is treated as a pure function of the shutter interval — each sample bakes its own state into the child's raster tree, so sub-frames memoize through the existing content-hash cache with no cache-key changes, and a static stretch short-circuits back to a single shared cache entry. The live preview gains a motion-blur toggle, and the demo scene gains a streak comet that showcases the effect. 17 files (+973 / −16) across `tellur-core`, `tellur-renderer`, `tellur-plugin`, and `tellur-live`.

## Motion blur engine (`tellur-core`, `tellur-renderer`)
- `Clock::shifted(dt)` shifts both time axes — the sampling primitive for temporal effects; `MotionBlur { shutter, samples, child }` wraps any `TimelineComponent` and averages its shutter samples.
- Cache coherence falls out of the existing design: animated stretches bake distinct per-sample states (own cache entries, shared across overlapping shutters), while static stretches collapse to one entry via a storage-identity short-circuit (`RasterImage::shares_storage`), costing the same as no blur.
- GPU accumulate/resolve compute kernels average in premultiplied u32 integer space and match the CPU fallback byte-for-byte (covered by a GPU smoke test); missing samples (a child absent for part of the shutter) count as transparent, so clips fade instead of brightening.

## Preview toggle (`tellur-live`)
- `RenderContext::motion_blur_enabled` (default on) is a policy signal like `gpu_preference`; the server threads a `motion_blur` query param through `/api/frame`, `/api/stream`, and `/api/video.mp4`, and the web UI gets an icon-button toggle with a CSS tooltip in the transport bar.
- Media-cache keys include the toggle (`mb1`/`mb0`), so blurred and unblurred segments cache separately and flipping the toggle back reuses existing chunks.
- The `RenderContext` / `GpuRasterBackend` vtables changed, so the plugin entry symbol bumps to `tellur_timeline_collection_v3` (a stale plugin fails to resolve cleanly instead of hitting vtable UB).

## Demo (`tellur-live` examples)
- A new `Streak` layer — a comet that rests, dashes across the lower band, and dashes back — wrapped in `MotionBlur` (1/60 s shutter × 16 samples): the dashes draw a visible trail while the rests collapse into the static cache path.

Verified: workspace tests and the GPU `--ignored` suite pass (including CPU/GPU byte-identity for the new kernels); during a dash, frames differ between blur on/off, while at rest they are md5-identical — the static path produces the same image either way.