### PR TITLE
feat(core): support broader audio codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,10 +1769,15 @@ checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
  "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
  "symphonia-format-mkv",
  "symphonia-format-ogg",
  "symphonia-format-riff",
@@ -1792,10 +1797,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
 name = "symphonia-codec-adpcm"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1833,6 +1871,30 @@ dependencies = [
  "bytemuck",
  "lazy_static",
  "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]

--- a/tellur-core/Cargo.toml
+++ b/tellur-core/Cargo.toml
@@ -26,10 +26,10 @@ kurbo = "0.11.3"
 lru = "0.12"
 png = "0.18.1"
 rustybuzz = "0.20"
-# Pure-Rust audio decode for the timeline AUDIO leaf (`AudioFile`). The `wav`
-# + `pcm` features cover the WAV fixtures the tests synthesize; the defaults
-# pull in the other common pure-Rust codecs (mp3/flac/ogg/aac/...).
-symphonia = { version = "0.5.4", features = ["wav", "pcm"] }
+# Pure-Rust audio decode for the timeline AUDIO leaf (`AudioFile`). Enable the
+# full Symphonia feature set so users can import common audio containers/codecs
+# such as WAV/AIFF, FLAC, Ogg/Vorbis, MP3, and MP4 AAC/ALAC.
+symphonia = { version = "0.5.4", default-features = false, features = ["all"] }
 tellur-macros = { path = "../tellur-macros", version = "0.1.0" }
 thiserror = "2.0.18"
 

--- a/tellur-core/src/audio.rs
+++ b/tellur-core/src/audio.rs
@@ -152,10 +152,16 @@ pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuff
                 if channels == 0 {
                     channels = spec.channels.count() as u16;
                 }
-                // (Re)allocate the interleaving scratch buffer to fit this frame.
-                let buf = sample_buf.get_or_insert_with(|| {
-                    SampleBuffer::<f32>::new(decoded.capacity() as u64, spec)
-                });
+                // Reallocate the interleaving scratch buffer when a codec emits
+                // a larger packet than the previous one.
+                let required = decoded.capacity().saturating_mul(spec.channels.count());
+                if sample_buf
+                    .as_ref()
+                    .map_or(true, |buf| buf.capacity() < required)
+                {
+                    sample_buf = Some(SampleBuffer::<f32>::new(decoded.capacity() as u64, spec));
+                }
+                let buf = sample_buf.as_mut().expect("sample buffer allocated");
                 buf.copy_interleaved_ref(decoded);
                 let decoded = buf.samples();
                 let ch = channels.max(1) as usize;

--- a/tellur-core/src/audio.rs
+++ b/tellur-core/src/audio.rs
@@ -157,7 +157,7 @@ pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuff
                 let required = decoded.capacity().saturating_mul(spec.channels.count());
                 if sample_buf
                     .as_ref()
-                    .map_or(true, |buf| buf.capacity() < required)
+                    .is_none_or(|buf| buf.capacity() < required)
                 {
                     sample_buf = Some(SampleBuffer::<f32>::new(decoded.capacity() as u64, spec));
                 }

--- a/tellur-core/src/timeline_container/tests.rs
+++ b/tellur-core/src/timeline_container/tests.rs
@@ -847,6 +847,38 @@ fn const_wav(name: &str, rate: u32, frames: usize, level: i16) -> std::path::Pat
     write_wav_fixture(name, rate, &vec![level; frames])
 }
 
+fn write_ffmpeg_sine_audio(name: &str, ext: &str, codec: &str, seconds: f32) -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "tellur_audio_{}_{}.{}",
+        name,
+        std::process::id(),
+        ext
+    ));
+
+    let source = format!("sine=frequency=440:sample_rate={TEST_RATE}:duration={seconds:.3}");
+    let status = std::process::Command::new("ffmpeg")
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            &source,
+            "-ac",
+            "1",
+            "-c:a",
+            codec,
+        ])
+        .arg(&path)
+        .status()
+        .expect("spawn ffmpeg audio fixture");
+    assert!(status.success(), "ffmpeg audio fixture write failed");
+    path
+}
+
 // Decode reads the real source length: a 1.0s fixture probes to ~1.0s.
 #[test]
 fn audiofile_probes_real_decoded_duration() {
@@ -854,6 +886,28 @@ fn audiofile_probes_real_decoded_duration() {
     let af = AudioFile::builder().path(path.to_str().unwrap()).build();
     let d = af.duration().expect("audio has a duration");
     assert!((d - 1.0).abs() < 1e-3, "decoded ~1.0s, got {d}");
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+#[ignore = "requires ffmpeg with libmp3lame on PATH"]
+fn audiofile_decodes_mp3_duration_and_mix() {
+    let path = write_ffmpeg_sine_audio("mp3", "mp3", "libmp3lame", 2.0);
+    let af = AudioFile::builder().path(path.to_str().unwrap()).build();
+
+    let d = af.duration().expect("mp3 audio has a duration");
+    assert!(
+        d > 1.5 && d < 2.3,
+        "mp3 should decode near 2s instead of falling back to 1s, got {d}"
+    );
+
+    let resolved = resolve_audio(Timeline::builder().child(af).build()).expect("media-backed");
+    let mixed = resolved.render_audio_window(0.25, 0.25, TEST_RATE, 1);
+    assert!(
+        mixed.samples.iter().any(|sample| sample.abs() > 0.001),
+        "decoded mp3 should contribute audible samples to the mix"
+    );
+
     let _ = std::fs::remove_file(&path);
 }
 


### PR DESCRIPTION
Enables the full Symphonia codec/container set for `AudioFile` so timelines can decode common audio sources beyond WAV/PCM, including MP3 and MP4 AAC/ALAC. The decode path also reallocates its interleaving scratch buffer when codecs emit larger packets. 4 files (+130 / -8) across `tellur-core` and `Cargo.lock`.

## Audio codec support
- Enables Symphonia's `all` feature set for timeline audio decode.
- Adds the newly required MP3, AAC, ALAC, CAF, and ISOBMFF Symphonia packages to the lockfile.
- Reallocates the interleaving scratch buffer when decoded packet capacity grows.

## Regression coverage
- Adds an ignored ffmpeg/libmp3lame smoke that checks MP3 duration probing and mix output.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p tellur-core audiofile_decodes_mp3_duration_and_mix -- --ignored --nocapture`
- `nix develop -c cargo test -p tellur-core`
- `cargo check -p tellur-live --examples`
- `git diff --check HEAD^..HEAD`
