### PR TITLE
feat(live): show project name in header

### DIFF
--- a/tellur-live/src/main.rs
+++ b/tellur-live/src/main.rs
@@ -116,6 +116,10 @@ fn parse_args(mut args: impl Iterator<Item = String>) -> Result<ServerOptions, B
     let plugin_path = plugin_path
         .or_else(|| build_example.as_deref().map(infer_plugin_path))
         .ok_or_else(usage)?;
+    let project_name = build_package
+        .clone()
+        .or_else(|| infer_example_name(&plugin_path))
+        .unwrap_or_else(|| "Project Name".to_owned());
     let auto_build = if auto_build_requested {
         let example = build_example
             .or_else(|| infer_example_name(&plugin_path))
@@ -141,6 +145,7 @@ fn parse_args(mut args: impl Iterator<Item = String>) -> Result<ServerOptions, B
 
     Ok(ServerOptions {
         plugin_path,
+        project_name,
         bind: bind.unwrap_or_else(|| format!("{host}:{port}")),
         resolution,
         fps,

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -32,6 +32,7 @@ const LIVE_PREVIEW_CACHE_BYTES: usize = 256 * 1024 * 1024;
 #[derive(Debug, Clone)]
 pub struct ServerOptions {
     pub plugin_path: PathBuf,
+    pub project_name: String,
     pub bind: String,
     pub resolution: Resolution,
     pub fps: u32,
@@ -59,6 +60,7 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
 
     let app = Arc::new(Mutex::new(PreviewApp {
         plugin: HotReloadPlugin::new(options.plugin_path),
+        project_name: options.project_name,
         ctx: CachingRenderContext::with_capacity_bytes(LIVE_PREVIEW_CACHE_BYTES)
             .with_gpu_preference(options.gpu_preference),
         resolution: options.resolution,
@@ -214,6 +216,7 @@ fn is_client_disconnect(error: &(dyn Error + 'static)) -> bool {
 
 struct PreviewApp {
     plugin: HotReloadPlugin,
+    project_name: String,
     ctx: CachingRenderContext,
     resolution: Resolution,
     fps: u32,
@@ -272,6 +275,7 @@ impl PreviewApp {
         let timelines = self.plugin.collection()?.timelines();
         let compile = self.compile_state.snapshot();
         Ok(info_json(
+            &self.project_name,
             self.resolution,
             self.fps,
             &timelines,
@@ -1512,6 +1516,7 @@ fn sanitize_header_value(value: &str) -> String {
 }
 
 fn info_json(
+    project_name: &str,
     resolution: Resolution,
     fps: u32,
     timelines: &[TimelineInfo],
@@ -1545,7 +1550,8 @@ fn info_json(
         None => "null".to_owned(),
     };
     format!(
-        "{{\"width\":{},\"height\":{},\"fps\":{},\"lastError\":{},\"cacheKey\":\"{}\",\"compileStatus\":\"{}\",\"compileError\":{},\"timelines\":[{}]}}",
+        "{{\"projectName\":\"{}\",\"width\":{},\"height\":{},\"fps\":{},\"lastError\":{},\"cacheKey\":\"{}\",\"compileStatus\":\"{}\",\"compileError\":{},\"timelines\":[{}]}}",
+        json_escape(project_name),
         resolution.width,
         resolution.height,
         fps,
@@ -1721,6 +1727,30 @@ mod tests {
 
         query.insert("motion_blur".to_owned(), "true".to_owned());
         assert!(request_motion_blur(&query));
+    }
+
+    #[test]
+    fn info_json_includes_the_project_name() {
+        let timelines = vec![TimelineInfo {
+            id: "main".to_owned(),
+            title: "Main".to_owned(),
+            duration: 4.0,
+            error: None,
+        }];
+        let json = info_json(
+            "demo \"crate\"",
+            Resolution::new(1280, 720),
+            30,
+            &timelines,
+            None,
+            "cache-key",
+            &CompileSnapshot::compiled(),
+        );
+
+        assert_eq!(
+            json,
+            "{\"projectName\":\"demo \\\"crate\\\"\",\"width\":1280,\"height\":720,\"fps\":30,\"lastError\":null,\"cacheKey\":\"cache-key\",\"compileStatus\":\"compiled\",\"compileError\":null,\"timelines\":[{\"id\":\"main\",\"title\":\"Main\",\"duration\":4,\"error\":null}]}"
+        );
     }
 
     // Round-trips the `.sketch/01` B.4 arrangement shape at a small scale: an

--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -389,7 +389,7 @@ export function App() {
   return (
     <div className="app">
       <Header
-        projectName="Project Name"
+        projectName={info?.projectName ?? "Project Name"}
         url={url}
         compileStatus={
           loadError ? "disconnected" : info?.compileStatus ?? "compiled"

--- a/tellur-live/web/src/components/Header.tsx
+++ b/tellur-live/web/src/components/Header.tsx
@@ -36,7 +36,9 @@ export function Header({
         Tellur
       </span>
       <span className="header__project">
-        <span className="header__project-name">{projectName}</span>
+        <span className="header__project-name" title={projectName}>
+          {projectName}
+        </span>
         <span className="header__project-divider">—</span>
         <span className="header__project-url">{url}</span>
         <span

--- a/tellur-live/web/src/styles/global.css
+++ b/tellur-live/web/src/styles/global.css
@@ -189,9 +189,12 @@ select option {
 }
 
 .header__project-name {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
   color: var(--text-primary);
   font-weight: 700;
+  text-overflow: ellipsis;
 }
 
 .header__project-divider {

--- a/tellur-live/web/src/types.ts
+++ b/tellur-live/web/src/types.ts
@@ -38,6 +38,7 @@ export interface PreviewResolution {
 }
 
 export interface ServerInfo {
+  projectName: string;
   width: number;
   height: number;
   fps: number;

--- a/tellur/src/bin/tellur.rs
+++ b/tellur/src/bin/tellur.rs
@@ -171,6 +171,7 @@ fn live(args: LiveArgs) -> Result<(), Box<dyn Error>> {
 
     serve(ServerOptions {
         plugin_path,
+        project_name: package.name.clone(),
         bind: format!("{}:{}", args.host, args.port),
         resolution,
         fps: args.fps,


### PR DESCRIPTION
Surfaces the resolved Tellur project name in the live preview header instead of the placeholder label. `tellur live` now passes the Cargo package name through `/api/info`, while standalone `tellur-live serve` falls back to the build package or inferred plugin file name. 7 files (+46 / -4) across `tellur` and `tellur-live`.

## Live project metadata
- Adds `projectName` to the live server info payload and covers its JSON emission with a focused test.
- Wires `tellur live` to pass the resolved Cargo package name to the preview server.
- Infers a display name for direct `tellur-live serve` usage from `--package` or the plugin file name.

## Header display
- Replaces the fixed `Project Name` header label with the server-provided name.
- Keeps the existing placeholder while info is loading and truncates long names cleanly.

## Verification
- `nix develop -c cargo test -p tellur-live -p tellur --all-targets`
- `env PATH=/home/aspulse/repos/tellur/tellur-live/web/node_modules/.bin:$PATH npm run build`
