### PR TITLE
ci: allow crate scopes in PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,9 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^(feat|fix|refactor|ci|test|chore|docs|perf|style|build|revert)(\((core|renderer|deps)\))?!?: [a-z].+'
+          allowed_scopes="tellur, core, live, macros, plugin, renderer, deps"
+          scope_pattern='(tellur|core|live|macros|plugin|renderer|deps)'
+          pattern="^(feat|fix|refactor|ci|test|chore|docs|perf|style|build|revert)(\\(${scope_pattern}\\))?!?: [a-z].+"
           if [[ "$PR_TITLE" =~ $pattern ]]; then
             echo "✓ $PR_TITLE"
           else
@@ -23,7 +25,7 @@ jobs:
             echo "Got:      $PR_TITLE"
             echo ""
             echo "Allowed types: feat, fix, refactor, ci, test, chore, docs, perf, style, build, revert"
-            echo "Allowed scopes (optional): core, renderer, deps"
+            echo "Allowed scopes (optional): $allowed_scopes"
             echo "Description must start with a lowercase letter."
             exit 1
           fi


### PR DESCRIPTION
Updates the PR title workflow so crate-related scopes use the shorthand names used in commit titles: `tellur`, `core`, `live`, `macros`, `plugin`, and `renderer`. Dependency PRs can still use `deps`, and full crate names such as `tellur-live` are no longer accepted. 1 file (+4 / -2) in `.github/workflows`.

## PR title validation
- Defines the allowed scope list separately from the regex so the error output stays in sync.
- Accepts shorthand crate scopes plus `deps`.
- Keeps the existing Conventional Commit type and lowercase description checks.

## Verification
- `git diff --check`
- Tested the Bash regex against accepted shorthand scopes and rejected `feat(tellur-live): ...`.
