### PR TITLE
feat(live): add preview mute toggle

### DIFF
--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -424,8 +424,10 @@ export function App() {
               resolution={resolution}
               resolutionOptions={resolutionOptions}
               motionBlur={motionBlur}
+              muted={preview.state.muted}
               playing={preview.state.playing}
               onTogglePlay={preview.togglePlay}
+              onToggleMute={preview.toggleMute}
               onStep={preview.stepFrame}
               onRewind={preview.rewindToStart}
               onResolutionChange={changeResolution}

--- a/tellur-live/web/src/components/Preview.tsx
+++ b/tellur-live/web/src/components/Preview.tsx
@@ -34,7 +34,7 @@ export const Preview = forwardRef<HTMLDivElement, PreviewProps & PreviewRefs>(
       <section className="preview" ref={ref} style={previewStyle}>
         <div className="preview__frame">
           <div className="preview__media">
-            <video ref={videoRef} muted playsInline preload="auto" />
+            <video ref={videoRef} playsInline preload="auto" />
             <img
               ref={imgRef}
               className={imageVisible ? "" : "hidden"}

--- a/tellur-live/web/src/components/Transport.tsx
+++ b/tellur-live/web/src/components/Transport.tsx
@@ -1,4 +1,11 @@
-import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
+import {
+  Pause,
+  Play,
+  SkipBack,
+  SkipForward,
+  Volume2,
+  VolumeX,
+} from "lucide-react";
 import { formatTimecode } from "../formatTime";
 import type { PreviewResolution } from "../types";
 
@@ -14,8 +21,10 @@ interface TransportProps {
   resolution: PreviewResolution;
   resolutionOptions: ResolutionOption[];
   motionBlur: boolean;
+  muted: boolean;
   playing: boolean;
   onTogglePlay: () => void;
+  onToggleMute: () => void;
   onStep: (delta: number) => void;
   onRewind: () => void;
   onResolutionChange: (resolution: PreviewResolution) => void;
@@ -34,8 +43,10 @@ export function Transport(props: TransportProps) {
     resolution,
     resolutionOptions,
     motionBlur,
+    muted,
     playing,
     onTogglePlay,
+    onToggleMute,
     onStep,
     onRewind,
     onResolutionChange,
@@ -99,6 +110,27 @@ export function Transport(props: TransportProps) {
           }}
         >
           <SkipForward size={14} strokeWidth={1.6} />
+        </button>
+        <button
+          type="button"
+          className={
+            muted
+              ? "transport__toggle transport__toggle--on"
+              : "transport__toggle"
+          }
+          aria-pressed={muted}
+          aria-label={muted ? "Unmute" : "Mute"}
+          data-tooltip={muted ? "Unmute" : "Mute"}
+          onClick={(e) => {
+            onToggleMute();
+            e.currentTarget.blur();
+          }}
+        >
+          {muted ? (
+            <VolumeX size={16} strokeWidth={1.6} />
+          ) : (
+            <Volume2 size={16} strokeWidth={1.6} />
+          )}
         </button>
       </div>
       <div className="transport__right">

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -125,6 +125,7 @@ export interface TimelinePlayerConfig {
   duration: number;
   fps: number;
   initialPosition: number;
+  isMuted: () => boolean;
   // Builds the /api/video.mp4 URL for the half-open segment [start, end). When
   // end >= duration the caller should omit the `duration` param (stream to the tail);
   // this closure handles that.
@@ -310,12 +311,12 @@ export class TimelinePlayer {
     }
   }
 
-  // Must be called inside the user gesture (it unmutes for the autoplay policy).
+  // Must be called inside the user gesture so unmuted playback satisfies autoplay policy.
   play(): void {
     if (this.disposed) return;
-    // Unmute synchronously within the gesture so the (now A/V) stream plays with sound.
+    // Apply the user's audio state synchronously within the gesture.
     // React does not re-apply the `muted` attribute after mount, so set the property.
-    this.video.muted = false;
+    this.video.muted = this.config.isMuted();
     // Play-from-the-end replays from the start: at duration the cursor loop has no work
     // and playback would silently never begin.
     const replayFromEnd = this.position >= this.config.duration - EPSILON;
@@ -342,6 +343,11 @@ export class TimelinePlayer {
     this.setDisplayMode("still", this.position, "hold");
     this.tryResolveReveal();
     this.kickFill();
+  }
+
+  setMuted(muted: boolean): void {
+    if (this.disposed) return;
+    this.video.muted = muted;
   }
 
   pause(): void {

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -17,6 +17,7 @@ const STILL_REQUEST_DEBOUNCE_MS = 100;
 export interface PreviewState {
   seconds: number;
   playing: boolean;
+  muted: boolean;
   cacheRanges: CacheRange[];
   error: string | null;
   imageSrc: string | null;
@@ -32,6 +33,7 @@ export interface PreviewControls {
   imgRef: RefObject<HTMLImageElement>;
   setSeconds: (s: number) => void;
   togglePlay: () => void;
+  toggleMute: () => void;
   stepFrame: (delta: number) => void;
   rewindToStart: () => void;
 }
@@ -77,6 +79,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
 
   const [seconds, setSecondsState] = useState(0);
   const [playing, setPlaying] = useState(false);
+  const [muted, setMuted] = useState(false);
   const [cacheRanges, setCacheRanges] = useState<CacheRange[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
@@ -85,6 +88,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
 
   const secondsRef = useRef(0);
   const playingRef = useRef(false);
+  const mutedRef = useRef(false);
   const playerRef = useRef<TimelinePlayer | null>(null);
 
   const cacheRef = useRef<MediaCache | null>(null);
@@ -236,6 +240,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
           duration,
           fps,
           initialPosition: secondsRef.current,
+          isMuted: () => mutedRef.current,
           videoUrl: buildVideoUrl,
           cache,
         },
@@ -329,9 +334,16 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
   const togglePlay = useCallback(() => {
     const player = playerRef.current;
     if (!player) return;
-    // Runs inside the click/keydown gesture so play() can unmute for the autoplay policy.
+    // Runs inside the click/keydown gesture so play() can apply the user's audio state.
     if (playingRef.current) player.pause();
     else player.play();
+  }, []);
+
+  const toggleMute = useCallback(() => {
+    const next = !mutedRef.current;
+    mutedRef.current = next;
+    setMuted(next);
+    playerRef.current?.setMuted(next);
   }, []);
 
   const stepFrame = useCallback(
@@ -356,6 +368,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
     state: {
       seconds,
       playing,
+      muted,
       cacheRanges,
       error,
       imageSrc,
@@ -366,6 +379,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
     imgRef,
     setSeconds: seekTo,
     togglePlay,
+    toggleMute,
     stepFrame,
     rewindToStart,
   };

--- a/tellur-live/web/src/styles/global.css
+++ b/tellur-live/web/src/styles/global.css
@@ -555,10 +555,10 @@ select option {
   color: var(--text-secondary);
 }
 
-/* Icon-only on/off toggle (e.g. Motion Blur) in the right control cluster. Same
-   geometry as .transport__btn; the state lives in the icon color — accent when
-   on, faint when off (dimmer than plain buttons so "off" reads as a state, not
-   just an idle control). The label is provided by aria-label + data-tooltip. */
+/* Icon-only on/off toggle (e.g. mute or Motion Blur). Same geometry as
+   .transport__btn; the state lives in the icon color — accent when on, faint
+   when off (dimmer than plain buttons so "off" reads as a state, not just an
+   idle control). The label is provided by aria-label + data-tooltip. */
 .transport__toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Adds a mute toggle to the live preview transport so users can silence preview audio without changing playback behavior. The muted state is owned by the preview hook and applied directly to the media element, keeping the existing MSE streaming and cache flow unchanged. 6 files (+64 / -10) in `tellur-live`.

## Preview audio controls
- Adds an icon-only mute/unmute button beside the playback controls.
- Reuses the transport toggle styling, tooltip, and accessibility patterns.
- Applies the selected muted state before playback starts and while playback is running.

## Verification
- `cargo fmt --all -- --check`
- `nix build .#web --no-link`
- `git diff --check`