### PR TITLE
feat: add a Background raster component

### DIFF
--- a/tellur-core/src/layout/decorated_box.rs
+++ b/tellur-core/src/layout/decorated_box.rs
@@ -61,7 +61,7 @@ pub(super) mod raster {
     use crate::color::Color;
     use crate::geometry::{Constraints, Rect, Vec2};
     use crate::layer::composite_children;
-    use crate::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
+    use crate::raster::{Background, RasterComponent, RasterImage, Resolution};
     use crate::render_context::RenderContext;
     use crate::Keyable;
 
@@ -99,7 +99,7 @@ pub(super) mod raster {
             };
             match self.background {
                 Some(color) => {
-                    let bg = SolidRect { color };
+                    let bg = Background::new(color);
                     let placed: Vec<(Vec2, Vec2, &dyn RasterComponent)> = vec![
                         (Vec2::ZERO, size, &bg as &dyn RasterComponent),
                         (Vec2::ZERO, size, self.child.as_ref()),
@@ -113,47 +113,6 @@ pub(super) mod raster {
                     ctx,
                 ),
             }
-        }
-    }
-
-    /// Internal helper: a solid-color rectangle that fills any layout
-    /// size the parent assigns, rasterized by buffer-filling.
-    #[derive(PartialEq, Hash)]
-    struct SolidRect {
-        color: Color,
-    }
-
-    impl RasterComponent for SolidRect {
-        fn layout(&self, constraints: Constraints) -> Vec2 {
-            constraints.constrain(constraints.max)
-        }
-
-        fn render(
-            &self,
-            _size: Vec2,
-            target: Resolution,
-            ctx: &mut dyn RenderContext,
-        ) -> RasterImage {
-            if ctx.prefers_gpu() {
-                if let Some(gpu) = ctx.gpu_backend() {
-                    if let Some(image) = gpu.solid_fill(target, self.color) {
-                        return image;
-                    }
-                }
-            }
-            let pixels = (target.width as usize) * (target.height as usize);
-            let mut buf = Vec::with_capacity(pixels * 4);
-            let r = (self.color.r * 255.0).round().clamp(0.0, 255.0) as u8;
-            let g = (self.color.g * 255.0).round().clamp(0.0, 255.0) as u8;
-            let b = (self.color.b * 255.0).round().clamp(0.0, 255.0) as u8;
-            let a = (self.color.a * 255.0).round().clamp(0.0, 255.0) as u8;
-            for _ in 0..pixels {
-                buf.push(r);
-                buf.push(g);
-                buf.push(b);
-                buf.push(a);
-            }
-            RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, buf)
         }
     }
 }

--- a/tellur-core/src/layout/sized_box.rs
+++ b/tellur-core/src/layout/sized_box.rs
@@ -36,7 +36,7 @@ impl VectorComponent for SizedBox {
 pub(super) mod raster {
     use crate::color::Color;
     use crate::geometry::{Constraints, Vec2};
-    use crate::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
+    use crate::raster::{Background, RasterComponent, RasterImage, Resolution};
     use crate::render_context::RenderContext;
 
     /// Raster mirror of the vector [`SizedBox`](super::SizedBox).
@@ -53,24 +53,11 @@ pub(super) mod raster {
 
         fn render(
             &self,
-            _size: Vec2,
+            size: Vec2,
             target: Resolution,
             ctx: &mut dyn RenderContext,
         ) -> RasterImage {
-            if ctx.prefers_gpu() {
-                if let Some(gpu) = ctx.gpu_backend() {
-                    if let Some(image) = gpu.solid_fill(target, Color::rgba_u8(0, 0, 0, 0)) {
-                        return image;
-                    }
-                }
-            }
-            let bytes = (target.width as usize) * (target.height as usize) * 4;
-            RasterImage::cpu(
-                target.width,
-                target.height,
-                PixelFormat::Rgba8,
-                vec![0u8; bytes],
-            )
+            Background::new(Color::rgba_u8(0, 0, 0, 0)).render(size, target, ctx)
         }
     }
 }

--- a/tellur-core/src/raster.rs
+++ b/tellur-core/src/raster.rs
@@ -7,9 +7,11 @@ use std::sync::Arc;
 use bytes::Bytes;
 use thiserror::Error;
 
+use crate::color::Color;
 use crate::dyn_compare::{DynEq, DynHash};
 use crate::geometry::{Constraints, Rect, Vec2};
 use crate::render_context::{CachePolicy, RenderContext};
+use crate::Keyable;
 
 #[derive(Debug, Clone)]
 pub enum RasterImage {
@@ -257,6 +259,114 @@ pub trait RasterComponent: DynEq + DynHash {
 
 // Compile-time guarantee that `RasterComponent` is dyn-safe.
 const _: Option<&dyn RasterComponent> = None;
+
+/// A solid-color raster component that fills its assigned layout area.
+///
+/// `Background` has no intrinsic size of its own. Under finite loose
+/// constraints it takes the full available size; under unbounded constraints it
+/// collapses to the minimum allowed size. During rendering it fills every pixel
+/// in the requested target resolution with `color`.
+#[crate::component(raster)]
+#[derive(Keyable)]
+pub struct Background {
+    pub color: Color,
+}
+
+impl Background {
+    pub const fn new(color: Color) -> Self {
+        Self { color }
+    }
+}
+
+impl RasterComponent for Background {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        let size = Vec2(
+            finite_or_min(constraints.max.0, constraints.min.0),
+            finite_or_min(constraints.max.1, constraints.min.1),
+        );
+        constraints.constrain(size)
+    }
+
+    fn render(&self, _size: Vec2, target: Resolution, ctx: &mut dyn RenderContext) -> RasterImage {
+        if ctx.prefers_gpu() {
+            if let Some(gpu) = ctx.gpu_backend() {
+                if let Some(image) = gpu.solid_fill(target, self.color) {
+                    return image;
+                }
+            }
+        }
+
+        let pixels = (target.width as usize) * (target.height as usize);
+        let mut buf = Vec::with_capacity(pixels * 4);
+        let [r, g, b, a] = color_rgba8(self.color);
+        for _ in 0..pixels {
+            buf.push(r);
+            buf.push(g);
+            buf.push(b);
+            buf.push(a);
+        }
+        RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, buf)
+    }
+}
+
+fn finite_or_min(max: f32, min: f32) -> f32 {
+    if max.is_finite() {
+        max
+    } else {
+        min
+    }
+}
+
+fn color_rgba8(color: Color) -> [u8; 4] {
+    [
+        (color.r * 255.0).round().clamp(0.0, 255.0) as u8,
+        (color.g * 255.0).round().clamp(0.0, 255.0) as u8,
+        (color.b * 255.0).round().clamp(0.0, 255.0) as u8,
+        (color.a * 255.0).round().clamp(0.0, 255.0) as u8,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render_context::PassThrough;
+
+    #[test]
+    fn background_layout_fills_finite_constraints() {
+        let bg = Background::new(Color::rgb_u8(1, 2, 3));
+
+        assert_eq!(
+            bg.layout(Constraints::loose(Vec2(640.0, 360.0))),
+            Vec2(640.0, 360.0)
+        );
+        assert_eq!(
+            bg.layout(Constraints::tight(Vec2(320.0, 180.0))),
+            Vec2(320.0, 180.0)
+        );
+        assert_eq!(bg.layout(Constraints::UNBOUNDED), Vec2::ZERO);
+    }
+
+    #[test]
+    fn background_fills_every_target_pixel() {
+        let bg = Background::new(Color::rgba_u8(10, 20, 30, 128));
+        let mut ctx = PassThrough;
+        let image = bg.render(Vec2(3.0, 2.0), Resolution::new(3, 2), &mut ctx);
+        let cpu = image.as_cpu().expect("background renders CPU image");
+
+        assert_eq!(cpu.width, 3);
+        assert_eq!(cpu.height, 2);
+        assert_eq!(cpu.format, PixelFormat::Rgba8);
+        for pixel in cpu.pixels.chunks_exact(4) {
+            assert_eq!(pixel, [10, 20, 30, 128]);
+        }
+    }
+
+    #[test]
+    fn complete_background_builder_boxes_as_raster_component() {
+        let _boxed: Box<dyn RasterComponent> =
+            Background::builder().color(Color::rgb_u8(1, 2, 3)).into();
+    }
+}
 
 impl PartialEq for dyn RasterComponent {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
Adds `tellur_core::raster::Background`, a solid-color raster component that fills its assigned layout area and uses the existing GPU `solid_fill` hook before falling back to CPU RGBA8 buffer filling. The existing raster `DecoratedBox` background and transparent `SizedBox` paths now reuse it instead of carrying private fill helpers. 3 files (+115 / -59) in `tellur-core`.

## Background raster leaf
- Adds `Background::new(color)` plus the generated builder API.
- Fills finite parent constraints, collapses under unbounded constraints, and writes every target pixel with the configured color.
- Covers layout behavior, pixel output, and builder boxing in focused unit tests.

## Existing fill paths
- Replaces the raster `DecoratedBox` private solid-fill helper with `Background`.
- Routes transparent raster `SizedBox` rendering through `Background` so CPU/GPU fill behavior stays shared.

## Verification
- `cargo fmt --all -- --check`
- `nix develop -c cargo test -p tellur-core`
- `nix develop -c cargo check -p tellur-renderer --examples`