### PR TITLE
feat(live): configure preview render settings

### DIFF
--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -36,6 +36,8 @@ const DEFAULT_PREVIEW_RESOLUTION: PreviewResolution = {
   width: 1280,
   height: 720,
 };
+const DEFAULT_PREVIEW_FPS = 30;
+const PREVIEW_SETTINGS_STORAGE_PREFIX = "tellur-live:preview-settings:v1:";
 const PREVIEW_RESOLUTION_OPTIONS = [
   { width: 3840, height: 2160, label: "3840 × 2160" },
   { width: 1920, height: 1080, label: "1920 × 1080" },
@@ -68,7 +70,7 @@ export function App() {
   const [resolution, setResolution] = useState<PreviewResolution>(
     DEFAULT_PREVIEW_RESOLUTION,
   );
-  const [fps, setFps] = useState(30);
+  const [fps, setFps] = useState(DEFAULT_PREVIEW_FPS);
   const [motionBlur, setMotionBlur] = useState(false);
   const [timelineViewport, setTimelineViewport] = useState<TimelineViewport>({
     start: 0,
@@ -90,7 +92,8 @@ export function App() {
   );
   const [resizingWorkspace, setResizingWorkspace] = useState(false);
   const fpsCounterRef = useRef({ frames: 0, last: performance.now() });
-  const userSelectedResolutionRef = useRef(false);
+  const previewSettingsProjectRef = useRef<string | null>(null);
+  const userChangedPreviewSettingsRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -99,15 +102,22 @@ export function App() {
 
     const applyInfo = (next: ServerInfo) => {
       if (cancelled) return;
-      setInfo((prev) => {
-        if (!prev) {
-          setFps((current) => Math.max(next.fps || current, 1));
-          if (!userSelectedResolutionRef.current) {
-            setResolution({ width: next.width, height: next.height });
-          }
+      if (previewSettingsProjectRef.current !== next.projectName) {
+        const keepPendingUserSettings =
+          previewSettingsProjectRef.current === null &&
+          userChangedPreviewSettingsRef.current;
+        previewSettingsProjectRef.current = next.projectName;
+
+        const stored = loadProjectPreviewSettings(next.projectName);
+        if (stored) {
+          setResolution(stored.resolution);
+          setFps(stored.fps);
+        } else if (!keepPendingUserSettings) {
+          setResolution({ width: next.width, height: next.height });
+          setFps(Math.max(next.fps || DEFAULT_PREVIEW_FPS, 1));
         }
-        return next;
-      });
+      }
+      setInfo(next);
       setLoadError(null);
     };
 
@@ -256,10 +266,31 @@ export function App() {
   const displayTimeline = timeline ?? FALLBACK_TIMELINE;
   const timelineDuration = displayTimeline.duration;
   const resolutionOptions = previewResolutionOptions(resolution);
-  const changeResolution = useCallback((next: PreviewResolution) => {
-    userSelectedResolutionRef.current = true;
-    setResolution(next);
-  }, []);
+  const projectName = info?.projectName ?? null;
+  const changeResolution = useCallback(
+    (next: PreviewResolution) => {
+      userChangedPreviewSettingsRef.current = true;
+      setResolution(next);
+      if (projectName) {
+        saveProjectPreviewSettings(projectName, { resolution: next, fps });
+      }
+    },
+    [fps, projectName],
+  );
+  const changeFps = useCallback(
+    (next: number) => {
+      const normalized = Math.max(1, Math.round(next));
+      userChangedPreviewSettingsRef.current = true;
+      setFps(normalized);
+      if (projectName) {
+        saveProjectPreviewSettings(projectName, {
+          resolution,
+          fps: normalized,
+        });
+      }
+    },
+    [projectName, resolution],
+  );
   const updateTimelineViewport = useCallback(
     (next: TimelineViewportChange) => {
       setTimelineViewport((current) => {
@@ -431,7 +462,7 @@ export function App() {
               onStep={preview.stepFrame}
               onRewind={preview.rewindToStart}
               onResolutionChange={changeResolution}
-              onFpsChange={setFps}
+              onFpsChange={changeFps}
               onMotionBlurChange={setMotionBlur}
             />
           </section>
@@ -514,6 +545,78 @@ function sameResolution(
 
 function mediaQueryMatches(query: string): boolean {
   return typeof window !== "undefined" ? window.matchMedia(query).matches : true;
+}
+
+interface ProjectPreviewSettings {
+  resolution: PreviewResolution;
+  fps: number;
+}
+
+function loadProjectPreviewSettings(
+  projectName: string,
+): ProjectPreviewSettings | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(
+      projectPreviewSettingsKey(projectName),
+    );
+    if (!raw) return null;
+    return parseProjectPreviewSettings(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function saveProjectPreviewSettings(
+  projectName: string,
+  settings: ProjectPreviewSettings,
+) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(
+      projectPreviewSettingsKey(projectName),
+      JSON.stringify(settings),
+    );
+  } catch {
+    // localStorage can be unavailable in private or locked-down browsers.
+  }
+}
+
+function projectPreviewSettingsKey(projectName: string): string {
+  return `${PREVIEW_SETTINGS_STORAGE_PREFIX}${projectName}`;
+}
+
+function parseProjectPreviewSettings(
+  value: unknown,
+): ProjectPreviewSettings | null {
+  if (!isRecord(value)) return null;
+
+  const resolution = parsePreviewResolution(value.resolution);
+  const fps = parsePreviewFps(value.fps);
+  if (!resolution || fps === null) return null;
+
+  return { resolution, fps };
+}
+
+function parsePreviewResolution(value: unknown): PreviewResolution | null {
+  if (!isRecord(value)) return null;
+  const { width, height } = value;
+  if (!positiveInteger(width) || !positiveInteger(height)) return null;
+  return { width, height };
+}
+
+function parsePreviewFps(value: unknown): number | null {
+  return positiveInteger(value) ? value : null;
+}
+
+function positiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function clampLandscapePreviewHeight(

--- a/tellur-live/web/src/components/Transport.tsx
+++ b/tellur-live/web/src/components/Transport.tsx
@@ -54,6 +54,7 @@ export function Transport(props: TransportProps) {
     onMotionBlurChange,
   } = props;
   const selectedResolutionKey = resolutionKey(resolution);
+  const fpsOptions = previewFpsOptions(fps);
 
   return (
     <div className="transport">
@@ -163,7 +164,7 @@ export function Transport(props: TransportProps) {
               e.currentTarget.blur();
             }}
           >
-            {FPS_OPTIONS.map((value) => (
+            {fpsOptions.map((value) => (
               <option key={value} value={value}>
                 {value} fps
               </option>
@@ -202,6 +203,12 @@ export function Transport(props: TransportProps) {
 
 function resolutionKey(resolution: PreviewResolution): string {
   return `${resolution.width}x${resolution.height}`;
+}
+
+function previewFpsOptions(fps: number): number[] {
+  const current = Math.max(1, Math.round(fps));
+  if (FPS_OPTIONS.includes(current)) return FPS_OPTIONS;
+  return [current, ...FPS_OPTIONS].sort((a, b) => b - a);
 }
 
 // Lucide has no motion-blur glyph, so this hand-rolled icon follows the same

--- a/tellur/src/bin/tellur.rs
+++ b/tellur/src/bin/tellur.rs
@@ -68,12 +68,14 @@ struct LiveArgs {
     /// TCP port for the preview server.
     #[arg(long, default_value_t = 4317)]
     port: u16,
-    /// Preview render resolution, `WIDTHxHEIGHT`.
-    #[arg(long, default_value = "1280x720")]
-    size: String,
-    /// Preview frame rate.
-    #[arg(long, default_value_t = 30)]
-    fps: u32,
+    /// Preview render resolution, `WIDTHxHEIGHT`. Defaults to
+    /// `package.metadata.tellur.live.size`, then `1280x720`.
+    #[arg(long, value_name = "WIDTHxHEIGHT")]
+    size: Option<String>,
+    /// Preview frame rate. Defaults to `package.metadata.tellur.live.fps`, then
+    /// 30.
+    #[arg(long)]
+    fps: Option<u32>,
     /// Prefer GPU rendering.
     #[arg(long, conflicts_with = "no_gpu")]
     gpu: bool,
@@ -99,7 +101,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn live(args: LiveArgs) -> Result<(), Box<dyn Error>> {
-    let resolution = parse_resolution(&args.size)?;
     let gpu_preference = if args.no_gpu {
         GpuPreference::Disabled
     } else if args.gpu {
@@ -126,6 +127,18 @@ fn live(args: LiveArgs) -> Result<(), Box<dyn Error>> {
                 return dispatch_to_host(&source, &version);
             }
         }
+    }
+
+    let live_defaults = live_defaults(package)?;
+    let resolution = args
+        .size
+        .as_deref()
+        .map(parse_resolution)
+        .transpose()?
+        .unwrap_or(live_defaults.resolution);
+    let fps = args.fps.unwrap_or(live_defaults.fps);
+    if fps == 0 {
+        return Err("fps must be greater than zero".into());
     }
 
     let lib_name = cdylib_target_name(package).ok_or_else(|| {
@@ -174,7 +187,7 @@ fn live(args: LiveArgs) -> Result<(), Box<dyn Error>> {
         project_name: package.name.clone(),
         bind: format!("{}:{}", args.host, args.port),
         resolution,
-        fps: args.fps,
+        fps,
         gpu_preference,
         verbose: args.verbose,
         auto_build,
@@ -401,6 +414,67 @@ fn parse_resolution(s: &str) -> Result<Resolution, Box<dyn Error>> {
     Ok(Resolution::new(w, h))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LiveDefaults {
+    resolution: Resolution,
+    fps: u32,
+}
+
+const FALLBACK_LIVE_DEFAULTS: LiveDefaults = LiveDefaults {
+    resolution: Resolution::new(1280, 720),
+    fps: 30,
+};
+
+const LIVE_DEFAULTS_TABLE: &str = "package.metadata.tellur.live";
+
+fn live_defaults(package: &Package) -> Result<LiveDefaults, Box<dyn Error>> {
+    let manifest = package.manifest_path.as_std_path();
+    let contents = fs::read_to_string(manifest)?;
+    live_defaults_from_manifest(&contents)
+}
+
+fn live_defaults_from_manifest(contents: &str) -> Result<LiveDefaults, Box<dyn Error>> {
+    let doc = contents.parse::<toml_edit::DocumentMut>()?;
+    let Some(package) = doc.get("package").and_then(|item| item.as_table_like()) else {
+        return Ok(FALLBACK_LIVE_DEFAULTS);
+    };
+    let Some(metadata) = package
+        .get("metadata")
+        .and_then(|item| item.as_table_like())
+    else {
+        return Ok(FALLBACK_LIVE_DEFAULTS);
+    };
+    let Some(tellur) = metadata.get("tellur").and_then(|item| item.as_table_like()) else {
+        return Ok(FALLBACK_LIVE_DEFAULTS);
+    };
+    let Some(item) = tellur.get("live") else {
+        return Ok(FALLBACK_LIVE_DEFAULTS);
+    };
+    let live = item
+        .as_table_like()
+        .ok_or_else(|| format!("{LIVE_DEFAULTS_TABLE} must be a table"))?;
+
+    let mut defaults = FALLBACK_LIVE_DEFAULTS;
+    if let Some(value) = live.get("size") {
+        let size = value
+            .as_str()
+            .ok_or_else(|| format!("{LIVE_DEFAULTS_TABLE}.size must be a string"))?;
+        defaults.resolution = parse_resolution(size)
+            .map_err(|e| format!("invalid {LIVE_DEFAULTS_TABLE}.size: {e}"))?;
+    }
+    if let Some(value) = live.get("fps") {
+        let fps = value
+            .as_integer()
+            .ok_or_else(|| format!("{LIVE_DEFAULTS_TABLE}.fps must be a positive integer"))?;
+        if !(1..=u32::MAX as i64).contains(&fps) {
+            return Err(format!("{LIVE_DEFAULTS_TABLE}.fps must be a positive integer").into());
+        }
+        defaults.fps = fps as u32;
+    }
+
+    Ok(defaults)
+}
+
 fn create(args: CreateArgs) -> Result<(), Box<dyn Error>> {
     let target = create_target(&args.path, &env::current_dir()?)?;
     let title = args.title.unwrap_or_else(|| target.crate_name.clone());
@@ -565,7 +639,12 @@ fn project_manifest(name: &str, workspace_dependency: bool) -> String {
          crate-type = [\"cdylib\"]\n\
          \n\
          [dependencies]\n\
-         tellur = {tellur_dependency}\n"
+         tellur = {tellur_dependency}\n\
+         \n\
+         # Optional defaults for `tellur live`:\n\
+         # [package.metadata.tellur.live]\n\
+         # size = \"1280x720\"\n\
+         # fps = 30\n"
     )
 }
 
@@ -1013,6 +1092,66 @@ mod tests {
     }
 
     #[test]
+    fn live_defaults_fall_back_without_metadata() {
+        let defaults =
+            live_defaults_from_manifest("[package]\nname = \"demo\"\nversion = \"0.1.0\"\n")
+                .unwrap();
+
+        assert_eq!(defaults, FALLBACK_LIVE_DEFAULTS);
+    }
+
+    #[test]
+    fn live_defaults_read_package_metadata() {
+        let defaults = live_defaults_from_manifest(
+            "[package]\n\
+             name = \"demo\"\n\
+             version = \"0.1.0\"\n\
+             \n\
+             [package.metadata.tellur.live]\n\
+             size = \"1920x1080\"\n\
+             fps = 60\n",
+        )
+        .unwrap();
+
+        assert_eq!(defaults.resolution, Resolution::new(1920, 1080));
+        assert_eq!(defaults.fps, 60);
+    }
+
+    #[test]
+    fn live_defaults_reject_zero_fps() {
+        let error = live_defaults_from_manifest(
+            "[package]\n\
+             name = \"demo\"\n\
+             version = \"0.1.0\"\n\
+             \n\
+             [package.metadata.tellur.live]\n\
+             fps = 0\n",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("package.metadata.tellur.live.fps"));
+        assert!(error.contains("positive integer"));
+    }
+
+    #[test]
+    fn live_defaults_reject_invalid_size() {
+        let error = live_defaults_from_manifest(
+            "[package]\n\
+             name = \"demo\"\n\
+             version = \"0.1.0\"\n\
+             \n\
+             [package.metadata.tellur.live]\n\
+             size = \"wide\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("package.metadata.tellur.live.size"));
+        assert!(error.contains("resolution must be WIDTHxHEIGHT"));
+    }
+
+    #[test]
     fn project_manifest_uses_workspace_dependency_for_workspace_member() {
         let manifest = project_manifest("demo", true);
 
@@ -1025,6 +1164,15 @@ mod tests {
 
         assert!(manifest.contains(&format!("tellur = \"{}\"", env!("CARGO_PKG_VERSION"))));
         assert!(!manifest.contains("workspace = true"));
+    }
+
+    #[test]
+    fn project_manifest_documents_live_defaults() {
+        let manifest = project_manifest("demo", true);
+
+        assert!(manifest.contains("[package.metadata.tellur.live]"));
+        assert!(manifest.contains("size = \"1280x720\""));
+        assert!(manifest.contains("fps = 30"));
     }
 
     #[test]


### PR DESCRIPTION
Allows `tellur live` to take initial preview size/FPS from `[package.metadata.tellur.live]` while preserving explicit CLI overrides, and persists browser-side size/FPS changes per project so reloads keep the user's preview settings. 3 files (+283 / -25) across `tellur` and `tellur-live`.

## Cargo.toml defaults
- Reads `package.metadata.tellur.live.size` and `fps` from the selected timeline project's manifest.
- Keeps `--size` and `--fps` as explicit CLI overrides.
- Documents optional defaults in the `tellur create` manifest template.

## Live preview persistence
- Restores project-scoped preview size/FPS from `localStorage` when available.
- Saves user changes from the Size and FPS controls without mixing settings between project names.
- Keeps non-standard FPS values visible in the transport select.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p tellur --features cli --bin tellur`
- `npm run build`
