### PR TITLE
feat: add responsive live preview layout controls

### DIFF
--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { fetchInfo } from "./api";
 import { Header } from "./components/Header";
 import { Inspector, type SelectedNode } from "./components/Inspector";
@@ -42,6 +50,17 @@ const PREVIEW_RESOLUTION_OPTIONS = [
   { width: 360, height: 640, label: "360 × 640" },
   { width: 240, height: 426, label: "240 × 426" },
 ];
+const WIDE_WORKSPACE_QUERY = "(min-width: 761px)";
+const SPLITTER_KEY_STEP_PX = 24;
+const LANDSCAPE_PREVIEW_MIN_PX = 220;
+const LANDSCAPE_TIMELINE_MIN_PX = 190;
+const PORTRAIT_PREVIEW_MIN_PX = 280;
+const PORTRAIT_TIMELINE_MIN_PX = 320;
+
+type WorkspaceStyle = CSSProperties & {
+  "--workspace-preview-h"?: string;
+  "--workspace-preview-w"?: string;
+};
 
 export function App() {
   const [info, setInfo] = useState<ServerInfo | null>(null);
@@ -60,6 +79,16 @@ export function App() {
   // via `onSelect` and reads the highlight back from `selectedNode.id`.
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const [measuredFps, setMeasuredFps] = useState(0);
+  const [landscapePreviewHeight, setLandscapePreviewHeight] = useState<
+    number | null
+  >(null);
+  const [portraitPreviewWidth, setPortraitPreviewWidth] = useState<
+    number | null
+  >(null);
+  const [wideWorkspace, setWideWorkspace] = useState(() =>
+    mediaQueryMatches(WIDE_WORKSPACE_QUERY),
+  );
+  const [resizingWorkspace, setResizingWorkspace] = useState(false);
   const fpsCounterRef = useRef({ frames: 0, last: performance.now() });
   const userSelectedResolutionRef = useRef(false);
 
@@ -116,6 +145,16 @@ export function App() {
       if (timer) clearTimeout(timer);
       source?.close();
     };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const query = window.matchMedia(WIDE_WORKSPACE_QUERY);
+    const update = () => setWideWorkspace(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
   }, []);
 
   const timeline = info?.timelines[0] ?? null;
@@ -200,9 +239,20 @@ export function App() {
 
   const aspect = resolution.width / resolution.height;
   const isPortraitPreview = resolution.height > resolution.width;
-  const workspaceClassName = isPortraitPreview
-    ? "workspace workspace--portrait-preview"
-    : "workspace";
+  const workspaceClassName = [
+    "workspace",
+    isPortraitPreview ? "workspace--portrait-preview" : null,
+    resizingWorkspace ? "workspace--resizing" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const workspaceStyle: WorkspaceStyle = {};
+  if (landscapePreviewHeight !== null) {
+    workspaceStyle["--workspace-preview-h"] = `${landscapePreviewHeight}px`;
+  }
+  if (portraitPreviewWidth !== null) {
+    workspaceStyle["--workspace-preview-w"] = `${portraitPreviewWidth}px`;
+  }
   const displayTimeline = timeline ?? FALLBACK_TIMELINE;
   const timelineDuration = displayTimeline.duration;
   const resolutionOptions = previewResolutionOptions(resolution);
@@ -227,6 +277,110 @@ export function App() {
     );
   }, [timelineDuration]);
 
+  const usesPortraitWorkspace = isPortraitPreview && wideWorkspace;
+  const handleWorkspaceSplitPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const workspace = event.currentTarget.closest(".workspace");
+      if (!(workspace instanceof HTMLElement)) return;
+
+      event.preventDefault();
+
+      const portrait = isPortraitPreview && wideWorkspace;
+      const workspaceRect = workspace.getBoundingClientRect();
+      const splitterRect = event.currentTarget.getBoundingClientRect();
+      const pointerOffset = portrait
+        ? event.clientX - splitterRect.left
+        : event.clientY - splitterRect.top;
+      const previousBodyCursor = document.body.style.cursor;
+      document.body.style.cursor = portrait ? "col-resize" : "row-resize";
+      setResizingWorkspace(true);
+
+      const applyPointer = (clientX: number, clientY: number) => {
+        if (portrait) {
+          setPortraitPreviewWidth(
+            clampPortraitPreviewWidth(
+              clientX - workspaceRect.left - pointerOffset,
+              workspaceRect.width,
+              splitterRect.width,
+            ),
+          );
+        } else {
+          setLandscapePreviewHeight(
+            clampLandscapePreviewHeight(
+              clientY - workspaceRect.top - pointerOffset,
+              workspaceRect.height,
+              splitterRect.height,
+            ),
+          );
+        }
+      };
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        moveEvent.preventDefault();
+        applyPointer(moveEvent.clientX, moveEvent.clientY);
+      };
+
+      const stopResize = () => {
+        setResizingWorkspace(false);
+        document.body.style.cursor = previousBodyCursor;
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", stopResize);
+        window.removeEventListener("pointercancel", stopResize);
+      };
+
+      applyPointer(event.clientX, event.clientY);
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", stopResize);
+      window.addEventListener("pointercancel", stopResize);
+    },
+    [isPortraitPreview, wideWorkspace],
+  );
+
+  const handleWorkspaceSplitterKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const portrait = isPortraitPreview && wideWorkspace;
+      const delta = splitterKeyDelta(event.key, portrait);
+      if (delta === 0) return;
+
+      const workspace = event.currentTarget.closest(".workspace");
+      if (!(workspace instanceof HTMLElement)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const workspaceRect = workspace.getBoundingClientRect();
+      const splitterRect = event.currentTarget.getBoundingClientRect();
+
+      if (portrait) {
+        const current =
+          portraitPreviewWidth ?? splitterRect.left - workspaceRect.left;
+        setPortraitPreviewWidth(
+          clampPortraitPreviewWidth(
+            current + delta,
+            workspaceRect.width,
+            splitterRect.width,
+          ),
+        );
+      } else {
+        const current =
+          landscapePreviewHeight ?? splitterRect.top - workspaceRect.top;
+        setLandscapePreviewHeight(
+          clampLandscapePreviewHeight(
+            current + delta,
+            workspaceRect.height,
+            splitterRect.height,
+          ),
+        );
+      }
+    },
+    [
+      isPortraitPreview,
+      landscapePreviewHeight,
+      portraitPreviewWidth,
+      wideWorkspace,
+    ],
+  );
+
   const url =
     typeof window !== "undefined" && window.location.origin
       ? window.location.origin
@@ -242,7 +396,7 @@ export function App() {
         }
         compileError={loadError ?? info?.compileError ?? null}
       />
-      <div className={workspaceClassName}>
+      <div className={workspaceClassName} style={workspaceStyle}>
         {/* The default layout keeps Preview + Details above the full-width
             Timeline. Portrait previews promote the viewer to a full-height
             left column through CSS. */}
@@ -281,6 +435,15 @@ export function App() {
           </section>
           <Inspector node={selectedNode} fps={fps} />
         </div>
+        <div
+          className="workspace__splitter"
+          role="separator"
+          tabIndex={0}
+          aria-label="Resize Preview and Timeline"
+          aria-orientation={usesPortraitWorkspace ? "vertical" : "horizontal"}
+          onPointerDown={handleWorkspaceSplitPointerDown}
+          onKeyDown={handleWorkspaceSplitterKeyDown}
+        />
         <section className="timeline-panel">
           <TabsRow
             timeline={displayTimeline}
@@ -345,4 +508,48 @@ function sameResolution(
   b: PreviewResolution,
 ): boolean {
   return a.width === b.width && a.height === b.height;
+}
+
+function mediaQueryMatches(query: string): boolean {
+  return typeof window !== "undefined" ? window.matchMedia(query).matches : true;
+}
+
+function clampLandscapePreviewHeight(
+  value: number,
+  workspaceHeight: number,
+  splitterHeight: number,
+): number {
+  return clamp(
+    value,
+    LANDSCAPE_PREVIEW_MIN_PX,
+    workspaceHeight - splitterHeight - LANDSCAPE_TIMELINE_MIN_PX,
+  );
+}
+
+function clampPortraitPreviewWidth(
+  value: number,
+  workspaceWidth: number,
+  splitterWidth: number,
+): number {
+  return clamp(
+    value,
+    PORTRAIT_PREVIEW_MIN_PX,
+    workspaceWidth - splitterWidth - PORTRAIT_TIMELINE_MIN_PX,
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), Math.max(min, max));
+}
+
+function splitterKeyDelta(key: string, portrait: boolean): number {
+  if (portrait) {
+    if (key === "ArrowLeft") return -SPLITTER_KEY_STEP_PX;
+    if (key === "ArrowRight") return SPLITTER_KEY_STEP_PX;
+    return 0;
+  }
+
+  if (key === "ArrowUp") return -SPLITTER_KEY_STEP_PX;
+  if (key === "ArrowDown") return SPLITTER_KEY_STEP_PX;
+  return 0;
 }

--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -199,6 +199,10 @@ export function App() {
   }, [preview.state.seconds, preview.state.playing]);
 
   const aspect = resolution.width / resolution.height;
+  const isPortraitPreview = resolution.height > resolution.width;
+  const workspaceClassName = isPortraitPreview
+    ? "workspace workspace--portrait-preview"
+    : "workspace";
   const displayTimeline = timeline ?? FALLBACK_TIMELINE;
   const timelineDuration = displayTimeline.duration;
   const resolutionOptions = previewResolutionOptions(resolution);
@@ -238,10 +242,10 @@ export function App() {
         }
         compileError={loadError ?? info?.compileError ?? null}
       />
-      <div className="workspace">
-        {/* Top row: preview (left, keeps its fixed viewer width) and the
-            Inspector (fills the leftover space to its right). The timeline
-            below stays full-width in the next row. */}
+      <div className={workspaceClassName}>
+        {/* The default layout keeps Preview + Details above the full-width
+            Timeline. Portrait previews promote the viewer to a full-height
+            left column through CSS. */}
         <div className="workspace-top">
           <section className="viewer-panel">
             <Preview

--- a/tellur-live/web/src/styles/global.css
+++ b/tellur-live/web/src/styles/global.css
@@ -695,6 +695,34 @@ select option {
   border-radius: 8px;
 }
 
+@media (min-width: 761px) {
+  .workspace--portrait-preview {
+    grid-template-columns: minmax(280px, min(var(--viewer-w), 54vw)) minmax(0, 1fr);
+    grid-template-rows: minmax(140px, min(var(--viewer-h), 34vh)) minmax(0, 1fr);
+    grid-template-areas:
+      "viewer inspector"
+      "viewer timeline";
+    gap: 6px;
+  }
+
+  .workspace--portrait-preview .workspace-top {
+    display: contents;
+  }
+
+  .workspace--portrait-preview .viewer-panel {
+    grid-area: viewer;
+    width: auto;
+  }
+
+  .workspace--portrait-preview .inspector {
+    grid-area: inspector;
+  }
+
+  .workspace--portrait-preview .timeline-panel {
+    grid-area: timeline;
+  }
+}
+
 .tabsrow {
   display: grid;
   grid-template-columns: var(--side-w) minmax(0, 1fr);

--- a/tellur-live/web/src/styles/global.css
+++ b/tellur-live/web/src/styles/global.css
@@ -29,6 +29,7 @@
   --viewer-h: 448px;
   --scrubber-h: 18px;
   --transport-h: 46px;
+  --splitter-size: 6px;
   --tabs-h: 50px;
   --track-h: 28px;
   --footer-h: 34px;
@@ -260,8 +261,20 @@ select option {
 
 .workspace {
   display: grid;
-  grid-template-rows: minmax(0, min(var(--viewer-h), 61vh)) minmax(0, 1fr);
-  row-gap: 6px;
+  grid-template-rows:
+    minmax(
+      0,
+      min(
+        var(--workspace-preview-h, min(var(--viewer-h), 61vh)),
+        calc(100% - var(--splitter-size) - 190px)
+      )
+    )
+    var(--splitter-size)
+    minmax(0, 1fr);
+  grid-template-areas:
+    "preview"
+    "splitter"
+    "timeline";
   height: calc(100vh - var(--header-h));
   min-height: 0;
   padding: 1px 1px 5px 10px;
@@ -272,10 +285,47 @@ select option {
    fills the leftover space to its right. The timeline occupies the full-width
    second row of `.workspace`. */
 .workspace-top {
+  grid-area: preview;
   display: grid;
   grid-template-columns: min(var(--viewer-w), 100%) minmax(0, 1fr);
   column-gap: 6px;
   min-height: 0;
+}
+
+.workspace__splitter {
+  position: relative;
+  grid-area: splitter;
+  min-width: 0;
+  min-height: 0;
+  cursor: row-resize;
+  touch-action: none;
+}
+
+.workspace__splitter::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 0;
+  left: 0;
+  height: 1px;
+  background: var(--border-panel);
+  transform: translateY(-50%);
+  transition: background 0.12s, height 0.12s;
+}
+
+.workspace__splitter:hover::before,
+.workspace__splitter:focus-visible::before,
+.workspace--resizing .workspace__splitter::before {
+  height: 2px;
+  background: #6b6b70;
+}
+
+.workspace__splitter:focus-visible {
+  outline: none;
+}
+
+.workspace--resizing {
+  user-select: none;
 }
 
 .viewer-panel {
@@ -686,6 +736,7 @@ select option {
 }
 
 .timeline-panel {
+  grid-area: timeline;
   display: grid;
   grid-template-rows: var(--tabs-h) minmax(0, 1fr) var(--footer-h);
   min-height: 0;
@@ -697,12 +748,21 @@ select option {
 
 @media (min-width: 761px) {
   .workspace--portrait-preview {
-    grid-template-columns: minmax(280px, min(var(--viewer-w), 54vw)) minmax(0, 1fr);
+    grid-template-columns:
+      minmax(
+        280px,
+        min(
+          var(--workspace-preview-w, min(var(--viewer-w), 54vw)),
+          calc(100% - var(--splitter-size) - 320px)
+        )
+      )
+      var(--splitter-size)
+      minmax(0, 1fr);
     grid-template-rows: minmax(140px, min(var(--viewer-h), 34vh)) minmax(0, 1fr);
     grid-template-areas:
-      "viewer inspector"
-      "viewer timeline";
-    gap: 6px;
+      "viewer splitter inspector"
+      "viewer splitter timeline";
+    row-gap: 6px;
   }
 
   .workspace--portrait-preview .workspace-top {
@@ -712,6 +772,27 @@ select option {
   .workspace--portrait-preview .viewer-panel {
     grid-area: viewer;
     width: auto;
+  }
+
+  .workspace--portrait-preview .workspace__splitter {
+    cursor: col-resize;
+  }
+
+  .workspace--portrait-preview .workspace__splitter::before {
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    height: auto;
+    transform: translateX(-50%);
+    transition: background 0.12s, width 0.12s;
+  }
+
+  .workspace--portrait-preview .workspace__splitter:hover::before,
+  .workspace--portrait-preview .workspace__splitter:focus-visible::before,
+  .workspace--portrait-preview.workspace--resizing .workspace__splitter::before {
+    width: 2px;
+    height: auto;
   }
 
   .workspace--portrait-preview .inspector {
@@ -1423,7 +1504,16 @@ select option {
   }
 
   .workspace {
-    grid-template-rows: minmax(0, 50vh) minmax(0, 1fr);
+    grid-template-rows:
+      minmax(
+        0,
+        min(
+          var(--workspace-preview-h, 50vh),
+          calc(100% - var(--splitter-size) - 190px)
+        )
+      )
+      var(--splitter-size)
+      minmax(0, 1fr);
   }
 
   .header__project-url {


### PR DESCRIPTION
Updates `tellur-live` web workspace so portrait preview resolutions use a full-height viewer beside Details/Timeline, and adds a draggable splitter to adjust Preview vs Timeline space in both portrait and landscape workspace layouts. 2 files (+337 / -8) in the web app.

## Portrait preview layout
- Detects portrait preview resolutions and moves the viewer into a full-height left column on wider screens.
- Keeps narrow screens on the stacked layout and clamps panel sizes so Timeline remains usable.

## Resizable workspace
- Adds a splitter between Preview and Timeline/right-side workspace areas.
- Supports pointer dragging plus keyboard arrow adjustment, with the resize axis switching between landscape and portrait modes.

## Verification
- `git diff --check origin/main..HEAD`
- `nix build .#web --no-link`
- Ran the `tellur-live` demo preview on `0.0.0.0:4318`; `/api/info` reported `compileStatus: compiled`.
