### PR TITLE
fix(tellur): forward latex feature through facade

### DIFF
--- a/tellur/Cargo.toml
+++ b/tellur/Cargo.toml
@@ -8,6 +8,9 @@ default = ["renderer"]
 # The GPU / encode backend (wgpu / vello / ffmpeg). Vector/raster-only projects
 # can turn this off to skip the heavy graphics stack: `default-features = false`.
 renderer = ["dep:tellur-renderer"]
+# Inline LaTeX math spans. Forwarded through the facade so authored projects can
+# depend on `tellur` alone and still opt into `tellur-core` feature gates.
+latex = ["tellur-core/latex", "tellur-renderer?/latex"]
 # The `tellur` command-line tool (the `tellur` binary). Pulls in the live-preview
 # host and the argument/metadata machinery; authored projects never enable this.
 cli = ["dep:clap", "dep:cargo_metadata", "dep:toml_edit", "dep:tellur-live", "renderer"]

--- a/tellur/src/lib.rs
+++ b/tellur/src/lib.rs
@@ -7,6 +7,7 @@
 //!   at the crate root, and
 //! - under the `renderer` feature (on by default) the GPU / encode backend at
 //!   [`renderer`].
+//! - optional authoring features such as `latex`, forwarded to the engine crates.
 //!
 //! The `#[component]` and `export_timeline!` macros emit their paths through this
 //! facade (resolved at expansion time), so an authored project never needs to


### PR DESCRIPTION
Forwards the `latex` feature from the public `tellur` facade to `tellur-core` and, when the renderer feature is enabled, to `tellur-renderer`. Authored projects can now opt into math spans through `tellur` alone instead of adding `tellur-core` directly. 2 files (+4 / -0) in `tellur`.

## Feature forwarding
- Adds a root `latex` feature that enables `tellur-core/latex`.
- Forwards to `tellur-renderer/latex` only when the renderer dependency is already enabled.
- Documents that optional authoring features are surfaced through the facade.

## Verification
- `cargo metadata --no-deps --format-version 1`
- `nix develop --command cargo check -p tellur --no-default-features --features latex`
- `nix develop --command cargo check -p tellur --features latex`
- `cargo fmt --all -- --check`
- `git diff --check HEAD^..HEAD`
