### PR TITLE
fix: stabilize live preview playback and rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,7 @@ dependencies = [
 name = "tellur-live"
 version = "0.1.0"
 dependencies = [
+ "png",
  "tellur-core",
  "tellur-plugin",
  "tellur-renderer",

--- a/tellur-core/src/audio.rs
+++ b/tellur-core/src/audio.rs
@@ -23,10 +23,11 @@ use std::io;
 use symphonia::core::audio::SampleBuffer;
 use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
 use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::FormatOptions;
+use symphonia::core::formats::{FormatOptions, SeekMode, SeekTo};
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
+use symphonia::core::units::Time as SymphoniaTime;
 
 use crate::timeline_component::AudioBuffer;
 
@@ -75,23 +76,65 @@ pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuff
         .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no decodable audio track"))?;
     let track_id = track.id;
+    let codec_params = track.codec_params.clone();
 
-    let rate = track.codec_params.sample_rate.ok_or_else(|| {
+    let rate = codec_params.sample_rate.ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidData, "audio track has no sample rate")
     })?;
+    let channel_hint = codec_params
+        .channels
+        .map(|channels| channels.count() as u16)
+        .unwrap_or(0);
 
     let mut decoder = symphonia::default::get_codecs()
-        .make(&track.codec_params, &DecoderOptions::default())
+        .make(&codec_params, &DecoderOptions::default())
         .map_err(map_err)?;
 
-    // The trim is in SOURCE seconds; convert to a per-channel frame window once
-    // we know the rate. Channels are read from the first decoded buffer's spec
-    // (the codec-params channel map can be absent for some containers).
-    let mut channels: u16 = 0;
+    let (start_secs, end_secs) = trim
+        .map(|(start, end)| (start.max(0.0), end.max(0.0)))
+        .unwrap_or((0.0, f32::INFINITY));
+    if end_secs <= start_secs {
+        return Ok(AudioBuffer {
+            samples: Vec::new(),
+            rate,
+            channels: channel_hint.max(1),
+        });
+    }
+
+    let start_frame = seconds_to_frame(start_secs, rate);
+    let end_frame = end_secs
+        .is_finite()
+        .then(|| seconds_to_frame(end_secs, rate));
+    let mut cursor_frame = 0u64;
+    if start_secs > 0.0 {
+        if let Ok(seeked) = format.seek(
+            SeekMode::Accurate,
+            SeekTo::Time {
+                time: SymphoniaTime::from(start_secs),
+                track_id: Some(track_id),
+            },
+        ) {
+            decoder.reset();
+            if seeked.track_id == track_id {
+                if let Some(time_base) = codec_params.time_base {
+                    cursor_frame = time_to_frame(time_base.calc_time(seeked.actual_ts), rate);
+                }
+            }
+        }
+    }
+
+    // The trim is in SOURCE seconds; append only the requested source-frame
+    // window. A successful seek skips the leading packets for seekable formats;
+    // the frame window below keeps the fallback path correct for unseekable
+    // formats and trims codec/seek pre-roll precisely.
+    let mut channels: u16 = channel_hint;
     let mut samples: Vec<f32> = Vec::new();
     let mut sample_buf: Option<SampleBuffer<f32>> = None;
 
     loop {
+        if end_frame.is_some_and(|end| cursor_frame >= end) {
+            break;
+        }
         let packet = match format.next_packet() {
             Ok(p) => p,
             // Clean EOF: symphonia signals end-of-stream as an IoError with the
@@ -114,7 +157,21 @@ pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuff
                     SampleBuffer::<f32>::new(decoded.capacity() as u64, spec)
                 });
                 buf.copy_interleaved_ref(decoded);
-                samples.extend_from_slice(buf.samples());
+                let decoded = buf.samples();
+                let ch = channels.max(1) as usize;
+                let decoded_frames = (decoded.len() / ch) as u64;
+                let chunk_start = cursor_frame;
+                let chunk_end = cursor_frame.saturating_add(decoded_frames);
+                if chunk_end > start_frame {
+                    let lo_frame = start_frame.max(chunk_start);
+                    let hi_frame = end_frame.map_or(chunk_end, |end| end.min(chunk_end));
+                    if hi_frame > lo_frame {
+                        let lo = ((lo_frame - chunk_start) as usize).saturating_mul(ch);
+                        let hi = ((hi_frame - chunk_start) as usize).saturating_mul(ch);
+                        samples.extend_from_slice(&decoded[lo..hi]);
+                    }
+                }
+                cursor_frame = chunk_end;
             }
             // A decode error on a single packet is recoverable — skip it.
             Err(SymphoniaError::DecodeError(_)) | Err(SymphoniaError::IoError(_)) => continue,
@@ -128,10 +185,6 @@ pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuff
         channels = 1;
     }
 
-    if let Some((start, end)) = trim {
-        crop_interleaved(&mut samples, rate, channels, start, end);
-    }
-
     Ok(AudioBuffer {
         samples,
         rate,
@@ -139,21 +192,13 @@ pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuff
     })
 }
 
-/// Crops `samples` in place to the SOURCE seconds `[start, end)` at `rate` /
-/// `channels`. Out-of-range bounds clamp to the buffer.
-fn crop_interleaved(samples: &mut Vec<f32>, rate: u32, channels: u16, start: f32, end: f32) {
-    let ch = channels.max(1) as usize;
-    let total_frames = samples.len() / ch;
-    let start_frame = ((start.max(0.0) * rate as f32).round() as usize).min(total_frames);
-    let end_frame = ((end.max(0.0) * rate as f32).round() as usize).min(total_frames);
-    if end_frame <= start_frame {
-        samples.clear();
-        return;
-    }
-    let lo = start_frame * ch;
-    let hi = end_frame * ch;
-    samples.copy_within(lo..hi, 0);
-    samples.truncate(hi - lo);
+fn seconds_to_frame(seconds: f32, rate: u32) -> u64 {
+    (seconds.max(0.0) * rate as f32).round().max(0.0) as u64
+}
+
+fn time_to_frame(time: SymphoniaTime, rate: u32) -> u64 {
+    let seconds = time.seconds as f64 + time.frac;
+    (seconds.max(0.0) * rate as f64).round() as u64
 }
 
 // ── Buffer transforms (rate / channel / gain / speed) ────────────────────────
@@ -291,15 +336,28 @@ impl AudioMix {
         self.channels
     }
 
+    /// The mix duration in seconds.
+    pub fn duration(&self) -> f32 {
+        let ch = self.channels.max(1) as usize;
+        let frames = self.samples.len() / ch;
+        frames as f32 / self.rate.max(1) as f32
+    }
+
     /// Sums an already-conformed (rate/channels/gain/speed-matched) interleaved
     /// buffer into the mix starting at `start_secs`, clamping each summed sample
-    /// to `[-1, 1]` so overlapping tracks never wrap. Frames past the mix end
-    /// are dropped (the resolved length is authoritative).
+    /// to `[-1, 1]` so overlapping tracks never wrap. Frames before the mix
+    /// start and past the mix end are dropped (the resolved length is
+    /// authoritative).
     pub fn add(&mut self, conformed: &[f32], start_secs: f32) {
         let ch = self.channels.max(1) as usize;
-        let start_frame = (start_secs.max(0.0) * self.rate as f32).round() as usize;
-        let base = start_frame * ch;
-        for (i, &s) in conformed.iter().enumerate() {
+        let start_frame = (start_secs * self.rate as f32).round() as isize;
+        let (base, source_offset) = if start_frame >= 0 {
+            (start_frame as usize * ch, 0)
+        } else {
+            let skipped_frames = (-start_frame) as usize;
+            (0, skipped_frames.saturating_mul(ch))
+        };
+        for (i, &s) in conformed.iter().skip(source_offset).enumerate() {
             let idx = base + i;
             if idx >= self.samples.len() {
                 break;
@@ -355,6 +413,16 @@ mod tests {
         let buf = mix.into_buffer();
         assert_eq!(buf.samples[0], 1.0);
         assert_eq!(buf.samples[1], 1.0);
+    }
+
+    #[test]
+    fn mix_add_clips_negative_start() {
+        let mut mix = AudioMix::new(1.0, 4, 1);
+
+        mix.add(&[0.1, 0.2, 0.3, 0.4], -0.5);
+
+        let buf = mix.into_buffer();
+        assert_eq!(buf.samples, vec![0.3, 0.4, 0.0, 0.0]);
     }
 
     #[test]

--- a/tellur-core/src/timeline_component/resolve.rs
+++ b/tellur-core/src/timeline_component/resolve.rs
@@ -294,6 +294,26 @@ impl ResolvedTimeline {
         self.source().mix_into(&mut mix, 0.0, 1.0);
         mix.into_buffer()
     }
+
+    /// Eager mix-down for a timeline window.
+    ///
+    /// This uses the same tree walk as [`render_audio`](Self::render_audio), but
+    /// the mix target is only `duration` seconds long and the global timeline is
+    /// shifted left by `start`, so live-preview cache segments do not allocate or
+    /// write a full-timeline WAV for every requested segment.
+    pub fn render_audio_window(
+        &self,
+        start: f32,
+        duration: f32,
+        rate: u32,
+        channels: u16,
+    ) -> AudioBuffer {
+        let start = start.max(0.0);
+        let duration = duration.max(0.0);
+        let mut mix = crate::audio::AudioMix::new(duration, rate, channels);
+        self.source().mix_into(&mut mix, -start, 1.0);
+        mix.into_buffer()
+    }
 }
 
 impl std::fmt::Debug for ResolvedTimeline {

--- a/tellur-core/src/timeline_container/leaves.rs
+++ b/tellur-core/src/timeline_container/leaves.rs
@@ -194,12 +194,34 @@ impl TimelineComponent for AudioFile {
     }
 
     fn mix_into(&self, mix: &mut AudioMix, start_secs: f32, speed: f32) {
-        // Decode the whole (trimmed) source, conform it to the mix's fixed
-        // rate / channel layout (applying gain + the placement speed), and sum
-        // it in at the resolved start. Decode failure ⇒ contribute silence.
-        if let Ok(buf) = audio::decode_file(&self.path, self.trim) {
+        // Decode only the source span that can land inside the current mix
+        // window, conform it to the mix's fixed rate / channel layout, and sum
+        // it in at the visible destination start. Decode failure ⇒ silence.
+        let speed = if speed.is_finite() && speed > 0.0 {
+            speed
+        } else {
+            1.0
+        };
+        let mix_duration = mix.duration();
+        let visible_start = start_secs.max(0.0);
+        if visible_start >= mix_duration {
+            return;
+        }
+        let source_offset = ((visible_start - start_secs) * speed).max(0.0);
+        let source_window = (mix_duration - visible_start).max(0.0) * speed;
+        let trim_start = self.trim.map(|(start, _)| start).unwrap_or(0.0);
+        let trim_end = self.trim.map(|(_, end)| end);
+        let decode_start = trim_start + source_offset;
+        let decode_end = trim_end
+            .map(|end| (decode_start + source_window).min(end))
+            .unwrap_or(decode_start + source_window);
+        if decode_end <= decode_start {
+            return;
+        }
+
+        if let Ok(buf) = audio::decode_file(&self.path, Some((decode_start, decode_end))) {
             let conformed = audio::conform(buf, mix.rate(), mix.channels(), self.gain, speed);
-            mix.add(&conformed, start_secs);
+            mix.add(&conformed, visible_start);
         }
     }
 

--- a/tellur-core/src/timeline_container/tests.rs
+++ b/tellur-core/src/timeline_container/tests.rs
@@ -962,6 +962,36 @@ fn sequence_concatenates_audio() {
     let _ = std::fs::remove_file(&b);
 }
 
+#[test]
+fn render_audio_window_matches_full_mix_slice_and_pads_tail() {
+    let level = (0.5 * i16::MAX as f32) as i16;
+    let frames = TEST_RATE as usize;
+    let path = const_wav("window", TEST_RATE, frames, level);
+
+    let tl = Timeline::builder()
+        .child(AudioFile::builder().path(path.to_str().unwrap()))
+        .build();
+    let resolved = resolve_audio(tl).expect("media-backed");
+    let full = resolved.render_audio(TEST_RATE, 1);
+    let window = resolved.render_audio_window(0.25, 0.5, TEST_RATE, 1);
+
+    let start = (TEST_RATE / 4) as usize;
+    let end = start + (TEST_RATE / 2) as usize;
+    assert_eq!(window.samples.len(), end - start);
+    for (a, b) in window.samples.iter().zip(&full.samples[start..end]) {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "window sample {a} should match full mix slice sample {b}"
+        );
+    }
+
+    let padded = resolved.render_audio_window(1.25, 0.25, TEST_RATE, 1);
+    assert_eq!(padded.samples.len(), (TEST_RATE / 4) as usize);
+    assert!(padded.samples.iter().all(|sample| *sample == 0.0));
+
+    let _ = std::fs::remove_file(&path);
+}
+
 // (mix) `gain` scales the decoded samples linearly.
 #[test]
 fn gain_scales_audio() {

--- a/tellur-live/Cargo.toml
+++ b/tellur-live/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 ]
 
 [dependencies]
+png = "0.18.1"
 tellur-core = { path = "../tellur-core" }
 tellur-plugin = { path = "../tellur-plugin" }
 tellur-renderer = { path = "../tellur-renderer" }

--- a/tellur-live/src/plugin.rs
+++ b/tellur-live/src/plugin.rs
@@ -12,6 +12,8 @@ use std::fmt;
 use std::fs;
 use std::io::Read;
 use std::os::raw::{c_char, c_int, c_void};
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -61,6 +63,7 @@ impl From<std::io::Error> for PluginLoadError {
 struct SourceStamp {
     modified: SystemTime,
     len: u64,
+    changed: Option<(i64, i64)>,
     hash: u64,
 }
 
@@ -71,6 +74,10 @@ impl SourceStamp {
 
     fn same_content(self, other: Self) -> bool {
         self.len == other.len && self.hash == other.hash
+    }
+
+    fn same_file_state(self, modified: SystemTime, len: u64, changed: Option<(i64, i64)>) -> bool {
+        self.modified == modified && self.len == len && self.changed == changed
     }
 }
 
@@ -89,6 +96,7 @@ pub struct HotReloadPlugin {
     loaded: Option<LoadedPlugin>,
     retired_libraries: Vec<DynamicLibrary>,
     last_error: Option<String>,
+    failed_stamp: Option<SourceStamp>,
 }
 
 impl HotReloadPlugin {
@@ -98,6 +106,7 @@ impl HotReloadPlugin {
             loaded: None,
             retired_libraries: Vec::new(),
             last_error: None,
+            failed_stamp: None,
         }
     }
 
@@ -120,15 +129,35 @@ impl HotReloadPlugin {
     }
 
     pub fn reload_if_changed(&mut self) -> Result<bool, PluginLoadError> {
-        let stamp = source_stamp(&self.source_path)?;
-        let changed = self
-            .loaded
-            .as_ref()
-            .map(|loaded| !loaded.stamp.same_content(stamp))
-            .unwrap_or(true);
+        let metadata = fs::metadata(&self.source_path)?;
+        let modified = metadata.modified()?;
+        let len = metadata.len();
+        let changed = metadata_change_time(&metadata);
+        if let Some(loaded) = &self.loaded {
+            if loaded.stamp.same_file_state(modified, len, changed) {
+                return Ok(false);
+            }
+            if self
+                .failed_stamp
+                .is_some_and(|stamp| stamp.same_file_state(modified, len, changed))
+            {
+                return Ok(false);
+            }
+        }
 
-        if !changed {
-            return Ok(false);
+        let stamp = SourceStamp {
+            modified,
+            len,
+            changed,
+            hash: file_hash(&self.source_path)?,
+        };
+        if let Some(loaded) = self.loaded.as_mut() {
+            if loaded.stamp.same_content(stamp) {
+                loaded.stamp = stamp;
+                self.failed_stamp = None;
+                self.last_error = None;
+                return Ok(false);
+            }
         }
 
         match load_plugin(&self.source_path, stamp) {
@@ -138,10 +167,12 @@ impl HotReloadPlugin {
                     self.retired_libraries.push(previous.library);
                 }
                 self.last_error = None;
+                self.failed_stamp = None;
                 Ok(true)
             }
             Err(e) if self.loaded.is_some() => {
                 self.last_error = Some(e.to_string());
+                self.failed_stamp = Some(stamp);
                 Ok(false)
             }
             Err(e) => Err(e),
@@ -156,13 +187,17 @@ impl HotReloadPlugin {
     }
 }
 
-fn source_stamp(path: &Path) -> Result<SourceStamp, PluginLoadError> {
-    let metadata = fs::metadata(path)?;
-    Ok(SourceStamp {
-        modified: metadata.modified()?,
-        len: metadata.len(),
-        hash: file_hash(path)?,
-    })
+fn metadata_change_time(metadata: &fs::Metadata) -> Option<(i64, i64)> {
+    #[cfg(unix)]
+    {
+        Some((metadata.ctime(), metadata.ctime_nsec()))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        None
+    }
 }
 
 fn load_plugin(path: &Path, stamp: SourceStamp) -> Result<LoadedPlugin, PluginLoadError> {

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -499,6 +499,7 @@ impl PreviewApp {
             return Err(format!("h264 stream requires Rgba8, got {:?}", image.format).into());
         }
         let after = self.ctx.metrics();
+        let gpu_init_error = self.ctx.gpu_init_error().map(str::to_owned);
 
         Ok(VideoFrame {
             image,
@@ -507,6 +508,9 @@ impl PreviewApp {
             cache_misses: after.misses.saturating_sub(before.misses),
             bytes_cached: after.bytes_cached,
             gpu_available: after.gpu_available,
+            gpu_init_attempted: after.gpu_init_attempted,
+            gpu_init_error,
+            gpu_preference: format!("{:?}", after.gpu_preference),
             gpu_ops: after.gpu.total_ops().saturating_sub(before.gpu.total_ops()),
             gpu_readbacks: after.gpu.readbacks.saturating_sub(before.gpu.readbacks),
         })
@@ -596,6 +600,7 @@ impl PreviewApp {
         let image = self.ctx.readback(image);
         let render_time = render_start.elapsed();
         let after = self.ctx.metrics();
+        let gpu_init_error = self.ctx.gpu_init_error().map(str::to_owned);
 
         Ok(RenderedImage {
             image,
@@ -612,6 +617,9 @@ impl PreviewApp {
                 cache_misses: after.misses.saturating_sub(before.misses),
                 bytes_cached: after.bytes_cached,
                 gpu_available: after.gpu_available,
+                gpu_init_attempted: after.gpu_init_attempted,
+                gpu_init_error,
+                gpu_preference: format!("{:?}", after.gpu_preference),
                 gpu_ops: after.gpu.total_ops().saturating_sub(before.gpu.total_ops()),
                 gpu_readbacks: after.gpu.readbacks.saturating_sub(before.gpu.readbacks),
             },
@@ -644,6 +652,9 @@ struct VideoFrame {
     cache_misses: u64,
     bytes_cached: usize,
     gpu_available: bool,
+    gpu_init_attempted: bool,
+    gpu_init_error: Option<String>,
+    gpu_preference: String,
     gpu_ops: u64,
     gpu_readbacks: u64,
 }
@@ -1046,7 +1057,7 @@ fn handle_video_stream(
             )?;
             if app.verbose {
                 println!(
-                    "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_available={} gpu_ops={} gpu_readbacks={}",
+                    "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={}",
                     setup.timeline_id,
                     seconds,
                     setup.resolution.width,
@@ -1058,6 +1069,9 @@ fn handle_video_stream(
                     frame.cache_hits,
                     frame.cache_misses,
                     format_bytes(frame.bytes_cached as u64),
+                    frame.gpu_preference,
+                    frame.gpu_init_attempted,
+                    frame.gpu_init_error.as_deref().unwrap_or("-"),
                     frame.gpu_available,
                     frame.gpu_ops,
                     frame.gpu_readbacks,
@@ -1148,6 +1162,9 @@ struct FrameRenderStats {
     cache_hits: u64,
     cache_misses: u64,
     bytes_cached: usize,
+    gpu_preference: String,
+    gpu_init_attempted: bool,
+    gpu_init_error: Option<String>,
     gpu_available: bool,
     gpu_ops: u64,
     gpu_readbacks: u64,
@@ -1155,7 +1172,7 @@ struct FrameRenderStats {
 
 impl FrameRenderStats {
     fn headers(&self) -> Vec<(&'static str, String)> {
-        vec![
+        let mut headers = vec![
             ("X-Tellur-Render-Ms", format!("{:.2}", ms(self.render_time))),
             ("X-Tellur-Encode-Ms", format!("{:.2}", ms(self.encode_time))),
             ("X-Tellur-Total-Ms", format!("{:.2}", ms(self.total_time))),
@@ -1169,10 +1186,19 @@ impl FrameRenderStats {
             ("X-Tellur-Cache-Hits", self.cache_hits.to_string()),
             ("X-Tellur-Cache-Misses", self.cache_misses.to_string()),
             ("X-Tellur-GPU-Available", self.gpu_available.to_string()),
+            (
+                "X-Tellur-GPU-Init-Attempted",
+                self.gpu_init_attempted.to_string(),
+            ),
+            ("X-Tellur-GPU-Preference", self.gpu_preference.clone()),
             ("X-Tellur-GPU-Active", (self.gpu_ops > 0).to_string()),
             ("X-Tellur-GPU-Ops", self.gpu_ops.to_string()),
             ("X-Tellur-GPU-Readbacks", self.gpu_readbacks.to_string()),
-        ]
+        ];
+        if let Some(error) = &self.gpu_init_error {
+            headers.push(("X-Tellur-GPU-Init-Error", sanitize_header_value(error)));
+        }
+        headers
     }
 }
 
@@ -1200,7 +1226,7 @@ impl FrameFormat {
 
 fn log_frame_stats(stats: &FrameRenderStats) {
     println!(
-        "frame timeline={} t={:.3}s size={}x{} format={} render={:.2}ms encode={:.2}ms total={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_available={} gpu_ops={} gpu_readbacks={}",
+        "frame timeline={} t={:.3}s size={}x{} format={} render={:.2}ms encode={:.2}ms total={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={}",
         stats.timeline_id,
         stats.seconds,
         stats.resolution.width,
@@ -1213,6 +1239,9 @@ fn log_frame_stats(stats: &FrameRenderStats) {
         stats.cache_hits,
         stats.cache_misses,
         format_bytes(stats.bytes_cached as u64),
+        stats.gpu_preference,
+        stats.gpu_init_attempted,
+        stats.gpu_init_error.as_deref().unwrap_or("-"),
         stats.gpu_available,
         stats.gpu_ops,
         stats.gpu_readbacks,
@@ -1473,6 +1502,13 @@ fn format_bytes(b: u64) -> String {
     } else {
         format!("{b} B")
     }
+}
+
+fn sanitize_header_value(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect()
 }
 
 fn info_json(

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -5,7 +5,7 @@ use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc, Mutex,
 };
 use std::thread;
@@ -73,12 +73,15 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
         app.reload_plugin_if_changed()?;
     }
 
+    let video_epochs: Arc<Mutex<HashMap<String, Arc<AtomicU64>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
                 let app = Arc::clone(&app);
+                let video_epochs = Arc::clone(&video_epochs);
                 thread::spawn(move || {
-                    if let Err(e) = handle_connection(app, stream) {
+                    if let Err(e) = handle_connection(app, video_epochs, stream) {
                         if !is_client_disconnect(e.as_ref()) {
                             eprintln!("request failed: {e}");
                         }
@@ -93,6 +96,7 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
 
 fn handle_connection(
     app: Arc<Mutex<PreviewApp>>,
+    video_epochs: Arc<Mutex<HashMap<String, Arc<AtomicU64>>>>,
     mut stream: TcpStream,
 ) -> Result<(), Box<dyn Error>> {
     let request = match read_request(&mut stream)? {
@@ -112,7 +116,9 @@ fn handle_connection(
 
     let path = request.path.clone();
     match path.as_str() {
-        "/api/video.mp4" | "/api/video" => handle_video_stream(app, stream, request.query),
+        "/api/video.mp4" | "/api/video" => {
+            handle_video_stream(app, video_epochs, stream, request.query)
+        }
         "/api/events" => handle_event_stream(app, stream),
         "/api/info" | "/api/frame" | "/api/stream" | "/api/arrangement" => {
             let mut app = app
@@ -699,9 +705,25 @@ fn write_temp_wav(buf: &AudioBuffer) -> std::io::Result<PathBuf> {
 
 fn handle_video_stream(
     app: Arc<Mutex<PreviewApp>>,
+    video_epochs: Arc<Mutex<HashMap<String, Arc<AtomicU64>>>>,
     mut stream: TcpStream,
     query: HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
+    let video_epoch = {
+        let session = query
+            .get("session")
+            .cloned()
+            .unwrap_or_else(|| "default".to_owned());
+        let mut epochs = video_epochs
+            .lock()
+            .map_err(|_| -> Box<dyn Error> { "video epoch lock poisoned".into() })?;
+        Arc::clone(
+            epochs
+                .entry(session)
+                .or_insert_with(|| Arc::new(AtomicU64::new(0))),
+        )
+    };
+    let stream_epoch = video_epoch.fetch_add(1, Ordering::AcqRel).wrapping_add(1);
     let setup = {
         let mut app = app
             .lock()
@@ -755,6 +777,9 @@ fn handle_video_stream(
             realtime: !cacheable,
         }
     };
+    if video_epoch.load(Ordering::Acquire) != stream_epoch {
+        return Ok(());
+    }
 
     // The frame-quantized video length, used to BOUND the output below with `-t`
     // (instead of `-shortest`; see that arg). This is also the loop's frame count.
@@ -787,6 +812,9 @@ fn handle_video_stream(
             .and_then(|buf| write_temp_wav(&buf).ok())
             .map(TempFile)
     };
+    if video_epoch.load(Ordering::Acquire) != stream_epoch {
+        return Ok(());
+    }
 
     write!(
         stream,
@@ -967,7 +995,10 @@ fn handle_video_stream(
     let frame_duration = Duration::from_secs_f32(frame_step);
 
     for frame in 0..total_frames {
-        if !client_alive.load(Ordering::Relaxed) {
+        if !client_alive.load(Ordering::Relaxed)
+            || video_epoch.load(Ordering::Acquire) != stream_epoch
+        {
+            client_alive.store(false, Ordering::Relaxed);
             break;
         }
 
@@ -1012,6 +1043,10 @@ fn handle_video_stream(
             frame.image
         };
 
+        if video_epoch.load(Ordering::Acquire) != stream_epoch {
+            client_alive.store(false, Ordering::Relaxed);
+            break;
+        }
         if stdin.write_all(&image.pixels).is_err() {
             client_alive.store(false, Ordering::Relaxed);
             break;

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -634,6 +634,7 @@ struct VideoStreamSetup {
     start_seconds: f32,
     cache_control: &'static str,
     realtime: bool,
+    verbose: bool,
 }
 
 struct VideoFrame {
@@ -709,6 +710,7 @@ fn handle_video_stream(
     mut stream: TcpStream,
     query: HashMap<String, String>,
 ) -> Result<(), Box<dyn Error>> {
+    let stream_start = Instant::now();
     let video_epoch = {
         let session = query
             .get("session")
@@ -724,6 +726,7 @@ fn handle_video_stream(
         )
     };
     let stream_epoch = video_epoch.fetch_add(1, Ordering::AcqRel).wrapping_add(1);
+    let setup_start = Instant::now();
     let setup = {
         let mut app = app
             .lock()
@@ -775,8 +778,10 @@ fn handle_video_stream(
                 "no-store"
             },
             realtime: !cacheable,
+            verbose: app.verbose,
         }
     };
+    let setup_time = setup_start.elapsed();
     if video_epoch.load(Ordering::Acquire) != stream_epoch {
         return Ok(());
     }
@@ -792,6 +797,7 @@ fn handle_video_stream(
     // `None` only for legacy/custom collections that do not expose audio, where
     // the stream falls back to a generated silent track. The guard removes the
     // file when this function returns.
+    let audio_start = Instant::now();
     let audio_wav = {
         let mut app = app
             .lock()
@@ -811,6 +817,12 @@ fn handle_video_stream(
             })
             .and_then(|buf| write_temp_wav(&buf).ok())
             .map(TempFile)
+    };
+    let audio_time = audio_start.elapsed();
+    let audio_source = if audio_wav.is_some() {
+        "window_wav"
+    } else {
+        "anullsrc"
     };
     if video_epoch.load(Ordering::Acquire) != stream_epoch {
         return Ok(());
@@ -943,7 +955,9 @@ fn handle_video_stream(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    let spawn_start = Instant::now();
     let mut child = cmd.spawn()?;
+    let ffmpeg_spawn_time = spawn_start.elapsed();
 
     let mut stdin = child.stdin.take().ok_or("ffmpeg stdin was not piped")?;
     let mut stdout = child.stdout.take().ok_or("ffmpeg stdout was not piped")?;
@@ -993,11 +1007,20 @@ fn handle_video_stream(
 
     let frame_step = 1.0 / setup.fps as f32;
     let frame_duration = Duration::from_secs_f32(frame_step);
+    let mut frames_rendered = 0u64;
+    let mut frames_written = 0u64;
+    let mut render_total = Duration::ZERO;
+    let mut stdin_write_total = Duration::ZERO;
+    let mut end_reason = "complete";
 
     for frame in 0..total_frames {
-        if !client_alive.load(Ordering::Relaxed)
-            || video_epoch.load(Ordering::Acquire) != stream_epoch
-        {
+        if !client_alive.load(Ordering::Relaxed) {
+            end_reason = "client_closed";
+            client_alive.store(false, Ordering::Relaxed);
+            break;
+        }
+        if video_epoch.load(Ordering::Acquire) != stream_epoch {
+            end_reason = "superseded";
             client_alive.store(false, Ordering::Relaxed);
             break;
         }
@@ -1040,17 +1063,25 @@ fn handle_video_stream(
                     frame.gpu_readbacks,
                 );
             }
+            render_total += frame.render_time;
+            frames_rendered += 1;
             frame.image
         };
 
         if video_epoch.load(Ordering::Acquire) != stream_epoch {
+            end_reason = "superseded";
             client_alive.store(false, Ordering::Relaxed);
             break;
         }
-        if stdin.write_all(&image.pixels).is_err() {
+        let write_start = Instant::now();
+        let write_result = stdin.write_all(&image.pixels);
+        stdin_write_total += write_start.elapsed();
+        if write_result.is_err() {
+            end_reason = "ffmpeg_stdin_closed";
             client_alive.store(false, Ordering::Relaxed);
             break;
         }
+        frames_written += 1;
         if setup.realtime {
             sleep_remainder(frame_duration, frame_start.elapsed());
         }
@@ -1061,8 +1092,32 @@ fn handle_video_stream(
         let _ = child.kill();
     }
     let _ = stdout_thread.join();
+    if !client_alive.load(Ordering::Relaxed) && end_reason == "complete" {
+        end_reason = "client_closed";
+    }
     let stderr_text = stderr_thread.join().unwrap_or_default();
     let status = child.wait()?;
+    if setup.verbose {
+        println!(
+            "video-stream timeline={} start={:.3}s duration={:.3}s frames={}/{} written={} reason={} setup={:.2}ms audio={} audio_setup={:.2}ms ffmpeg_spawn={:.2}ms render_total={:.2}ms stdin_write={:.2}ms total={:.2}ms status={} stderr_bytes={}",
+            setup.timeline_id,
+            setup.start_seconds,
+            video_seconds,
+            frames_rendered,
+            total_frames,
+            frames_written,
+            end_reason,
+            ms(setup_time),
+            audio_source,
+            ms(audio_time),
+            ms(ffmpeg_spawn_time),
+            ms(render_total),
+            ms(stdin_write_total),
+            ms(stream_start.elapsed()),
+            status,
+            stderr_text.len(),
+        );
+    }
     if !status.success() && client_alive.load(Ordering::Relaxed) {
         return Err(format!("ffmpeg exited with {status}: {stderr_text}").into());
     }

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -24,6 +24,11 @@ use crate::build_watch::{
 use crate::plugin::HotReloadPlugin;
 use tellur_plugin::TimelineInfo;
 
+/// Live preview re-encodes short MP4 segments repeatedly. Keeping the render
+/// cache below the renderer's export-oriented 1 GiB default avoids memory
+/// pressure and LRU churn making playback look stalled.
+const LIVE_PREVIEW_CACHE_BYTES: usize = 256 * 1024 * 1024;
+
 #[derive(Debug, Clone)]
 pub struct ServerOptions {
     pub plugin_path: PathBuf,
@@ -54,7 +59,8 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
 
     let app = Arc::new(Mutex::new(PreviewApp {
         plugin: HotReloadPlugin::new(options.plugin_path),
-        ctx: CachingRenderContext::new().with_gpu_preference(options.gpu_preference),
+        ctx: CachingRenderContext::with_capacity_bytes(LIVE_PREVIEW_CACHE_BYTES)
+            .with_gpu_preference(options.gpu_preference),
         resolution: options.resolution,
         fps: options.fps,
         verbose: options.verbose,

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -750,11 +750,17 @@ fn handle_video_stream(
         }
     };
 
-    // Render the timeline's audio once and stage it as a temp WAV so the stream
-    // can mux a real AAC track. `render_audio` returns a full-length buffer
-    // (silent if the tree has no audio sources); `None` only for legacy
-    // collections, where the stream falls back to a generated silent track. The
-    // guard removes the file when this function returns.
+    // The frame-quantized video length, used to BOUND the output below with `-t`
+    // (instead of `-shortest`; see that arg). This is also the loop's frame count.
+    let total_frames = (setup.duration * setup.fps as f32).ceil().max(0.0) as u64;
+    let video_seconds = total_frames as f32 / setup.fps as f32;
+
+    // Render only this stream's audio window and stage it as a temp WAV. Full
+    // timeline audio can be huge, and live preview requests many short cache
+    // segments, so every segment must mix only `[start, start + video_seconds)`.
+    // `None` only for legacy/custom collections that do not expose audio, where
+    // the stream falls back to a generated silent track. The guard removes the
+    // file when this function returns.
     let audio_wav = {
         let mut app = app
             .lock()
@@ -763,7 +769,15 @@ fn handle_video_stream(
         app.plugin
             .collection()
             .ok()
-            .and_then(|c| c.render_audio(&setup.timeline_id, AUDIO_RATE, AUDIO_CHANNELS))
+            .and_then(|c| {
+                c.render_audio_window(
+                    &setup.timeline_id,
+                    setup.start_seconds,
+                    video_seconds,
+                    AUDIO_RATE,
+                    AUDIO_CHANNELS,
+                )
+            })
             .and_then(|buf| write_temp_wav(&buf).ok())
             .map(TempFile)
     };
@@ -780,11 +794,6 @@ fn handle_video_stream(
          Connection: close\r\n\r\n",
         setup.resolution.width, setup.resolution.height, setup.fps, setup.gop, setup.cache_control,
     )?;
-
-    // The frame-quantized video length, used to BOUND the output below with `-t`
-    // (instead of `-shortest`; see that arg). This is also the loop's frame count.
-    let total_frames = (setup.duration * setup.fps as f32).ceil().max(0.0) as u64;
-    let video_seconds = total_frames as f32 / setup.fps as f32;
 
     // FLAC block size aligned to ONE video frame's worth of audio samples, applied
     // to the encoder below (only when the sample rate divides evenly by fps — the
@@ -812,15 +821,12 @@ fn handle_video_stream(
         ])
         .args(["-r", &setup.fps.to_string()])
         .args(["-i", "-"]);
-    // Input 1: the audio track. A rendered WAV seeked to the stream's start when
-    // the timeline has audio; otherwise a generated silent track, so every
-    // stream has the same A/V structure the client's SourceBuffer expects.
+    // Input 1: the audio track. A rendered WAV already starts at the stream's
+    // timeline time; otherwise a generated silent track keeps every stream in
+    // the same A/V structure the client's SourceBuffer expects.
     match &audio_wav {
         Some(wav) => {
-            cmd.arg("-ss")
-                .arg(format!("{:.6}", setup.start_seconds))
-                .arg("-i")
-                .arg(&wav.0);
+            cmd.arg("-i").arg(&wav.0);
         }
         None => {
             cmd.args(["-f", "lavfi"]).arg("-i").arg(format!(

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -520,7 +520,7 @@ impl PreviewApp {
 
         let encode_start = Instant::now();
         let mut body = Vec::new();
-        rendered.image.export_png(&mut body)?;
+        export_preview_png(&rendered.image, &mut body)?;
         let encode_time = encode_start.elapsed();
 
         let mut stats = rendered.stats;
@@ -1284,6 +1284,29 @@ fn request_resolution(query: &HashMap<String, String>, default: Resolution) -> R
 
 fn scaled_dimension(value: u32, scale: f32) -> u32 {
     ((value as f32) * scale).round().clamp(1.0, u32::MAX as f32) as u32
+}
+
+fn export_preview_png<W: Write>(image: &CpuRasterImage, writer: W) -> Result<(), Box<dyn Error>> {
+    if image.format != PixelFormat::Rgba8 {
+        return Err(format!("png frame requires Rgba8, got {:?}", image.format).into());
+    }
+
+    let expected = (image.width as usize) * (image.height as usize) * 4;
+    if image.pixels.len() != expected {
+        return Err(format!(
+            "png frame size mismatch: expected {expected} bytes, got {}",
+            image.pixels.len()
+        )
+        .into());
+    }
+
+    let mut encoder = png::Encoder::new(writer, image.width, image.height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    encoder.set_compression(png::Compression::Fastest);
+    let mut png_writer = encoder.write_header()?;
+    png_writer.write_image_data(&image.pixels)?;
+    Ok(())
 }
 
 /// Clamps a requested frame time into the timeline's RENDERABLE range.

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -1246,11 +1246,11 @@ fn request_fps(query: &HashMap<String, String>, default_fps: u32) -> u32 {
         .unwrap_or(default_fps.max(1))
 }
 
-/// The preview's motion-blur toggle; on unless the request says otherwise.
+/// The preview's motion-blur toggle; off unless the request explicitly opts in.
 fn request_motion_blur(query: &HashMap<String, String>) -> bool {
-    !matches!(
+    matches!(
         query.get("motion_blur").map(String::as_str),
-        Some("0") | Some("false")
+        Some("1") | Some("true")
     )
 }
 
@@ -1640,6 +1640,28 @@ mod tests {
         assert_eq!(clamp_to_renderable(0.005, 0.01, 60), 0.0);
         // A negative request floors at 0.0.
         assert_eq!(clamp_to_renderable(-2.0, 7.6, 60), 0.0);
+    }
+
+    #[test]
+    fn request_motion_blur_defaults_off() {
+        assert!(!request_motion_blur(&HashMap::new()));
+
+        let mut query = HashMap::new();
+        query.insert("motion_blur".to_owned(), "0".to_owned());
+        assert!(!request_motion_blur(&query));
+
+        query.insert("motion_blur".to_owned(), "false".to_owned());
+        assert!(!request_motion_blur(&query));
+    }
+
+    #[test]
+    fn request_motion_blur_is_explicitly_opt_in() {
+        let mut query = HashMap::new();
+        query.insert("motion_blur".to_owned(), "1".to_owned());
+        assert!(request_motion_blur(&query));
+
+        query.insert("motion_blur".to_owned(), "true".to_owned());
+        assert!(request_motion_blur(&query));
     }
 
     // Round-trips the `.sketch/01` B.4 arrangement shape at a small scale: an

--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -69,7 +69,7 @@ export function App() {
     DEFAULT_PREVIEW_RESOLUTION,
   );
   const [fps, setFps] = useState(30);
-  const [motionBlur, setMotionBlur] = useState(true);
+  const [motionBlur, setMotionBlur] = useState(false);
   const [timelineViewport, setTimelineViewport] = useState<TimelineViewport>({
     start: 0,
     zoom: DEFAULT_TIMELINE_ZOOM,

--- a/tellur-live/web/src/api.ts
+++ b/tellur-live/web/src/api.ts
@@ -55,6 +55,7 @@ export interface VideoRequestParams extends FrameRequestParams {
   gop: number;
   crf: number;
   duration?: number;
+  session?: string;
 }
 
 export function videoUrl(params: VideoRequestParams): string {
@@ -71,6 +72,9 @@ export function videoUrl(params: VideoRequestParams): string {
   });
   if (params.duration != null) {
     query.set("duration", params.duration.toFixed(4));
+  }
+  if (params.session) {
+    query.set("session", params.session);
   }
   return `/api/video.mp4?${query}`;
 }

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -77,14 +77,13 @@ const STARVE_PROBE = 0.2;
 // codec or appended segments fail to parse. FLAC (not AAC) because AAC's per-encode
 // priming left an audible click at every fresh-encode cache seam; FLAC has zero
 // encoder delay so segments concatenate gaplessly. The three avc1 profiles cover
-// browsers that support different H.264 levels; video-only and bare fallbacks last.
+// browsers that support different H.264 levels; the bare MP4 fallback is last for
+// browsers that accept container-level probing without explicit codecs. Video-only
+// codec strings are intentionally omitted because the server always muxes audio.
 const MP4_MIME_TYPES = [
   'video/mp4; codecs="avc1.42E01E, flac"',
   'video/mp4; codecs="avc1.4D401E, flac"',
   'video/mp4; codecs="avc1.64001E, flac"',
-  'video/mp4; codecs="avc1.42E01E"',
-  'video/mp4; codecs="avc1.4D401E"',
-  'video/mp4; codecs="avc1.64001E"',
   "video/mp4",
 ];
 
@@ -226,9 +225,13 @@ export class TimelinePlayer {
     // Start filling only once BOTH the SourceBuffer is open AND the committed ranges are
     // loaded from IndexedDB. Otherwise, on a warm-cache reload, runFill would start with an
     // empty committedRanges mirror and re-stream a region that is already cached (req 7).
-    void Promise.all([this.ready, committed]).then(() => {
-      if (!this.disposed) this.kickFill();
-    });
+    void Promise.all([this.ready, committed])
+      .then(() => {
+        if (!this.disposed) this.kickFill();
+      })
+      .catch(() => {
+        // init() already surfaced the error; do not retry without a SourceBuffer.
+      });
   }
 
   // ---- public API -------------------------------------------------------------
@@ -432,6 +435,7 @@ export class TimelinePlayer {
       };
     } catch (e) {
       if (!this.disposed) this.events.onError?.(String(e));
+      throw e;
     }
   }
 
@@ -502,9 +506,13 @@ export class TimelinePlayer {
   private kickFill(): void {
     if (this.disposed) return;
     if (!this.sourceBuffer) {
-      void this.ready.then(() => {
-        if (!this.disposed) this.kickFill();
-      });
+      void this.ready
+        .then(() => {
+          if (!this.disposed) this.kickFill();
+        })
+        .catch(() => {
+          // init() already surfaced the error; do not retry without a SourceBuffer.
+        });
       return;
     }
     const gen = this.fillGen;
@@ -1380,7 +1388,7 @@ function selectMimeType(): string {
   for (const mimeType of MP4_MIME_TYPES) {
     if (MediaSource.isTypeSupported(mimeType)) return mimeType;
   }
-  return "video/mp4";
+  throw new Error("MP4 preview streams with FLAC audio are not supported");
 }
 
 function waitForSourceOpen(mediaSource: MediaSource): Promise<void> {

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -153,7 +153,7 @@ interface RemoveJob {
 }
 
 type QueuedOp =
-  | ({ kind: "append" } & AppendJob & { settle: () => void })
+  | ({ kind: "append" } & AppendJob & { settle: (ok: boolean) => void })
   | ({ kind: "remove" } & RemoveJob & { settle: () => void });
 
 // A single self-contained MSE-backed timeline player. Owns ONE MediaSource + ONE
@@ -364,7 +364,13 @@ export class TimelinePlayer {
     this.stopTicker();
     this.abortInflight();
     // Drop every queued op so awaiters don't hang and the pump exits.
-    for (const op of this.opQueue.splice(0)) op.settle();
+    for (const op of this.opQueue.splice(0)) {
+      if (op.kind === "append") {
+        op.settle(false);
+      } else {
+        op.settle();
+      }
+    }
     try {
       this.video.pause();
     } catch {
@@ -567,9 +573,13 @@ export class TimelinePlayer {
           (seg.end - seg.start >= MIN_SEGMENT_REUSE ||
             seg.end >= duration - EPSILON);
         if (seg && reusable && seg.end > cursor + EPSILON) {
-          await this.appendSegment(seg.start, await blobToArrayBuffer(seg.blob), gen);
+          const appended = await this.appendSegment(
+            seg.start,
+            await blobToArrayBuffer(seg.blob),
+            gen,
+          );
           if (this.disposed || gen !== this.fillGen) return;
-          if (!this.isTimeBuffered(cursor)) {
+          if (!appended || !this.isTimeBuffered(cursor)) {
             // The append never landed (quota that even eviction couldn't relieve, or
             // an unparsable blob). Drop the range from the in-memory mirror and
             // stream it fresh — putSegment subsumes the stale row, so a bad blob
@@ -650,8 +660,9 @@ export class TimelinePlayer {
           value.byteOffset + value.byteLength,
         ) as ArrayBuffer;
         inflight.received.push(slice);
-        await this.appendSegment(start, slice.slice(0), gen);
+        const appended = await this.appendSegment(start, slice.slice(0), gen);
         if (this.disposed || gen !== this.fillGen) return reached;
+        if (!appended) throw new Error("SourceBuffer append failed");
         // The live green edge is the buffered end of THIS segment only — never bytes
         // received (which over-report before parse) and never the global buffered end
         // (contaminated by lookahead / eviction). buffered advances per GOP fragment.
@@ -695,19 +706,24 @@ export class TimelinePlayer {
         return reached;
       }
       if (this.disposed || gen !== this.fillGen) return reached;
-      // Arm the backoff and skip past the failed span for this pass; without both,
-      // the per-frame kickFill turns a failing server into a fetch storm.
+      // Arm the backoff and leave this span uncovered; without the backoff, the
+      // per-frame kickFill would turn a failing server or SourceBuffer into a
+      // fetch storm.
       this.streamBlockedUntil = Date.now() + STREAM_ERROR_BACKOFF_MS;
       this.events.onError?.(String(e));
-      return end;
+      return reached;
     }
   }
 
   // Enqueue an append for a segment slice and resolve once it has drained (backpressure
   // so the reader can't outrun the SourceBuffer). The op carries fillGen so a stale
   // cursor's slices are dropped by the pump rather than polluting buffered ranges.
-  private appendSegment(offset: number, data: ArrayBuffer, fillGen: number): Promise<void> {
-    return new Promise<void>((resolve) => {
+  private appendSegment(
+    offset: number,
+    data: ArrayBuffer,
+    fillGen: number,
+  ): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
       this.opQueue.push({ kind: "append", offset, data, fillGen, settle: resolve });
       void this.pump();
     });
@@ -728,19 +744,24 @@ export class TimelinePlayer {
         if (!sb || this.mediaSource.readyState === "closed") break;
         const op = this.opQueue.shift()!;
         if (op.kind === "append" && op.fillGen !== this.fillGen) {
-          op.settle(); // stale cursor — drop, but settle so the awaiter continues
+          op.settle(false); // stale cursor — drop, but settle so the awaiter continues
           continue;
         }
+        let appended = false;
         try {
           if (op.kind === "append") {
-            await this.appendWithQuota(sb, op.offset, op.data);
+            appended = await this.appendWithQuota(sb, op.offset, op.data);
           } else {
             await this.removeRange(sb, op.start, op.end);
           }
         } catch (e) {
           if (isInvalidState(e)) {
             // MediaSource detached mid-op (teardown) — stop draining.
-            op.settle();
+            if (op.kind === "append") {
+              op.settle(false);
+            } else {
+              op.settle();
+            }
             break;
           }
           if (
@@ -752,7 +773,11 @@ export class TimelinePlayer {
             this.events.onError?.(String(e));
           }
         }
-        op.settle();
+        if (op.kind === "append") {
+          op.settle(appended);
+        } else {
+          op.settle();
+        }
       }
     } finally {
       this.pumping = false;
@@ -763,11 +788,10 @@ export class TimelinePlayer {
     sb: SourceBuffer,
     offset: number,
     data: ArrayBuffer,
-  ): Promise<void> {
+  ): Promise<boolean> {
     for (let attempt = 0; ; attempt++) {
       try {
-        await this.appendOne(sb, offset, data);
-        return;
+        return await this.appendOne(sb, offset, data);
       } catch (e) {
         // QuotaExceededError is thrown synchronously when the buffer is full. Evict
         // and retry; this is the normal path during long playback, not an edge case.
@@ -775,7 +799,7 @@ export class TimelinePlayer {
           if (await this.evictForQuota(sb, offset)) continue;
           // Nothing evictable: give up this append; it will be retried as the
           // playhead advances and frees room.
-          return;
+          return false;
         }
         throw e;
       }
@@ -820,11 +844,11 @@ export class TimelinePlayer {
     sb: SourceBuffer,
     offset: number,
     data: ArrayBuffer,
-  ): Promise<void> {
+  ): Promise<boolean> {
     await waitForSourceBufferIdle(sb);
     // "ended" is fine here — setting timestampOffset / appendBuffer transitions the
     // MediaSource back to "open". Bail only when it's "closed" (detached on teardown).
-    if (this.disposed || this.mediaSource.readyState === "closed") return;
+    if (this.disposed || this.mediaSource.readyState === "closed") return false;
     if (offset !== this.lastAppliedOffset) {
       // Position this segment so buffered-time == timeline-time. Each segment is a
       // self-contained encode with its own IDR at `offset` (a frame-aligned time) and an
@@ -834,10 +858,10 @@ export class TimelinePlayer {
       sb.timestampOffset = offset;
       this.lastAppliedOffset = offset;
     }
-    await new Promise<void>((resolve, reject) => {
+    return await new Promise<boolean>((resolve, reject) => {
       const onEnd = () => {
         cleanup();
-        resolve();
+        resolve(true);
       };
       const onErr = () => {
         cleanup();
@@ -854,7 +878,7 @@ export class TimelinePlayer {
       // during real playback.
       const timer = setTimeout(() => {
         cleanup();
-        resolve();
+        resolve(false);
       }, SETTLE_TIMEOUT_MS);
       sb.addEventListener("updateend", onEnd);
       sb.addEventListener("error", onErr);

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -15,11 +15,11 @@ const PLAY_AHEAD = 10;
 // Buffered history kept behind the playhead before eviction frees it. The persistent
 // green bar comes from IndexedDB, so evicting MSE never shrinks it.
 const KEEP_BEHIND = 6;
-// Max seconds streamed (and cached) per /api/video.mp4 request. The fill loop streams
-// FORWARD from the playhead in pieces of at most this length, so an interrupted fetch
-// (seek away) wastes at most this much, and a completed piece is a self-contained,
-// frame-aligned cached segment.
-const STREAM_PIECE = 3;
+// Max seconds streamed (and cached) per paused/priming /api/video.mp4 request. Active
+// playback uses a much larger cap so ordinary short previews stream as one request, while
+// long timelines still retain a bounded memory/cache footprint.
+const PRIME_STREAM_PIECE = 3;
+const PLAY_STREAM_PIECE = 30;
 // Minimum length for a cached segment row to be worth re-appending from IndexedDB.
 // Shorter rows (shards from the old lookahead-clamped frontier) are streamed over in
 // full pieces instead — putSegment's subsume then deletes them, so a fragmented store
@@ -350,12 +350,17 @@ export class TimelinePlayer {
     // The video is parked on the correct frame: hold it and swap to the still only once a
     // fresh still for THIS time decodes, so pausing never flashes a stale frame.
     this.setDisplayMode("still", this.position, "hold");
-    // Deliberately do NOT bump fillGen or abort the in-flight stream. The piece being
-    // streamed when the user paused must finish and persist so the just-played region is
-    // cached without waste (req 7) — bumping fillGen would make streamSegment bail before
-    // putSegment. The fill loop re-reads `mode` each iteration, so it transparently
-    // downshifts to the priming look-ahead; the cursor stays put so fetched-ahead work is
-    // retained. (If the loop already idled, kickFill restarts it in priming mode.)
+    // Let short priming pieces finish and persist, but stop a long playback stream
+    // when the user pauses. Otherwise pausing near the start of a long timeline would keep
+    // the server encoding far past the now-still playhead.
+    if (
+      this.inflight &&
+      this.inflight.end - this.inflight.start > PRIME_STREAM_PIECE + EPSILON
+    ) {
+      this.abortInflight();
+    }
+    // The fill loop re-reads `mode` each iteration, so it transparently downshifts to
+    // priming look-ahead. If it already idled, kickFill restarts it in priming mode.
     this.kickFill();
   }
 
@@ -606,20 +611,23 @@ export class TimelinePlayer {
       }
 
       // Cache miss: stream FORWARD from the cursor (frame-aligned), bounded by the next
-      // committed cache range (in-memory) and STREAM_PIECE. Deliberately NOT bounded by
-      // targetEnd: the lookahead only gates WHEN to stream (the window check above), never
-      // the piece size. Clamping the piece to the moving lookahead edge degenerates the
-      // frontier into per-tick frame-sized requests once it catches up — each one a fresh
-      // server encode and a one-frame IndexedDB row — grinding forward caching far below
-      // realtime and fragmenting the store.
+      // committed cache range (in-memory). While playing, request a large continuous
+      // stream toward that boundary/tail, capped by PLAY_STREAM_PIECE; while priming,
+      // keep small bounded pieces so paused scrubs do not waste long encodes.
+      // Deliberately NOT bounded by targetEnd: the lookahead only gates WHEN to stream,
+      // never the piece size. Clamping to the moving lookahead edge degenerates the
+      // frontier into per-tick frame-sized requests once it catches up.
       // While the post-failure backoff is armed, end this pass instead of fetching —
       // the ticker re-kicks the fill every frame, so the retry happens as soon as the
       // backoff expires.
       if (Date.now() < this.streamBlockedUntil) return;
       const start = this.frameAlign(cursor);
+      const maxEnd =
+        start +
+        (this.mode === "playing" ? PLAY_STREAM_PIECE : PRIME_STREAM_PIECE);
       const end = Math.min(
         this.nextCachedStart(cursor),
-        start + STREAM_PIECE,
+        maxEnd,
         duration,
       );
       if (end <= start + EPSILON) {
@@ -635,8 +643,9 @@ export class TimelinePlayer {
   // Stream a segment FORWARD from `start` to `end`, appending each slice as it arrives and
   // persisting the WHOLE piece on natural EOF. A partial (aborted) fetch is NOT persisted
   // — a truncated fMP4 isn't a self-contained segment and could overlap a neighbour — so a
-  // cached segment is always frame-aligned and gap-free; STREAM_PIECE keeps the dropped
-  // amount small. Returns how far it actually reached (frame-aligned buffered end).
+  // cached segment is always frame-aligned and gap-free. Paused priming bounds the dropped
+  // amount; active playback aborts its long stream on seek/pause. Returns how far it
+  // actually reached (frame-aligned buffered end).
   private async streamSegment(start: number, end: number, gen: number): Promise<number> {
     const controller = new AbortController();
     const inflight: InFlight = {
@@ -709,7 +718,7 @@ export class TimelinePlayer {
       if (this.inflight === inflight) this.inflight = null;
       if (isAbortError(e)) {
         // Intentional interruption (seek/pause/dispose): drop the partial and recede the
-        // live edge. The bounded STREAM_PIECE keeps the re-streamed amount small.
+        // live edge. Stream spans are bounded so the re-streamed amount stays finite.
         this.emitRanges();
         return reached;
       }
@@ -833,9 +842,13 @@ export class TimelinePlayer {
       }
     }
     // PLAY_AHEAD past both the playhead and the appending segment keeps everything
-    // the player is about to need; segments are at most STREAM_PIECE long, so the
-    // append target itself can never be clipped.
-    const aheadStart = Math.max(playhead, offset) + PLAY_AHEAD;
+    // the player is about to need; include the active stream's nominal end as well so
+    // quota eviction never splits the row that will be persisted when it reaches EOF.
+    const inflightEnd =
+      this.inflight && this.inflight.start <= offset + EPSILON
+        ? this.inflight.end
+        : offset;
+    const aheadStart = Math.max(playhead, offset, inflightEnd) + PLAY_AHEAD;
     if (this.bufferedEnd() > aheadStart + EPSILON) {
       try {
         await this.removeRange(sb, aheadStart, Number.POSITIVE_INFINITY);
@@ -1214,16 +1227,11 @@ export class TimelinePlayer {
   private emitRanges(): void {
     if (this.disposed) return;
     // The green bar = everything playable without re-fetching from the server:
-    // IndexedDB-committed ranges (never shrink under MSE eviction), the in-flight
-    // segment's growing live edge, and whatever currently sits in the MSE buffer.
-    // The live buffer matters twice: an aborted partial stream stays perfectly
-    // playable even though it was never committed, and when IndexedDB writes fail
-    // the buffer is the only cache there is — committed-only would under-report both.
+    // IndexedDB-committed ranges (never shrink under MSE eviction) and whatever
+    // currently sits in the MSE buffer. The live buffer matters twice: an aborted
+    // partial stream stays playable even though it was never committed, and when
+    // IndexedDB writes fail the buffer is the only cache there is.
     const ranges = [...this.committedRanges, ...this.bufferedRanges()];
-    const inflight = this.inflight;
-    if (inflight && inflight.liveEnd > inflight.start + EPSILON) {
-      ranges.push({ start: inflight.start, end: inflight.liveEnd });
-    }
     this.events.onRanges?.(mergeRanges(ranges));
   }
 
@@ -1286,19 +1294,21 @@ export class TimelinePlayer {
     return t;
   }
 
-  // The buffered end of the in-flight segment [start,end] — clamped to its nominal end,
-  // scoped to the range containing `start` so lookahead/eviction of OTHER segments never
-  // moves the live green edge.
+  // The buffered end of the in-flight segment [start,end] — clamped to its nominal end
+  // and scoped to ranges overlapping that segment. The segment start may already be
+  // evicted behind the playhead before EOF, so this must not require a range containing
+  // `start`.
   private liveEndOf(start: number, end: number): number {
     const sb = this.sourceBuffer;
     if (!sb) return start;
     const buffered = sb.buffered;
+    let liveEnd = start;
     for (let i = 0; i < buffered.length; i++) {
-      if (buffered.start(i) <= start + EPSILON && buffered.end(i) > start + EPSILON) {
-        return Math.min(end, buffered.end(i));
+      if (buffered.end(i) > start + EPSILON && buffered.start(i) < end - EPSILON) {
+        liveEnd = Math.max(liveEnd, Math.min(end, buffered.end(i)));
       }
     }
-    return start;
+    return liveEnd;
   }
 
   private bufferedEnd(): number {

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -13,7 +13,6 @@ import type {
 const EPSILON = 0.001;
 const CRF = 23;
 const STILL_REQUEST_DEBOUNCE_MS = 100;
-const PLAYBACK_PROXY_MAX_EDGE = 640;
 
 export interface PreviewState {
   seconds: number;
@@ -56,12 +55,6 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
   const duration = timeline?.duration ?? 0;
   const width = Math.max(1, Math.round(resolution.width));
   const height = Math.max(1, Math.round(resolution.height));
-  const playbackResolution = useMemo(
-    () => playbackProxyResolution({ width, height }),
-    [width, height],
-  );
-  const playbackWidth = playbackResolution.width;
-  const playbackHeight = playbackResolution.height;
   const gop = Math.max(1, Math.floor(fps / 4));
 
   const groupKey = useMemo(
@@ -69,14 +62,14 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
       groupKeyOf({
         pluginKey,
         timelineId,
-        width: playbackWidth,
-        height: playbackHeight,
+        width,
+        height,
         fps,
         motionBlur,
         gop,
         crf: CRF,
       }),
-    [pluginKey, timelineId, playbackWidth, playbackHeight, fps, motionBlur, gop],
+    [pluginKey, timelineId, width, height, fps, motionBlur, gop],
   );
 
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -155,8 +148,8 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
       return videoUrl({
         timelineId,
         time: start,
-        width: playbackWidth,
-        height: playbackHeight,
+        width,
+        height,
         fps,
         motionBlur,
         gop,
@@ -303,8 +296,6 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
     duration,
     width,
     height,
-    playbackWidth,
-    playbackHeight,
     fps,
     motionBlur,
     gop,
@@ -394,18 +385,4 @@ function createStreamSession(): string {
 
 function isAbortError(e: unknown): boolean {
   return e instanceof DOMException && e.name === "AbortError";
-}
-
-function playbackProxyResolution(resolution: PreviewResolution): PreviewResolution {
-  const maxEdge = Math.max(resolution.width, resolution.height);
-  const scale =
-    maxEdge <= PLAYBACK_PROXY_MAX_EDGE ? 1 : PLAYBACK_PROXY_MAX_EDGE / maxEdge;
-  return {
-    width: evenDimension(resolution.width * scale),
-    height: evenDimension(resolution.height * scale),
-  };
-}
-
-function evenDimension(value: number): number {
-  return Math.max(2, Math.round(value / 2) * 2);
 }

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -124,6 +124,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
     }
     let cancelled = false;
     const cache = cacheRef.current!;
+    const streamSession = createStreamSession();
 
     const buildVideoUrl = (start: number, end: number): string => {
       const segmentDuration =
@@ -139,6 +140,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
         crf: CRF,
         duration: segmentDuration,
         cacheKey: pluginKey,
+        session: streamSession,
       });
     };
 
@@ -327,4 +329,12 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
 
 function clamp(value: number, duration: number): number {
   return Math.max(0, Math.min(Number.isFinite(value) ? value : 0, duration));
+}
+
+function createStreamSession(): string {
+  const crypto = globalThis.crypto;
+  if (crypto && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -13,6 +13,7 @@ import type {
 const EPSILON = 0.001;
 const CRF = 23;
 const STILL_REQUEST_DEBOUNCE_MS = 100;
+const PLAYBACK_PROXY_MAX_EDGE = 640;
 
 export interface PreviewState {
   seconds: number;
@@ -55,6 +56,12 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
   const duration = timeline?.duration ?? 0;
   const width = Math.max(1, Math.round(resolution.width));
   const height = Math.max(1, Math.round(resolution.height));
+  const playbackResolution = useMemo(
+    () => playbackProxyResolution({ width, height }),
+    [width, height],
+  );
+  const playbackWidth = playbackResolution.width;
+  const playbackHeight = playbackResolution.height;
   const gop = Math.max(1, Math.floor(fps / 4));
 
   const groupKey = useMemo(
@@ -62,14 +69,14 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
       groupKeyOf({
         pluginKey,
         timelineId,
-        width,
-        height,
+        width: playbackWidth,
+        height: playbackHeight,
         fps,
         motionBlur,
         gop,
         crf: CRF,
       }),
-    [pluginKey, timelineId, width, height, fps, motionBlur, gop],
+    [pluginKey, timelineId, playbackWidth, playbackHeight, fps, motionBlur, gop],
   );
 
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -148,8 +155,8 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
       return videoUrl({
         timelineId,
         time: start,
-        width,
-        height,
+        width: playbackWidth,
+        height: playbackHeight,
         fps,
         motionBlur,
         gop,
@@ -289,7 +296,20 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
       playerRef.current = null;
       void player?.dispose();
     };
-  }, [groupKey, pluginKey, timelineId, duration, width, height, fps, motionBlur, gop, setSeconds]);
+  }, [
+    groupKey,
+    pluginKey,
+    timelineId,
+    duration,
+    width,
+    height,
+    playbackWidth,
+    playbackHeight,
+    fps,
+    motionBlur,
+    gop,
+    setSeconds,
+  ]);
 
   // Revoke the last still URL on unmount.
   useEffect(
@@ -374,4 +394,18 @@ function createStreamSession(): string {
 
 function isAbortError(e: unknown): boolean {
   return e instanceof DOMException && e.name === "AbortError";
+}
+
+function playbackProxyResolution(resolution: PreviewResolution): PreviewResolution {
+  const maxEdge = Math.max(resolution.width, resolution.height);
+  const scale =
+    maxEdge <= PLAYBACK_PROXY_MAX_EDGE ? 1 : PLAYBACK_PROXY_MAX_EDGE / maxEdge;
+  return {
+    width: evenDimension(resolution.width * scale),
+    height: evenDimension(resolution.height * scale),
+  };
+}
+
+function evenDimension(value: number): number {
+  return Math.max(2, Math.round(value / 2) * 2);
 }

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -12,6 +12,7 @@ import type {
 
 const EPSILON = 0.001;
 const CRF = 23;
+const STILL_REQUEST_DEBOUNCE_MS = 100;
 
 export interface PreviewState {
   seconds: number;
@@ -107,6 +108,10 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
   // latest, and the object URL is revoked only after the next one is swapped in.
   const stillTokenRef = useRef(0);
   const stillUrlRef = useRef<string | null>(null);
+  const stillRequestRef = useRef<{
+    timer: ReturnType<typeof setTimeout> | null;
+    controller: AbortController | null;
+  }>({ timer: null, controller: null });
 
   const setSeconds = useCallback((value: number) => {
     secondsRef.current = value;
@@ -125,6 +130,17 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
     let cancelled = false;
     const cache = cacheRef.current!;
     const streamSession = createStreamSession();
+    const cancelStillRequest = () => {
+      const pending = stillRequestRef.current;
+      if (pending.timer != null) {
+        clearTimeout(pending.timer);
+        pending.timer = null;
+      }
+      if (pending.controller) {
+        pending.controller.abort();
+        pending.controller = null;
+      }
+    };
 
     const buildVideoUrl = (start: number, end: number): string => {
       const segmentDuration =
@@ -163,36 +179,51 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
         cacheKey: pluginKey,
       });
       const token = ++stillTokenRef.current;
-      void fetch(url, { cache: "no-store" })
-        .then((response) => {
-          if (!response.ok) throw new Error(`${url} failed: ${response.status}`);
-          return response.blob();
-        })
-        .then((blob) => {
-          if (token !== stillTokenRef.current || cancelled) return;
-          const objectUrl = URL.createObjectURL(blob);
-          // Decode in a throwaway Image first so a slow/broken frame never clobbers a
-          // newer one and we never flash a half-decoded image.
-          const image = new Image();
-          image.onload = () => {
+      cancelStillRequest();
+      const controller = new AbortController();
+      stillRequestRef.current.controller = controller;
+      stillRequestRef.current.timer = setTimeout(() => {
+        stillRequestRef.current.timer = null;
+        void fetch(url, { cache: "no-store", signal: controller.signal })
+          .then((response) => {
+            if (!response.ok) throw new Error(`${url} failed: ${response.status}`);
+            return response.blob();
+          })
+          .then((blob) => {
             if (token !== stillTokenRef.current || cancelled) {
-              URL.revokeObjectURL(objectUrl);
               return;
             }
-            const previous = stillUrlRef.current;
-            stillUrlRef.current = objectUrl;
-            setImageSrc(objectUrl);
-            // Reveal only now — the still matches the intended time, so swapping the held
-            // video frame for it is seamless (same frame, no flash).
-            if (revealOnLoad) setImageVisible(true);
-            if (previous && previous !== objectUrl) URL.revokeObjectURL(previous);
-          };
-          image.onerror = () => URL.revokeObjectURL(objectUrl);
-          image.src = objectUrl;
-        })
-        .catch(() => {
-          // A failed still leaves the held frame up; the player surfaces real errors.
-        });
+            const objectUrl = URL.createObjectURL(blob);
+            // Decode in a throwaway Image first so a slow/broken frame never clobbers a
+            // newer one and we never flash a half-decoded image.
+            const image = new Image();
+            image.onload = () => {
+              if (token !== stillTokenRef.current || cancelled) {
+                URL.revokeObjectURL(objectUrl);
+                return;
+              }
+              const previous = stillUrlRef.current;
+              stillUrlRef.current = objectUrl;
+              setImageSrc(objectUrl);
+              // Reveal only now — the still matches the intended time, so swapping the held
+              // video frame for it is seamless (same frame, no flash).
+              if (revealOnLoad) setImageVisible(true);
+              if (previous && previous !== objectUrl) URL.revokeObjectURL(previous);
+            };
+            image.onerror = () => URL.revokeObjectURL(objectUrl);
+            image.src = objectUrl;
+          })
+          .catch((e) => {
+            if (!isAbortError(e)) {
+              // A failed still leaves the held frame up; the player surfaces real errors.
+            }
+          })
+          .finally(() => {
+            if (stillRequestRef.current.controller === controller) {
+              stillRequestRef.current.controller = null;
+            }
+          });
+      }, STILL_REQUEST_DEBOUNCE_MS);
     };
 
     void cache.activatePlugin(pluginKey).then(() => {
@@ -226,6 +257,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
               // (e.g. the still requested as play() began) can't re-cover the now-running
               // video by firing its revealOnLoad after we switched to video.
               stillTokenRef.current++;
+              cancelStillRequest();
             } else if (cover === "hold") {
               // The current display (parked video frame or trailing still) is the best
               // stand-in (pause / end / play / paused scrub over cold frames): keep it
@@ -252,6 +284,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
 
     return () => {
       cancelled = true;
+      cancelStillRequest();
       const player = playerRef.current;
       playerRef.current = null;
       void player?.dispose();
@@ -337,4 +370,8 @@ function createStreamSession(): string {
     return crypto.randomUUID();
   }
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function isAbortError(e: unknown): boolean {
+  return e instanceof DOMException && e.name === "AbortError";
 }

--- a/tellur-plugin/src/lib.rs
+++ b/tellur-plugin/src/lib.rs
@@ -43,7 +43,11 @@ pub use tellur_core as __core;
 /// vtable slot and `GpuRasterBackend` gained `temporal_average`, so a `v2`
 /// plugin calling through a `v3` host context would hit the same class of
 /// vtable mismatch.
-pub const ENTRY_SYMBOL: &[u8] = b"tellur_timeline_collection_v3\0";
+///
+/// Bumped to `v4` for live-preview audio windows: `TimelineCollection` gained
+/// `render_audio_window`, so stale `v3` plugins must fail at `dlsym` instead of
+/// landing on the wrong vtable slot.
+pub const ENTRY_SYMBOL: &[u8] = b"tellur_timeline_collection_v4\0";
 
 /// The signature of the [`ENTRY_SYMBOL`] entry point a plugin exports.
 pub type EntryFn = unsafe extern "Rust" fn() -> Box<dyn TimelineCollection>;
@@ -88,6 +92,22 @@ pub trait TimelineCollection: Send {
     /// consistent A/V stream structure). Defaulted so collections migrate in
     /// stages, mirroring [`arrangement`](Self::arrangement).
     fn render_audio(&self, _id: &str, _rate: u32, _channels: u16) -> Option<AudioBuffer> {
+        None
+    }
+
+    /// Eager audio mix-down for `[start, start + duration)`, used by the live
+    /// preview when it encodes an individual cache segment. Custom collections
+    /// must implement this explicitly to preview audio; falling back to the
+    /// whole-track [`render_audio`](Self::render_audio) would reintroduce the
+    /// per-segment full-timeline work this API avoids.
+    fn render_audio_window(
+        &self,
+        _id: &str,
+        _start: f32,
+        _duration: f32,
+        _rate: u32,
+        _channels: u16,
+    ) -> Option<AudioBuffer> {
         None
     }
 }
@@ -188,6 +208,23 @@ impl TimelineCollection for SingleTimeline {
         // determinate track to mux.
         Some(self.resolved()?.render_audio(rate, channels))
     }
+
+    fn render_audio_window(
+        &self,
+        id: &str,
+        start: f32,
+        duration: f32,
+        rate: u32,
+        channels: u16,
+    ) -> Option<AudioBuffer> {
+        if id != self.id {
+            return None;
+        }
+        Some(
+            self.resolved()?
+                .render_audio_window(start, duration, rate, channels),
+        )
+    }
 }
 
 /// Adapts an old closure-based [`Timeline`] to the new [`TimelineComponent`]
@@ -276,14 +313,14 @@ impl<T: Timeline + Send + 'static> TimelineComponent for LegacyTimeline<T> {
 macro_rules! export_timeline {
     ($id:expr, $title:expr, $builder:path) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v3(
+        pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($crate::single_timeline($id, $title, $builder()))
         }
     };
     ($id:expr, $title:expr, $builder:path, canvas = ($w:expr, $h:expr)) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v3(
+        pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($crate::single_timeline_with_canvas(
                 $id,
@@ -307,7 +344,7 @@ macro_rules! export_timeline {
 macro_rules! export_legacy_timeline {
     ($id:expr, $title:expr, $builder:path) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v3(
+        pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($crate::single_timeline(
                 $id,
@@ -323,7 +360,7 @@ macro_rules! export_legacy_timeline {
 macro_rules! export_timeline_collection {
     ($builder:path) => {
         #[no_mangle]
-        pub extern "Rust" fn tellur_timeline_collection_v3(
+        pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
             ::std::boxed::Box::new($builder())
         }

--- a/tellur-renderer/src/render_context.rs
+++ b/tellur-renderer/src/render_context.rs
@@ -267,6 +267,7 @@ pub struct CachingRenderContext {
     gpu_preference: GpuPreference,
     gpu: Option<GpuRenderer>,
     gpu_init_attempted: bool,
+    gpu_init_error: Option<String>,
     motion_blur_enabled: bool,
     // Running total of every `ctx.render` call's inclusive duration.
     // A `render` invocation snapshots this on entry and re-reads it on
@@ -298,6 +299,7 @@ impl CachingRenderContext {
             gpu_preference: GpuPreference::Auto,
             gpu: None,
             gpu_init_attempted: false,
+            gpu_init_error: None,
             motion_blur_enabled: true,
             total_render_time: Duration::ZERO,
         }
@@ -330,7 +332,15 @@ impl CachingRenderContext {
             return None;
         }
         self.gpu_init_attempted = true;
-        self.gpu = GpuRenderer::new().ok();
+        match GpuRenderer::new() {
+            Ok(gpu) => {
+                self.gpu_init_error = None;
+                self.gpu = Some(gpu);
+            }
+            Err(err) => {
+                self.gpu_init_error = Some(err);
+            }
+        }
         self.gpu.as_mut()
     }
 
@@ -342,6 +352,12 @@ impl CachingRenderContext {
     /// Configured maximum capacity in bytes.
     pub fn capacity_bytes(&self) -> usize {
         self.cap_bytes
+    }
+
+    /// The last GPU initialization error, when backend creation was attempted
+    /// but no renderer is available.
+    pub fn gpu_init_error(&self) -> Option<&str> {
+        self.gpu_init_error.as_deref()
     }
 
     /// A snapshot of the cumulative cache counters. The per-type table


### PR DESCRIPTION
Fixes the remaining live-preview stalls by tightening the media streaming pipeline, cancelling stale requests, preserving the selected preview resolution, and surfacing GPU/render timing diagnostics. The preview now avoids repeated stale frame/video fetches, reports append/codec failures instead of silently wedging playback, and exposes whether frame renders actually used the GPU. 14 files (+708 / -191) across `tellur-core`, `tellur-live`, `tellur-plugin`, and `tellur-renderer`.

## Playback and stream stability
- Renders live preview audio by segment and propagates SourceBuffer append failures back to the UI.
- Avoids mismatched preview MP4 codecs and cancels superseded video streams/still-frame requests.
- Reduces duplicate video request churn while keeping playback at the selected preview resolution.

## Render performance and diagnostics
- Caps the live preview render cache and skips unchanged plugin hashing.
- Defaults live-preview motion blur off and speeds up PNG still-frame responses.
- Adds render timing, output, cache, and GPU availability/activity diagnostics to preview responses.

## Verification
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo check -p tellur-live`
- `nix develop -c cargo test -p tellur-renderer render_context`
- `nix develop -c cargo test -p tellur-live`
- `npm run build`
- `nix develop -c cargo build -p tellur-live --release --bin tellur-live --example demo_timeline_plugin`
- Ran the demo preview on `0.0.0.0:4318` and verified 1080p frame/video responses reported active GPU diagnostics.
