### PR TITLE
fix(renderer): align stacked raster outlines

### DIFF
--- a/tellur-core/src/render_context.rs
+++ b/tellur-core/src/render_context.rs
@@ -155,8 +155,6 @@ pub struct OutlineInput<'a> {
     pub target: Resolution,
     pub child_offset_x: i32,
     pub child_offset_y: i32,
-    pub outline_offset_x: i32,
-    pub outline_offset_y: i32,
     pub radius_x: u32,
     pub radius_y: u32,
     pub color: Color,

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -1449,6 +1449,43 @@ struct Params {
 @group(0) @binding(1) var<storage, read> alpha: array<u32>;
 @group(0) @binding(2) var<storage, read> params: Params;
 
+fn line_coverage(delta: i32, radius: u32) -> f32 {
+    let edge_distance = f32(abs(delta)) - f32(radius);
+    return clamp(0.5 - edge_distance, 0.0, 1.0);
+}
+
+fn ellipse_coverage(dx: i32, dy: i32, rx: u32, ry: u32) -> f32 {
+    if (rx == 0u && ry == 0u) {
+        return select(0.0, 1.0, dx == 0 && dy == 0);
+    }
+    if (rx == 0u) {
+        if (dx != 0) {
+            return 0.0;
+        }
+        return line_coverage(dy, ry);
+    }
+    if (ry == 0u) {
+        if (dy != 0) {
+            return 0.0;
+        }
+        return line_coverage(dx, rx);
+    }
+
+    let dx_f = f32(dx);
+    let dy_f = f32(dy);
+    let center_distance = sqrt(dx_f * dx_f + dy_f * dy_f);
+    if (center_distance == 0.0) {
+        return 1.0;
+    }
+
+    let nx = dx_f / f32(rx);
+    let ny = dy_f / f32(ry);
+    let normalized = sqrt(nx * nx + ny * ny);
+    let radius_along_ray = center_distance / normalized;
+    let edge_distance = center_distance - radius_along_ray;
+    return clamp(0.5 - edge_distance, 0.0, 1.0);
+}
+
 @compute @workgroup_size(16, 16)
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let x = id.x;
@@ -1459,34 +1496,33 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
 
     let rx = i32(params.radius_x);
     let ry = i32(params.radius_y);
-    let rx2 = max(rx * rx, 1);
-    let ry2 = max(ry * ry, 1);
-    let limit = rx2 * ry2;
-    var m = 0u;
-    var oy = -ry;
+    var m = 0.0;
+    var oy = -(ry + 1);
     loop {
-        var ox = -rx;
+        var ox = -(rx + 1);
         loop {
-            if (ox * ox * ry2 + oy * oy * rx2 <= limit) {
+            let coverage = ellipse_coverage(ox, oy, params.radius_x, params.radius_y);
+            if (coverage > 0.0) {
                 let sx = i32(x) + ox;
                 let sy = i32(y) + oy;
                 if (sx >= 0 && sy >= 0 && sx < i32(params.src_w) && sy < i32(params.src_h)) {
-                    m = max(m, alpha[u32(sy) * params.src_w + u32(sx)]);
+                    m = max(m, f32(alpha[u32(sy) * params.src_w + u32(sx)]) * coverage);
                 }
             }
-            if (ox >= rx) {
+            if (ox >= rx + 1) {
                 break;
             }
             ox = ox + 1;
         }
-        if (oy >= ry) {
+        if (oy >= ry + 1) {
             break;
         }
         oy = oy + 1;
     }
 
+    let dilated = u32(round(clamp(m, 0.0, 255.0)));
     let orig = alpha[y * params.src_w + x];
-    let ring = select(0u, m - orig, m > orig);
+    let ring = select(0u, dilated - orig, dilated > orig);
     let a = (ring * params.a + 127u) / 255u;
     if (a == 0u) {
         return;
@@ -1782,9 +1818,9 @@ mod tests {
         assert_eq!(
             rendered.pixels.as_ref(),
             &[
-                0, 0, 0, 0, 1, 2, 3, 255, 0, 0, 0, 0, //
-                1, 2, 3, 255, 9, 8, 7, 255, 1, 2, 3, 255, //
-                0, 0, 0, 0, 1, 2, 3, 255, 0, 0, 0, 0,
+                1, 2, 3, 22, 1, 2, 3, 128, 1, 2, 3, 22, //
+                1, 2, 3, 128, 9, 8, 7, 255, 1, 2, 3, 128, //
+                1, 2, 3, 22, 1, 2, 3, 128, 1, 2, 3, 22,
             ]
         );
     }

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -91,8 +91,8 @@ struct CopyAlphaParams {
     src_h: u32,
     out_w: u32,
     out_h: u32,
-    pad_x: u32,
-    pad_y: u32,
+    offset_x: i32,
+    offset_y: i32,
     _pad0: u32,
     _pad1: u32,
 }
@@ -365,16 +365,16 @@ impl GpuRenderer {
         encoder: &mut wgpu::CommandEncoder,
         src: &GpuBufferImage,
         alpha: &GpuBufferImage,
-        pad_x: u32,
-        pad_y: u32,
+        offset_x: i32,
+        offset_y: i32,
     ) {
         let params = CopyAlphaParams {
             src_w: src.width,
             src_h: src.height,
             out_w: alpha.width,
             out_h: alpha.height,
-            pad_x,
-            pad_y,
+            offset_x,
+            offset_y,
             _pad0: 0,
             _pad1: 0,
         };
@@ -729,7 +729,7 @@ impl GpuRasterBackend for GpuRenderer {
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some("tellur-gpu-drop-shadow"),
             });
-        self.copy_alpha(&mut encoder, &child, &alpha_a, pad, pad);
+        self.copy_alpha(&mut encoder, &child, &alpha_a, pad as i32, pad as i32);
         self.blur_alpha(&mut encoder, &alpha_a, &alpha_b, input.blur_radius);
         self.composite_shadow_alpha(
             &mut encoder,
@@ -757,9 +757,7 @@ impl GpuRasterBackend for GpuRenderer {
         if child.format != PixelFormat::Rgba8 {
             return None;
         }
-        let outline_w = child.width.checked_add(input.radius_x.checked_mul(2)?)?;
-        let outline_h = child.height.checked_add(input.radius_y.checked_mul(2)?)?;
-        let alpha = self.alpha_image(outline_w, outline_h);
+        let alpha = self.alpha_image(input.target.width, input.target.height);
         let target = self.empty_image(input.target);
 
         let mut encoder = self
@@ -767,12 +765,18 @@ impl GpuRasterBackend for GpuRenderer {
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some("tellur-gpu-outline"),
             });
-        self.copy_alpha(&mut encoder, &child, &alpha, input.radius_x, input.radius_y);
+        self.copy_alpha(
+            &mut encoder,
+            &child,
+            &alpha,
+            input.child_offset_x,
+            input.child_offset_y,
+        );
         self.composite_outline_alpha(
             &mut encoder,
             &target,
             &alpha,
-            (input.outline_offset_x, input.outline_offset_y),
+            (0, 0),
             (input.radius_x, input.radius_y),
             input.color,
         );
@@ -1303,8 +1307,8 @@ struct Params {
     src_h: u32,
     out_w: u32,
     out_h: u32,
-    pad_x: u32,
-    pad_y: u32,
+    offset_x: i32,
+    offset_y: i32,
     pad0: u32,
     pad1: u32,
 }
@@ -1321,12 +1325,14 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
         return;
     }
     let out_idx = y * params.out_w + x;
-    if (x < params.pad_x || y < params.pad_y) {
+    let sx_i = i32(x) - params.offset_x;
+    let sy_i = i32(y) - params.offset_y;
+    if (sx_i < 0 || sy_i < 0) {
         alpha[out_idx] = 0u;
         return;
     }
-    let sx = x - params.pad_x;
-    let sy = y - params.pad_y;
+    let sx = u32(sx_i);
+    let sy = u32(sy_i);
     if (sx >= params.src_w || sy >= params.src_h) {
         alpha[out_idx] = 0u;
         return;
@@ -1521,9 +1527,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     }
 
     let dilated = u32(round(clamp(m, 0.0, 255.0)));
-    let orig = alpha[y * params.src_w + x];
-    let ring = select(0u, dilated - orig, dilated > orig);
-    let a = (ring * params.a + 127u) / 255u;
+    let a = (dilated * params.a + 127u) / 255u;
     if (a == 0u) {
         return;
     }
@@ -1805,8 +1809,6 @@ mod tests {
             target: Resolution::new(3, 3),
             child_offset_x: 1,
             child_offset_y: 1,
-            outline_offset_x: 0,
-            outline_offset_y: 0,
             radius_x: 1,
             radius_y: 1,
             color: Color::rgba_u8(1, 2, 3, 255),

--- a/tellur-renderer/src/outline.rs
+++ b/tellur-renderer/src/outline.rs
@@ -51,17 +51,6 @@ impl RasterComponent for Outline {
         let sy = target.height as f32 / paint.size.1;
         let gpu_available = ctx.prefers_gpu() && ctx.gpu_backend().is_some();
 
-        // Render the child through the context so its output is memoized
-        // independently of the outline — matches the shadow component's
-        // strategy for static subtrees.
-        let child_px_w = (child_paint.size.0 * sx).round().max(1.0) as u32;
-        let child_px_h = (child_paint.size.1 * sy).round().max(1.0) as u32;
-        let child_image = ctx.render(
-            self.child.as_ref(),
-            size,
-            Resolution::new(child_px_w, child_px_h),
-        );
-
         // Dilate the child alpha by `width` logical units and subtract
         // the original alpha so only the ring outside the child
         // remains. The dilation radius is computed independently along
@@ -71,6 +60,16 @@ impl RasterComponent for Outline {
         // past the buffer edge and get clipped.
         let width_px_x = (self.width.max(0.0) * sx).round() as u32;
         let width_px_y = (self.width.max(0.0) * sy).round() as u32;
+        let child_px_w = inner_axis_pixels(target.width, width_px_x);
+        let child_px_h = inner_axis_pixels(target.height, width_px_y);
+        // Render the child through the context so its output is memoized
+        // independently of the outline — matches the shadow component's
+        // strategy for static subtrees.
+        let child_image = ctx.render(
+            self.child.as_ref(),
+            size,
+            Resolution::new(child_px_w, child_px_h),
+        );
 
         let pad_lu_x = width_px_x as f32 / sx;
         let pad_lu_y = width_px_y as f32 / sy;
@@ -131,6 +130,10 @@ fn blank_image(target: Resolution) -> RasterImage {
     )
 }
 
+fn inner_axis_pixels(target: u32, pad: u32) -> u32 {
+    target.saturating_sub(pad.saturating_mul(2)).max(1)
+}
+
 fn make_outline(
     image: &CpuRasterImage,
     width_px_x: u32,
@@ -155,13 +158,13 @@ fn make_outline(
         }
     }
 
-    // Dilate the alpha by an elliptical structuring element so the
-    // outline tracks the shape's curvature. A separable square SE is
-    // cheaper but visibly flattens curved tips (the top/bottom of a
-    // circle becomes a horizontal cap); the ellipse keeps the contour
-    // following the original shape, even when sx ≠ sy.
+    // Dilate the alpha by an antialiased elliptical structuring
+    // element so the outline tracks the shape's curvature. A separable
+    // square SE is cheaper but visibly flattens curved tips (the
+    // top/bottom of a circle becomes a horizontal cap); the ellipse
+    // keeps the contour following the original shape, even when sx ≠ sy.
     let dilated = if pad_x > 0 || pad_y > 0 {
-        dilate_ellipse(&alpha, out_w, out_h, pad_x, pad_y)
+        dilate_ellipse_antialiased(&alpha, out_w, out_h, pad_x, pad_y)
     } else {
         alpha.clone()
     };
@@ -189,13 +192,15 @@ fn make_outline(
 
 /// Morphological dilation by an axis-aligned ellipse with semi-axes
 /// `rx` and `ry` (in pixels). For each output pixel, the result is the
-/// max of all source pixels `(x+dx, y+dy)` whose offset satisfies
-/// `(dx/rx)^2 + (dy/ry)^2 <= 1`.
+/// max of nearby source alpha, weighted by a 1px linear coverage ramp at
+/// the ellipse boundary. The ramp keeps a 1:1 render (notably 1080p
+/// when logical units map directly to pixels) from exposing a jagged
+/// binary dilation edge.
 ///
 /// Not separable: the ellipse SE has to be applied as a 2-D
 /// neighborhood. Cost is O(W·H·|SE|) ≈ O(W·H·π·rx·ry), which is fine
 /// here because the outline is memoized on a per-subtree basis.
-fn dilate_ellipse(src: &[u8], w: usize, h: usize, rx: usize, ry: usize) -> Vec<u8> {
+fn dilate_ellipse_antialiased(src: &[u8], w: usize, h: usize, rx: usize, ry: usize) -> Vec<u8> {
     let mut dst = vec![0u8; w * h];
     if w == 0 || h == 0 || (rx == 0 && ry == 0) {
         dst.copy_from_slice(src);
@@ -203,13 +208,12 @@ fn dilate_ellipse(src: &[u8], w: usize, h: usize, rx: usize, ry: usize) -> Vec<u
     }
     let rx_i = rx as i64;
     let ry_i = ry as i64;
-    let rx2 = (rx_i * rx_i).max(1);
-    let ry2 = (ry_i * ry_i).max(1);
-    let mut offsets: Vec<(i64, i64)> = Vec::new();
-    for dy in -ry_i..=ry_i {
-        for dx in -rx_i..=rx_i {
-            if dx * dx * ry2 + dy * dy * rx2 <= rx2 * ry2 {
-                offsets.push((dx, dy));
+    let mut offsets: Vec<(i64, i64, f32)> = Vec::new();
+    for dy in -(ry_i + 1)..=(ry_i + 1) {
+        for dx in -(rx_i + 1)..=(rx_i + 1) {
+            let coverage = ellipse_coverage(dx, dy, rx, ry);
+            if coverage > 0.0 {
+                offsets.push((dx, dy, coverage));
             }
         }
     }
@@ -218,11 +222,12 @@ fn dilate_ellipse(src: &[u8], w: usize, h: usize, rx: usize, ry: usize) -> Vec<u
     for y in 0..h {
         for x in 0..w {
             let mut m: u8 = 0;
-            for &(dx, dy) in &offsets {
+            for &(dx, dy, coverage) in &offsets {
                 let nx = x as i64 + dx;
                 let ny = y as i64 + dy;
                 if nx >= 0 && nx < w_i && ny >= 0 && ny < h_i {
-                    let v = src[(ny as usize) * w + (nx as usize)];
+                    let src_alpha = src[(ny as usize) * w + (nx as usize)] as f32;
+                    let v = (src_alpha * coverage).round().clamp(0.0, 255.0) as u8;
                     if v > m {
                         m = v;
                     }
@@ -232,4 +237,77 @@ fn dilate_ellipse(src: &[u8], w: usize, h: usize, rx: usize, ry: usize) -> Vec<u
         }
     }
     dst
+}
+
+fn ellipse_coverage(dx: i64, dy: i64, rx: usize, ry: usize) -> f32 {
+    match (rx, ry) {
+        (0, 0) => {
+            if dx == 0 && dy == 0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        (0, ry) => {
+            if dx != 0 {
+                return 0.0;
+            }
+            let edge_distance = dy.unsigned_abs() as f32 - ry as f32;
+            (0.5 - edge_distance).clamp(0.0, 1.0)
+        }
+        (rx, 0) => {
+            if dy != 0 {
+                return 0.0;
+            }
+            let edge_distance = dx.unsigned_abs() as f32 - rx as f32;
+            (0.5 - edge_distance).clamp(0.0, 1.0)
+        }
+        (rx, ry) => {
+            let dx_f = dx as f32;
+            let dy_f = dy as f32;
+            let center_distance = (dx_f * dx_f + dy_f * dy_f).sqrt();
+            if center_distance == 0.0 {
+                return 1.0;
+            }
+
+            let nx = dx_f / rx as f32;
+            let ny = dy_f / ry as f32;
+            let normalized = (nx * nx + ny * ny).sqrt();
+            let radius_along_ray = center_distance / normalized;
+            let edge_distance = center_distance - radius_along_ray;
+            (0.5 - edge_distance).clamp(0.0, 1.0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opaque_pixel() -> CpuRasterImage {
+        CpuRasterImage::new(1, 1, PixelFormat::Rgba8, vec![9, 8, 7, 255])
+    }
+
+    fn alpha_at(image: &CpuRasterImage, x: usize, y: usize) -> u8 {
+        image.pixels[(y * image.width as usize + x) * 4 + 3]
+    }
+
+    #[test]
+    fn inner_axis_pixels_keeps_padding_in_lockstep_with_target() {
+        assert_eq!(inner_axis_pixels(101, 5), 91);
+        assert_eq!(inner_axis_pixels(8, 5), 1);
+    }
+
+    #[test]
+    fn outline_antialiases_outer_ellipse_edge() {
+        let outline = make_outline(&opaque_pixel(), 2, 2, Color::rgba_u8(1, 2, 3, 255));
+
+        assert_eq!(outline.width, 5);
+        assert_eq!(outline.height, 5);
+        assert_eq!(alpha_at(&outline, 2, 2), 0);
+        assert_eq!(alpha_at(&outline, 0, 0), 0);
+        assert!(alpha_at(&outline, 2, 0) > 0);
+        assert!(alpha_at(&outline, 2, 0) < 255);
+        assert_eq!(alpha_at(&outline, 2, 1), 255);
+    }
 }

--- a/tellur-renderer/src/outline.rs
+++ b/tellur-renderer/src/outline.rs
@@ -181,14 +181,12 @@ fn make_outline(
     let alpha_scale = color.a.clamp(0.0, 1.0);
 
     let mut out = Vec::with_capacity(out_w * out_h * 4);
-    for i in 0..dilated.len() {
+    for alpha in &dilated {
         // Paint the full dilated silhouette behind the child instead of
         // subtracting the original alpha. The later child composite covers
         // opaque interiors, while antialiased child edges blend against
         // outline color rather than the background.
-        let a = ((dilated[i] as f32) * alpha_scale)
-            .round()
-            .clamp(0.0, 255.0) as u8;
+        let a = ((*alpha as f32) * alpha_scale).round().clamp(0.0, 255.0) as u8;
         out.push(r);
         out.push(g);
         out.push(b);

--- a/tellur-renderer/src/outline.rs
+++ b/tellur-renderer/src/outline.rs
@@ -1,12 +1,13 @@
 //! Outline (hard-edge stroke) effect for raster components.
 //!
 //! Wraps a `RasterComponent` and paints a solid-colored ring around the
-//! outside of the child's alpha shape. The ring is produced by dilating
-//! the child's alpha by the outline width and subtracting the original
-//! alpha, so the stroke never bleeds inside the child. `paint_bounds`
-//! expands by `width` so the surrounding `Layer` allocates enough
-//! pixels; `layout_box` is left unchanged so outlines do not disturb
-//! layout.
+//! outside of the child's alpha shape. The stroke layer is produced by
+//! dilating the child's alpha by the outline width, painting that
+//! silhouette behind the child, and then drawing the child on top. Keeping
+//! the full dilated alpha behind antialiased child edges avoids background
+//! fringes between stacked outlines. `paint_bounds` expands by `width` so
+//! the surrounding `Layer` allocates enough pixels; `layout_box` is left
+//! unchanged so outlines do not disturb layout.
 
 use tellur_core::color::Color;
 use tellur_core::composite::composite_at;
@@ -51,17 +52,16 @@ impl RasterComponent for Outline {
         let sy = target.height as f32 / paint.size.1;
         let gpu_available = ctx.prefers_gpu() && ctx.gpu_backend().is_some();
 
-        // Dilate the child alpha by `width` logical units and subtract
-        // the original alpha so only the ring outside the child
-        // remains. The dilation radius is computed independently along
-        // each axis so it stays exactly in lockstep with `paint_bounds`
-        // (which expands by `width` logical units in both directions);
-        // otherwise an anisotropic pixel ratio would push the outline
-        // past the buffer edge and get clipped.
+        // Dilate the child alpha by `width` logical units and paint that
+        // silhouette behind the child. Radius and offset are rounded
+        // separately because half-pixel logical widths (e.g. 4.5 at 1x)
+        // cannot be represented as symmetric integer padding: the child
+        // must be copied into the target-sized alpha buffer at the same
+        // pixel offset where it will later be composited.
         let width_px_x = (self.width.max(0.0) * sx).round() as u32;
         let width_px_y = (self.width.max(0.0) * sy).round() as u32;
-        let child_px_w = inner_axis_pixels(target.width, width_px_x);
-        let child_px_h = inner_axis_pixels(target.height, width_px_y);
+        let child_px_w = (child_paint.size.0 * sx).round().max(1.0) as u32;
+        let child_px_h = (child_paint.size.1 * sy).round().max(1.0) as u32;
         // Render the child through the context so its output is memoized
         // independently of the outline — matches the shadow component's
         // strategy for static subtrees.
@@ -71,12 +71,6 @@ impl RasterComponent for Outline {
             Resolution::new(child_px_w, child_px_h),
         );
 
-        let pad_lu_x = width_px_x as f32 / sx;
-        let pad_lu_y = width_px_y as f32 / sy;
-        let outline_local_x = (child_paint.origin.0 - pad_lu_x) - paint.origin.0;
-        let outline_local_y = (child_paint.origin.1 - pad_lu_y) - paint.origin.1;
-        let outline_px_x = (outline_local_x * sx).round() as i32;
-        let outline_px_y = (outline_local_y * sy).round() as i32;
         let child_local_x = child_paint.origin.0 - paint.origin.0;
         let child_local_y = child_paint.origin.1 - paint.origin.1;
         let child_px_x = (child_local_x * sx).round() as i32;
@@ -88,8 +82,6 @@ impl RasterComponent for Outline {
                 target,
                 child_offset_x: child_px_x,
                 child_offset_y: child_px_y,
-                outline_offset_x: outline_px_x,
-                outline_offset_y: outline_px_y,
                 radius_x: width_px_x,
                 radius_y: width_px_y,
                 color: self.color,
@@ -102,17 +94,19 @@ impl RasterComponent for Outline {
         }
 
         let child_image = ctx.readback(child_image);
-        let outline_image = make_outline(&child_image, width_px_x, width_px_y, self.color);
+        let outline_image = make_outline(
+            &child_image,
+            target,
+            child_px_x,
+            child_px_y,
+            width_px_x,
+            width_px_y,
+            self.color,
+        );
 
         let mut accum = vec![0u8; (target.width as usize) * (target.height as usize) * 4];
 
-        composite_at(
-            &mut accum,
-            target,
-            &outline_image,
-            outline_px_x,
-            outline_px_y,
-        );
+        composite_at(&mut accum, target, &outline_image, 0, 0);
 
         composite_at(&mut accum, target, &child_image, child_px_x, child_px_y);
 
@@ -130,30 +124,36 @@ fn blank_image(target: Resolution) -> RasterImage {
     )
 }
 
-fn inner_axis_pixels(target: u32, pad: u32) -> u32 {
-    target.saturating_sub(pad.saturating_mul(2)).max(1)
-}
-
 fn make_outline(
     image: &CpuRasterImage,
+    target: Resolution,
+    offset_x: i32,
+    offset_y: i32,
     width_px_x: u32,
     width_px_y: u32,
     color: Color,
 ) -> CpuRasterImage {
     assert_eq!(image.format, PixelFormat::Rgba8);
-    let pad_x = width_px_x as usize;
-    let pad_y = width_px_y as usize;
     let in_w = image.width as usize;
     let in_h = image.height as usize;
-    let out_w = in_w + 2 * pad_x;
-    let out_h = in_h + 2 * pad_y;
+    let out_w = target.width as usize;
+    let out_h = target.height as usize;
 
     let mut alpha = vec![0u8; out_w * out_h];
     let pixels = image.pixels.as_ref();
     for y in 0..in_h {
         for x in 0..in_w {
+            let dst_x = x as i32 + offset_x;
+            let dst_y = y as i32 + offset_y;
+            if dst_x < 0
+                || dst_y < 0
+                || dst_x >= target.width as i32
+                || dst_y >= target.height as i32
+            {
+                continue;
+            }
             let src_idx = (y * in_w + x) * 4 + 3;
-            let dst_idx = (y + pad_y) * out_w + (x + pad_x);
+            let dst_idx = dst_y as usize * out_w + dst_x as usize;
             alpha[dst_idx] = pixels[src_idx];
         }
     }
@@ -163,8 +163,14 @@ fn make_outline(
     // square SE is cheaper but visibly flattens curved tips (the
     // top/bottom of a circle becomes a horizontal cap); the ellipse
     // keeps the contour following the original shape, even when sx ≠ sy.
-    let dilated = if pad_x > 0 || pad_y > 0 {
-        dilate_ellipse_antialiased(&alpha, out_w, out_h, pad_x, pad_y)
+    let dilated = if width_px_x > 0 || width_px_y > 0 {
+        dilate_ellipse_antialiased(
+            &alpha,
+            out_w,
+            out_h,
+            width_px_x as usize,
+            width_px_y as usize,
+        )
     } else {
         alpha.clone()
     };
@@ -176,18 +182,20 @@ fn make_outline(
 
     let mut out = Vec::with_capacity(out_w * out_h * 4);
     for i in 0..dilated.len() {
-        // Ring = dilated - original. Saturating sub means pixels fully
-        // inside the child contribute zero, leaving only the outside
-        // band.
-        let ring = dilated[i].saturating_sub(alpha[i]);
-        let a = ((ring as f32) * alpha_scale).round().clamp(0.0, 255.0) as u8;
+        // Paint the full dilated silhouette behind the child instead of
+        // subtracting the original alpha. The later child composite covers
+        // opaque interiors, while antialiased child edges blend against
+        // outline color rather than the background.
+        let a = ((dilated[i] as f32) * alpha_scale)
+            .round()
+            .clamp(0.0, 255.0) as u8;
         out.push(r);
         out.push(g);
         out.push(b);
         out.push(a);
     }
 
-    CpuRasterImage::new(out_w as u32, out_h as u32, PixelFormat::Rgba8, out)
+    CpuRasterImage::new(target.width, target.height, PixelFormat::Rgba8, out)
 }
 
 /// Morphological dilation by an axis-aligned ellipse with semi-axes
@@ -283,6 +291,30 @@ fn ellipse_coverage(dx: i64, dy: i64, rx: usize, ry: usize) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tellur_core::render_context::PassThrough;
+
+    #[derive(PartialEq, Eq, Hash)]
+    struct UnitPixel;
+
+    impl RasterComponent for UnitPixel {
+        fn layout(&self, constraints: Constraints) -> Vec2 {
+            constraints.constrain(Vec2(1.0, 1.0))
+        }
+
+        fn render(
+            &self,
+            _size: Vec2,
+            target: Resolution,
+            _ctx: &mut dyn RenderContext,
+        ) -> RasterImage {
+            RasterImage::cpu(
+                target.width,
+                target.height,
+                PixelFormat::Rgba8,
+                vec![9, 8, 7, 255],
+            )
+        }
+    }
 
     fn opaque_pixel() -> CpuRasterImage {
         CpuRasterImage::new(1, 1, PixelFormat::Rgba8, vec![9, 8, 7, 255])
@@ -293,21 +325,44 @@ mod tests {
     }
 
     #[test]
-    fn inner_axis_pixels_keeps_padding_in_lockstep_with_target() {
-        assert_eq!(inner_axis_pixels(101, 5), 91);
-        assert_eq!(inner_axis_pixels(8, 5), 1);
-    }
-
-    #[test]
     fn outline_antialiases_outer_ellipse_edge() {
-        let outline = make_outline(&opaque_pixel(), 2, 2, Color::rgba_u8(1, 2, 3, 255));
+        let outline = make_outline(
+            &opaque_pixel(),
+            Resolution::new(5, 5),
+            2,
+            2,
+            2,
+            2,
+            Color::rgba_u8(1, 2, 3, 255),
+        );
 
         assert_eq!(outline.width, 5);
         assert_eq!(outline.height, 5);
-        assert_eq!(alpha_at(&outline, 2, 2), 0);
+        assert_eq!(alpha_at(&outline, 2, 2), 255);
         assert_eq!(alpha_at(&outline, 0, 0), 0);
         assert!(alpha_at(&outline, 2, 0) > 0);
         assert!(alpha_at(&outline, 2, 0) < 255);
         assert_eq!(alpha_at(&outline, 2, 1), 255);
+    }
+
+    #[test]
+    fn half_pixel_width_keeps_outline_centered_on_child_offset() {
+        let outline = Outline {
+            width: 4.5,
+            color: Color::rgba_u8(1, 2, 3, 255),
+            child: Box::new(UnitPixel),
+        };
+        let mut ctx = PassThrough;
+        let rendered = outline
+            .render(Vec2(1.0, 1.0), Resolution::new(10, 10), &mut ctx)
+            .into_cpu()
+            .expect("CPU outline render");
+
+        let center = (5 * rendered.width as usize + 5) * 4;
+        assert_eq!(&rendered.pixels[center..center + 4], &[9, 8, 7, 255]);
+        assert!(alpha_at(&rendered, 4, 5) > 0);
+        assert!(alpha_at(&rendered, 5, 4) > 0);
+        assert!(alpha_at(&rendered, 6, 5) > 0);
+        assert!(alpha_at(&rendered, 5, 6) > 0);
     }
 }


### PR DESCRIPTION
Corrects raster `Outline` rendering so half-pixel outline widths no longer shift nested outlines and antialiased stacked outline edges no longer expose background gaps. The CPU path and GPU primitive now build outline alpha in target coordinates. 3 files (+270 / -101) across `tellur-core` and `tellur-renderer`.

## Raster outline alignment
- Renders child alpha into target-sized alpha buffers at the child composite offset before dilation.
- Removes the separate outline offset from the GPU outline input and uses signed copy-alpha offsets.
- Adds regression coverage for half-pixel outline widths.

## Stacked outline blending
- Paints the full dilated outline silhouette behind children instead of subtracting the original alpha.
- Keeps CPU and GPU outline dilation behavior aligned with antialiased coverage.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p tellur-renderer`
- `cargo test -p tellur-core`
- `cargo check -p tellur-renderer --examples`
- `cargo test -p tellur-renderer gpu::tests::outline_dilates_child_alpha -- --ignored --nocapture`
- `git diff --check`
- Rendered the `sqrt2_plus_sqrt3` dialogue frame at 480p, 720p, 1080p, and 2160p with `X-Tellur-GPU-Active: true`.
