### PR TITLE
perf: improve rendering performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,6 +2086,7 @@ dependencies = [
  "indicatif",
  "lru",
  "pollster",
+ "rustc-hash",
  "sysinfo",
  "tellur-core",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
 name = "tellur-live"
 version = "0.1.0"
 dependencies = [
+ "lru",
  "png",
  "tellur-core",
  "tellur-plugin",

--- a/tellur-core/src/audio.rs
+++ b/tellur-core/src/audio.rs
@@ -19,7 +19,11 @@
 //! therefore PITCH-SHIFTS the source, which is acceptable for v1.
 
 use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::UNIX_EPOCH;
 
+use lru::LruCache;
 use symphonia::core::audio::SampleBuffer;
 use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
 use symphonia::core::errors::Error as SymphoniaError;
@@ -30,6 +34,177 @@ use symphonia::core::probe::Hint;
 use symphonia::core::units::Time as SymphoniaTime;
 
 use crate::timeline_component::AudioBuffer;
+
+const AUDIO_CACHE_CAPACITY_BYTES: usize = 512 * 1024 * 1024;
+const CACHE_FULL_ON_TRIM_SOURCE_BYTES_LIMIT: u64 = 64 * 1024 * 1024;
+
+static DECODE_CACHE: LazyLock<Mutex<AudioDecodeCache>> =
+    LazyLock::new(|| Mutex::new(AudioDecodeCache::default()));
+static CONFORM_CACHE: LazyLock<Mutex<ConformedAudioCache>> =
+    LazyLock::new(|| Mutex::new(ConformedAudioCache::default()));
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AudioCacheKey {
+    path: PathBuf,
+    len: u64,
+    modified_ns: Option<u128>,
+}
+
+struct AudioDecodeCache {
+    entries: LruCache<AudioCacheKey, Arc<AudioBuffer>>,
+    bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ConformedAudioCacheKey {
+    source: AudioCacheKey,
+    trim: Option<(u32, u32)>,
+    rate: u32,
+    channels: u16,
+    gain_bits: u32,
+    speed_bits: u32,
+}
+
+struct ConformedAudioCache {
+    entries: LruCache<ConformedAudioCacheKey, Arc<AudioBuffer>>,
+    bytes: usize,
+}
+
+impl Default for AudioDecodeCache {
+    fn default() -> Self {
+        Self {
+            entries: LruCache::unbounded(),
+            bytes: 0,
+        }
+    }
+}
+
+impl AudioDecodeCache {
+    fn get(&mut self, key: &AudioCacheKey) -> Option<Arc<AudioBuffer>> {
+        self.entries.get(key).cloned()
+    }
+
+    fn insert(&mut self, key: AudioCacheKey, buffer: Arc<AudioBuffer>) {
+        let bytes = audio_buffer_bytes(&buffer);
+        if bytes > AUDIO_CACHE_CAPACITY_BYTES {
+            return;
+        }
+
+        while self.bytes + bytes > AUDIO_CACHE_CAPACITY_BYTES {
+            let Some((_, old)) = self.entries.pop_lru() else {
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+        }
+
+        if let Some(old) = self.entries.put(key, buffer) {
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+        }
+        self.bytes += bytes;
+    }
+}
+
+impl Default for ConformedAudioCache {
+    fn default() -> Self {
+        Self {
+            entries: LruCache::unbounded(),
+            bytes: 0,
+        }
+    }
+}
+
+impl ConformedAudioCache {
+    fn get(&mut self, key: &ConformedAudioCacheKey) -> Option<Arc<AudioBuffer>> {
+        self.entries.get(key).cloned()
+    }
+
+    fn insert(&mut self, key: ConformedAudioCacheKey, buffer: Arc<AudioBuffer>) {
+        let bytes = audio_buffer_bytes(&buffer);
+        if bytes > AUDIO_CACHE_CAPACITY_BYTES {
+            return;
+        }
+
+        while self.bytes + bytes > AUDIO_CACHE_CAPACITY_BYTES {
+            let Some((_, old)) = self.entries.pop_lru() else {
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+        }
+
+        if let Some(old) = self.entries.put(key, buffer) {
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+        }
+        self.bytes += bytes;
+    }
+}
+
+fn audio_buffer_bytes(buffer: &AudioBuffer) -> usize {
+    buffer.samples.len() * std::mem::size_of::<f32>()
+}
+
+fn audio_cache_key(path: &str) -> io::Result<AudioCacheKey> {
+    let raw_path = Path::new(path);
+    let metadata = std::fs::metadata(raw_path)?;
+    let canonical = std::fs::canonicalize(raw_path).unwrap_or_else(|_| raw_path.to_path_buf());
+    let modified_ns = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos());
+    Ok(AudioCacheKey {
+        path: canonical,
+        len: metadata.len(),
+        modified_ns,
+    })
+}
+
+fn cached_full_audio(key: &AudioCacheKey) -> Option<Arc<AudioBuffer>> {
+    DECODE_CACHE.lock().ok()?.get(key)
+}
+
+fn cache_full_audio(key: AudioCacheKey, buffer: Arc<AudioBuffer>) {
+    if let Ok(mut cache) = DECODE_CACHE.lock() {
+        cache.insert(key, buffer);
+    }
+}
+
+fn cached_conformed_audio(key: &ConformedAudioCacheKey) -> Option<Arc<AudioBuffer>> {
+    CONFORM_CACHE.lock().ok()?.get(key)
+}
+
+fn cache_conformed_audio(key: ConformedAudioCacheKey, buffer: Arc<AudioBuffer>) {
+    if let Ok(mut cache) = CONFORM_CACHE.lock() {
+        cache.insert(key, buffer);
+    }
+}
+
+#[cfg(test)]
+fn clear_decode_cache_for_tests() {
+    if let Ok(mut cache) = DECODE_CACHE.lock() {
+        cache.entries.clear();
+        cache.bytes = 0;
+    }
+    if let Ok(mut cache) = CONFORM_CACHE.lock() {
+        cache.entries.clear();
+        cache.bytes = 0;
+    }
+}
+
+#[cfg(test)]
+fn decode_cache_len_for_tests() -> usize {
+    DECODE_CACHE
+        .lock()
+        .map(|cache| cache.entries.len())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+fn conform_cache_len_for_tests() -> usize {
+    CONFORM_CACHE
+        .lock()
+        .map(|cache| cache.entries.len())
+        .unwrap_or(0)
+}
 
 /// Maps a symphonia error into an [`io::Error`] so the decode path stays in the
 /// crate's existing `io::Result` vocabulary (the encoder/probe seams use it).
@@ -47,16 +222,87 @@ fn map_err(e: SymphoniaError) -> io::Error {
 /// mix-down resamples / re-channels it into the encoder's fixed layout. A `None`
 /// trim decodes the whole file.
 pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuffer> {
+    let key = audio_cache_key(path)?;
+
+    if let Some(cached) = cached_full_audio(&key) {
+        return Ok(slice_audio_buffer(&cached, trim));
+    }
+
+    let should_cache_full = trim.is_none() || key.len <= CACHE_FULL_ON_TRIM_SOURCE_BYTES_LIMIT;
+    if should_cache_full {
+        let decoded = Arc::new(decode_file_uncached(&key.path, None)?);
+        let out = slice_audio_buffer(&decoded, trim);
+        cache_full_audio(key, decoded);
+        return Ok(out);
+    }
+
+    decode_file_uncached(&key.path, trim)
+}
+
+/// Decoded duration in seconds, using the same cache as [`decode_file`] without
+/// cloning a large sample buffer just to count frames.
+pub fn decoded_duration(path: &str, trim: Option<(f32, f32)>) -> io::Result<f32> {
+    let key = audio_cache_key(path)?;
+
+    if let Some(cached) = cached_full_audio(&key) {
+        return Ok(audio_buffer_duration(&slice_audio_buffer(&cached, trim)));
+    }
+
+    let should_cache_full = trim.is_none() || key.len <= CACHE_FULL_ON_TRIM_SOURCE_BYTES_LIMIT;
+    let decoded = if should_cache_full {
+        let decoded = Arc::new(decode_file_uncached(&key.path, None)?);
+        cache_full_audio(key, Arc::clone(&decoded));
+        slice_audio_buffer(&decoded, trim)
+    } else {
+        decode_file_uncached(&key.path, trim)?
+    };
+    Ok(audio_buffer_duration(&decoded))
+}
+
+/// Decodes and conforms a whole source (or source trim) once for repeated
+/// timeline windows. Live preview segments can then slice the conformed PCM
+/// instead of re-decoding and re-resampling the same media on every request.
+pub(crate) fn conform_file_cached(
+    path: &str,
+    trim: Option<(f32, f32)>,
+    rate: u32,
+    channels: u16,
+    gain: f32,
+    speed: f32,
+) -> io::Result<Arc<AudioBuffer>> {
+    let source = audio_cache_key(path)?;
+    let key = ConformedAudioCacheKey {
+        source,
+        trim: trim.map(|(start, end)| (start.to_bits(), end.to_bits())),
+        rate,
+        channels,
+        gain_bits: gain.to_bits(),
+        speed_bits: speed.to_bits(),
+    };
+
+    if let Some(cached) = cached_conformed_audio(&key) {
+        return Ok(cached);
+    }
+
+    let decoded = decode_file(path, trim)?;
+    let samples = conform(decoded, rate, channels, gain, speed);
+    let conformed = Arc::new(AudioBuffer {
+        samples,
+        rate,
+        channels,
+    });
+    cache_conformed_audio(key, Arc::clone(&conformed));
+    Ok(conformed)
+}
+
+fn decode_file_uncached(path: &Path, trim: Option<(f32, f32)>) -> io::Result<AudioBuffer> {
     let file = std::fs::File::open(path)?;
     let mss = MediaSourceStream::new(Box::new(file), Default::default());
 
     // Hint the demuxer with the file extension; symphonia still falls back to
     // content sniffing if the extension is absent or wrong.
     let mut hint = Hint::new();
-    if let Some(ext) = std::path::Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-    {
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
         hint.with_extension(ext);
     }
 
@@ -196,6 +442,40 @@ pub fn decode_file(path: &str, trim: Option<(f32, f32)>) -> io::Result<AudioBuff
         rate,
         channels,
     })
+}
+
+pub(crate) fn slice_audio_buffer(buffer: &AudioBuffer, trim: Option<(f32, f32)>) -> AudioBuffer {
+    let Some((start, end)) = trim else {
+        return buffer.clone();
+    };
+
+    let start = start.max(0.0);
+    let end = end.max(0.0);
+    if end <= start {
+        return AudioBuffer::empty(buffer.rate, buffer.channels);
+    }
+
+    let channels = buffer.channels.max(1) as usize;
+    let total_frames = buffer.samples.len() / channels;
+    let start_frame = seconds_to_frame(start, buffer.rate).min(total_frames as u64) as usize;
+    let end_frame = seconds_to_frame(end, buffer.rate).min(total_frames as u64) as usize;
+    if end_frame <= start_frame {
+        return AudioBuffer::empty(buffer.rate, buffer.channels);
+    }
+
+    let lo = start_frame * channels;
+    let hi = end_frame * channels;
+    AudioBuffer {
+        samples: buffer.samples[lo..hi].to_vec(),
+        rate: buffer.rate,
+        channels: buffer.channels,
+    }
+}
+
+fn audio_buffer_duration(buffer: &AudioBuffer) -> f32 {
+    let channels = buffer.channels.max(1) as usize;
+    let frames = buffer.samples.len() / channels;
+    frames as f32 / buffer.rate.max(1) as f32
 }
 
 fn seconds_to_frame(seconds: f32, rate: u32) -> u64 {
@@ -386,6 +666,44 @@ impl AudioMix {
 mod tests {
     use super::*;
 
+    fn temp_wav(samples: &[i16], rate: u32, channels: u16) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock after unix epoch")
+            .as_nanos();
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "tellur-audio-cache-{}-{nanos}.wav",
+            std::process::id()
+        ));
+
+        let bits = 16u16;
+        let data_bytes = (samples.len() * 2) as u32;
+        let byte_rate = rate * channels as u32 * (bits as u32 / 8);
+        let block_align = channels * (bits / 8);
+        let mut bytes = Vec::with_capacity(44 + samples.len() * 2);
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(36 + data_bytes).to_le_bytes());
+        bytes.extend_from_slice(b"WAVE");
+        bytes.extend_from_slice(b"fmt ");
+        bytes.extend_from_slice(&16u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&channels.to_le_bytes());
+        bytes.extend_from_slice(&rate.to_le_bytes());
+        bytes.extend_from_slice(&byte_rate.to_le_bytes());
+        bytes.extend_from_slice(&block_align.to_le_bytes());
+        bytes.extend_from_slice(&bits.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&data_bytes.to_le_bytes());
+        for sample in samples {
+            bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+        std::fs::write(&path, bytes).expect("write wav fixture");
+        path
+    }
+
     #[test]
     fn resample_doubles_rate_length() {
         // Mono ramp at 4 Hz upsampled to 8 Hz roughly doubles the frame count.
@@ -441,5 +759,45 @@ mod tests {
         // Same rate, mono→mono, gain 0.5 halves the samples.
         let out = conform(buf, 48_000, 1, 0.5, 1.0);
         assert_eq!(out, vec![0.25, 0.25]);
+    }
+
+    #[test]
+    fn trimmed_decode_populates_and_reuses_full_cache_for_small_sources() {
+        clear_decode_cache_for_tests();
+        let path = temp_wav(&[0, 1000, 2000, 3000, 4000, 5000], 6, 1);
+        let path_str = path.to_string_lossy();
+
+        let window = decode_file(&path_str, Some((0.0, 0.5))).expect("decode trimmed wav");
+
+        assert_eq!(decode_cache_len_for_tests(), 1);
+        assert_eq!(window.rate, 6);
+        assert_eq!(window.channels, 1);
+        assert_eq!(window.samples.len(), 3);
+
+        let duration = decoded_duration(&path_str, None).expect("duration from cached wav");
+        assert!((duration - 1.0).abs() < 1e-6);
+
+        let _ = std::fs::remove_file(path);
+        clear_decode_cache_for_tests();
+    }
+
+    #[test]
+    fn conformed_audio_is_cached_for_repeated_windows() {
+        clear_decode_cache_for_tests();
+        let path = temp_wav(&[0, 1000, 2000, 3000, 4000, 5000], 6, 1);
+        let path_str = path.to_string_lossy();
+
+        let first =
+            conform_file_cached(&path_str, None, 12, 2, 0.5, 1.0).expect("conform first time");
+        let second =
+            conform_file_cached(&path_str, None, 12, 2, 0.5, 1.0).expect("conform second time");
+
+        assert_eq!(conform_cache_len_for_tests(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(first.rate, 12);
+        assert_eq!(first.channels, 2);
+
+        let _ = std::fs::remove_file(path);
+        clear_decode_cache_for_tests();
     }
 }

--- a/tellur-core/src/audio.rs
+++ b/tellur-core/src/audio.rs
@@ -666,6 +666,8 @@ impl AudioMix {
 mod tests {
     use super::*;
 
+    static AUDIO_CACHE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
     fn temp_wav(samples: &[i16], rate: u32, channels: u16) -> std::path::PathBuf {
         use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -763,6 +765,9 @@ mod tests {
 
     #[test]
     fn trimmed_decode_populates_and_reuses_full_cache_for_small_sources() {
+        let _guard = AUDIO_CACHE_TEST_LOCK
+            .lock()
+            .expect("audio cache test lock should not be poisoned");
         clear_decode_cache_for_tests();
         let path = temp_wav(&[0, 1000, 2000, 3000, 4000, 5000], 6, 1);
         let path_str = path.to_string_lossy();
@@ -783,6 +788,9 @@ mod tests {
 
     #[test]
     fn conformed_audio_is_cached_for_repeated_windows() {
+        let _guard = AUDIO_CACHE_TEST_LOCK
+            .lock()
+            .expect("audio cache test lock should not be poisoned");
         clear_decode_cache_for_tests();
         let path = temp_wav(&[0, 1000, 2000, 3000, 4000, 5000], 6, 1);
         let path_str = path.to_string_lossy();

--- a/tellur-core/src/composite.rs
+++ b/tellur-core/src/composite.rs
@@ -16,8 +16,73 @@
 //! source pixels skip the write entirely and fully-opaque ones go
 //! through a 4-byte copy.
 
-use crate::raster::{CpuRasterImage, PixelFormat, RasterImage, Resolution};
+use std::sync::{LazyLock, Mutex};
+
+use lru::LruCache;
+
+use crate::raster::{CpuRasterImage, PixelFormat, RasterImage, RasterStorageId, Resolution};
 use crate::render_context::{CompositeInput, RenderContext};
+
+const COMPOSITE_FRAMES_CACHE_ENTRIES: usize = 32;
+
+static COMPOSITE_FRAMES_CACHE: LazyLock<
+    Mutex<LruCache<CompositeFramesCacheKey, CompositeFramesCacheEntry>>,
+> = LazyLock::new(|| Mutex::new(LruCache::unbounded()));
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CompositeFramesCacheKey {
+    target: Resolution,
+    inputs: Vec<RasterStorageId>,
+}
+
+#[derive(Clone)]
+struct CompositeFramesCacheEntry {
+    _inputs: Vec<RasterImage>,
+    output: RasterImage,
+}
+
+#[cfg(test)]
+fn clear_composite_frames_cache_for_tests() {
+    if let Ok(mut cache) = COMPOSITE_FRAMES_CACHE.lock() {
+        cache.clear();
+    }
+}
+
+fn composite_frames_cache_key(
+    frames: &[RasterImage],
+    target: Resolution,
+) -> CompositeFramesCacheKey {
+    CompositeFramesCacheKey {
+        target,
+        inputs: frames.iter().map(RasterImage::storage_id).collect(),
+    }
+}
+
+fn cached_composite_frames(key: &CompositeFramesCacheKey) -> Option<RasterImage> {
+    COMPOSITE_FRAMES_CACHE
+        .lock()
+        .ok()
+        .and_then(|mut cache| cache.get(key).map(|entry| entry.output.clone()))
+}
+
+fn cache_composite_frames(
+    key: CompositeFramesCacheKey,
+    inputs: Vec<RasterImage>,
+    output: RasterImage,
+) {
+    if let Ok(mut cache) = COMPOSITE_FRAMES_CACHE.lock() {
+        cache.put(
+            key,
+            CompositeFramesCacheEntry {
+                _inputs: inputs,
+                output,
+            },
+        );
+        while cache.len() > COMPOSITE_FRAMES_CACHE_ENTRIES {
+            cache.pop_lru();
+        }
+    }
+}
 
 /// Source-over composites `src` onto `dst` at pixel offset
 /// `(offset_x, offset_y)`. Both buffers hold 8-bit straight-alpha RGBA
@@ -126,6 +191,12 @@ pub(crate) fn composite_frames_over(
         _ => {}
     }
 
+    let cache_key = composite_frames_cache_key(&frames, target);
+    if let Some(image) = cached_composite_frames(&cache_key) {
+        return Some(image);
+    }
+    let cache_inputs = frames.clone();
+
     if ctx.prefers_gpu() {
         let inputs: Vec<CompositeInput<'_>> = frames
             .iter()
@@ -137,6 +208,7 @@ pub(crate) fn composite_frames_over(
             .collect();
         if let Some(gpu) = ctx.gpu_backend() {
             if let Some(image) = gpu.composite(target, &inputs) {
+                cache_composite_frames(cache_key, cache_inputs, image.clone());
                 return Some(image);
             }
         }
@@ -147,12 +219,9 @@ pub(crate) fn composite_frames_over(
         let frame = ctx.readback(frame);
         composite_at(&mut buffer, target, &frame, 0, 0);
     }
-    Some(RasterImage::cpu(
-        target.width,
-        target.height,
-        PixelFormat::Rgba8,
-        buffer,
-    ))
+    let image = RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, buffer);
+    cache_composite_frames(cache_key, cache_inputs, image.clone());
+    Some(image)
 }
 
 /// Source-over blends `span_w` consecutive RGBA pixels of `src` onto
@@ -435,6 +504,7 @@ mod tests {
 
     #[test]
     fn composite_frames_uses_gpu_batch_without_readback() {
+        clear_composite_frames_cache_for_tests();
         let frames = vec![
             RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![255, 0, 0, 255]),
             RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![0, 0, 255, 255]),
@@ -449,10 +519,34 @@ mod tests {
         assert_eq!(ctx.readbacks, 0);
         assert_eq!(ctx.gpu.composite_calls, 1);
         assert_eq!(ctx.gpu.composite_inputs, vec![2]);
+        clear_composite_frames_cache_for_tests();
+    }
+
+    #[test]
+    fn composite_frames_reuses_cached_batch_for_same_input_storage() {
+        clear_composite_frames_cache_for_tests();
+        let frames = vec![
+            RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![255, 0, 0, 255]),
+            RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![0, 0, 255, 255]),
+        ];
+        let mut ctx = FakeContext::new(true);
+
+        let _ = composite_frames_over(frames.clone(), Resolution::new(1, 1), &mut ctx)
+            .expect("first composite produces an output");
+        let cached = composite_frames_over(frames, Resolution::new(1, 1), &mut ctx)
+            .expect("cached composite produces an output");
+        let cached = cached.into_cpu().expect("fake GPU returns CPU image");
+
+        assert_eq!(cached.pixels.as_ref(), &[42, 42, 42, 42]);
+        assert_eq!(ctx.readbacks, 0);
+        assert_eq!(ctx.gpu.composite_calls, 1);
+        assert_eq!(ctx.gpu.composite_inputs, vec![2]);
+        clear_composite_frames_cache_for_tests();
     }
 
     #[test]
     fn composite_frames_falls_back_to_cpu_when_gpu_declines() {
+        clear_composite_frames_cache_for_tests();
         let frames = vec![
             RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![255, 0, 0, 255]),
             RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![0, 0, 255, 255]),
@@ -467,5 +561,6 @@ mod tests {
         assert_eq!(ctx.readbacks, 2);
         assert_eq!(ctx.gpu.composite_calls, 1);
         assert_eq!(ctx.gpu.composite_inputs, vec![2]);
+        clear_composite_frames_cache_for_tests();
     }
 }

--- a/tellur-core/src/composite.rs
+++ b/tellur-core/src/composite.rs
@@ -138,36 +138,6 @@ pub fn composite_at(
     }
 }
 
-/// Source-over composites the image-channel frame `top` onto the running
-/// accumulator `acc`, at the full `target` frame (offset `(0, 0)`).
-///
-/// This is the timeline-sampling counterpart of [`composite_children`]
-/// (`layer.rs`): the spatial path renders `&dyn RasterComponent` children
-/// itself, but a timeline container has already turned each child into an
-/// `Option<RasterImage>` by recursing `frame`, so it must composite at the
-/// IMAGE layer (`.sketch/02 §8`). `top` is read back to CPU through `ctx` and
-/// blended over `acc`; the first contributing frame seeds a transparent
-/// `target`-sized accumulator. A `None` `top` leaves `acc` untouched.
-pub(crate) fn composite_frame_over(
-    acc: Option<RasterImage>,
-    top: RasterImage,
-    target: Resolution,
-    ctx: &mut dyn RenderContext,
-) -> RasterImage {
-    // Seed a transparent accumulator on the first contributing frame.
-    let mut buffer = match acc {
-        Some(image) => {
-            let cpu = ctx.readback(image);
-            // The accumulator owns its bytes; copy out of the (shared) `Bytes`.
-            cpu.pixels.to_vec()
-        }
-        None => vec![0u8; (target.width as usize) * (target.height as usize) * 4],
-    };
-    let top = ctx.readback(top);
-    composite_at(&mut buffer, target, &top, 0, 0);
-    RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, buffer)
-}
-
 /// Source-over composites already-rendered timeline frames, bottom to top.
 ///
 /// Timeline containers recurse into child timelines before they can composite,

--- a/tellur-core/src/effect/outline.rs
+++ b/tellur-core/src/effect/outline.rs
@@ -5,8 +5,13 @@
 //! strokes, the output remains ordinary vector paths and can be further
 //! transformed or rasterized through the existing pipeline.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, LazyLock, Mutex};
+
 use clipper2::{difference, inflate, intersect, simplify, union, EndType, FillRule, JoinType};
 use kurbo::{BezPath, PathEl, Point};
+use lru::LruCache;
 
 use crate::builder::VectorBuilder;
 use crate::geometry::{Constraints, Rect, Transform, Vec2};
@@ -16,8 +21,32 @@ use crate::Keyable;
 const DEFAULT_TOLERANCE: f32 = 0.2;
 const DEFAULT_MITER_LIMIT: f32 = 4.0;
 const MAX_CURVE_STEPS: usize = 96;
+const OUTLINE_CACHE_ENTRIES: usize = 512;
 
 type ClipperPaths = clipper2::Paths<clipper2::Milli>;
+
+static OUTLINE_CACHE: LazyLock<Mutex<LruCache<OutlineCacheKey, OutlineCacheEntry>>> =
+    LazyLock::new(|| Mutex::new(LruCache::unbounded()));
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct OutlineCacheKey {
+    content_hash: u64,
+    size_x_bits: u32,
+    size_y_bits: u32,
+}
+
+#[derive(Clone)]
+struct OutlineCacheEntry {
+    view_box: Rect,
+    paths: Option<Arc<ClipperPaths>>,
+}
+
+#[cfg(test)]
+fn clear_outline_cache_for_tests() {
+    if let Ok(mut cache) = OUTLINE_CACHE.lock() {
+        cache.clear();
+    }
+}
 
 /// Which side of the original silhouette the outline band occupies.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
@@ -114,25 +143,21 @@ impl VectorComponent for Outlined {
     }
 
     fn paint_bounds(&self, size: Vec2) -> Rect {
-        let inner = self.child.render(size);
-        let paths = self.outline_paths(&inner.root);
-        outline_view_box(size, &inner.view_box, paths.as_ref())
+        self.outline_entry(size).view_box
     }
 
     fn render(&self, size: Vec2) -> VectorGraphic {
-        let inner = self.child.render(size);
-        let paths = self.outline_paths(&inner.root);
-        let view_box = outline_view_box(size, &inner.view_box, paths.as_ref());
-        let Some(paths) = paths else {
+        let entry = self.outline_entry(size);
+        let Some(paths) = entry.paths else {
             return VectorGraphic {
-                view_box,
+                view_box: entry.view_box,
                 root: Node::empty(),
             };
         };
 
         VectorGraphic {
-            view_box,
-            root: paths_to_node(paths, self.paint.clone()),
+            view_box: entry.view_box,
+            root: paths_to_node(&paths, self.paint.clone()),
         }
     }
 }
@@ -156,7 +181,42 @@ pub trait VectorBuilderOutline: VectorBuilder {
 impl<B: VectorBuilder> VectorBuilderOutline for B {}
 
 impl Outlined {
-    fn outline_paths(&self, root: &Node) -> Option<ClipperPaths> {
+    fn outline_entry(&self, size: Vec2) -> OutlineCacheEntry {
+        let key = self.outline_cache_key(size);
+        if let Some(entry) = OUTLINE_CACHE
+            .lock()
+            .ok()
+            .and_then(|mut cache| cache.get(&key).cloned())
+        {
+            return entry;
+        }
+
+        let inner = self.child.render(size);
+        let paths = self.compute_outline_paths(&inner.root).map(Arc::new);
+        let entry = OutlineCacheEntry {
+            view_box: outline_view_box(size, &inner.view_box, paths.as_deref()),
+            paths,
+        };
+        if let Ok(mut cache) = OUTLINE_CACHE.lock() {
+            cache.put(key, entry.clone());
+            while cache.len() > OUTLINE_CACHE_ENTRIES {
+                cache.pop_lru();
+            }
+        }
+        entry
+    }
+
+    fn outline_cache_key(&self, size: Vec2) -> OutlineCacheKey {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        OutlineCacheKey {
+            content_hash: hasher.finish(),
+            size_x_bits: size.0.to_bits(),
+            size_y_bits: size.1.to_bits(),
+        }
+    }
+
+    fn compute_outline_paths(&self, root: &Node) -> Option<ClipperPaths> {
         if self.width <= 0.0 || !self.paint.is_visible() {
             return None;
         }
@@ -485,7 +545,7 @@ fn flatten_bez_path(path: &BezPath, tolerance: f32) -> Vec<Vec<Vec2>> {
     flatten_commands(&commands, Transform::IDENTITY, tolerance, true)
 }
 
-fn paths_to_node(paths: ClipperPaths, paint: Paint) -> Node {
+fn paths_to_node(paths: &ClipperPaths, paint: Paint) -> Node {
     let commands = paths_to_commands(paths);
     if commands.is_empty() {
         return Node::empty();
@@ -499,8 +559,8 @@ fn paths_to_node(paths: ClipperPaths, paint: Paint) -> Node {
     })
 }
 
-fn paths_to_commands(paths: ClipperPaths) -> Vec<PathCommand> {
-    let raw: Vec<Vec<(f64, f64)>> = paths.into();
+fn paths_to_commands(paths: &ClipperPaths) -> Vec<PathCommand> {
+    let raw: Vec<Vec<(f64, f64)>> = paths.clone().into();
     let mut commands = Vec::new();
     for path in raw {
         let mut iter = path.into_iter();
@@ -638,6 +698,7 @@ mod tests {
     use super::*;
     use crate::color::Color;
     use crate::shapes::Rectangle;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn red() -> Paint {
         Paint::solid(Color::rgb_u8(255, 0, 0))
@@ -645,6 +706,40 @@ mod tests {
 
     fn blue() -> Paint {
         Paint::solid(Color::rgb_u8(0, 0, 255))
+    }
+
+    struct CountingRect {
+        renders: Arc<AtomicUsize>,
+    }
+
+    impl PartialEq for CountingRect {
+        fn eq(&self, other: &Self) -> bool {
+            Arc::ptr_eq(&self.renders, &other.renders)
+        }
+    }
+
+    impl Eq for CountingRect {}
+
+    impl Hash for CountingRect {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            Arc::as_ptr(&self.renders).hash(state);
+        }
+    }
+
+    impl VectorComponent for CountingRect {
+        fn layout(&self, constraints: Constraints) -> Vec2 {
+            constraints.constrain(Vec2(10.0, 6.0))
+        }
+
+        fn render(&self, _size: Vec2) -> VectorGraphic {
+            self.renders.fetch_add(1, Ordering::Relaxed);
+            Rectangle {
+                size: Vec2(10.0, 6.0),
+                fill: Some(red().into()),
+                stroke: None,
+            }
+            .render(Vec2(10.0, 6.0))
+        }
     }
 
     #[test]
@@ -726,5 +821,21 @@ mod tests {
         assert!(bounds.origin.1 <= -0.99, "{bounds:?}");
         assert!(bounds.size.0 >= 11.9, "{bounds:?}");
         assert!(bounds.size.1 >= 7.9, "{bounds:?}");
+    }
+
+    #[test]
+    fn outline_reuses_geometry_between_bounds_and_render() {
+        clear_outline_cache_for_tests();
+        let renders = Arc::new(AtomicUsize::new(0));
+        let outlined = CountingRect {
+            renders: Arc::clone(&renders),
+        }
+        .outlined(2.0, blue());
+
+        let _ = outlined.paint_bounds(Vec2(10.0, 6.0));
+        let _ = outlined.render(Vec2(10.0, 6.0));
+
+        assert_eq!(renders.load(Ordering::Relaxed), 1);
+        clear_outline_cache_for_tests();
     }
 }

--- a/tellur-core/src/effect/write.rs
+++ b/tellur-core/src/effect/write.rs
@@ -180,7 +180,7 @@ impl VectorComponent for Write {
             fallback_stroke_width: self.stroke_width,
         };
         let fill = fill_node(inner.root.clone(), &mut fill_state);
-        if !node_is_empty(&fill) {
+        if !fill.is_empty() {
             children.push(fill);
         }
 
@@ -192,7 +192,7 @@ impl VectorComponent for Write {
                 fallback_stroke_width: self.stroke_width,
             };
             let stroke = stroke_node(inner.root, &mut stroke_state);
-            if !node_is_empty(&stroke) {
+            if !stroke.is_empty() {
                 children.push(stroke);
             }
         }
@@ -344,7 +344,7 @@ impl VectorComponent for TimedWrite {
             fallback_stroke_width: self.stroke_width,
         };
         let fill = timed_fill_node(inner.root.clone(), &mut fill_state);
-        if !node_is_empty(&fill) {
+        if !fill.is_empty() {
             children.push(fill);
         }
 
@@ -355,7 +355,7 @@ impl VectorComponent for TimedWrite {
             fallback_stroke_width: self.stroke_width,
         };
         let stroke = stroke_node(inner.root, &mut stroke_state);
-        if !node_is_empty(&stroke) {
+        if !stroke.is_empty() {
             children.push(stroke);
         }
 
@@ -973,21 +973,6 @@ fn smoothstep(t: f32) -> f32 {
     t * t * (3.0 - 2.0 * t)
 }
 
-fn node_is_empty(node: &Node) -> bool {
-    match node {
-        Node::Group(group) => group.opacity <= 0.0 || group.children.iter().all(node_is_empty),
-        Node::SingleGroup(group) => group.opacity <= 0.0 || node_is_empty(&group.child),
-        Node::ClipGroup(group) => node_is_empty(&group.child),
-        Node::Path(path) => {
-            !path.fill.as_ref().is_some_and(|fill| fill.is_visible())
-                && !path
-                    .stroke
-                    .as_ref()
-                    .is_some_and(|stroke| stroke.is_visible())
-        }
-    }
-}
-
 fn distance(a: Vec2, b: Vec2) -> f32 {
     ((b.0 - a.0).powi(2) + (b.1 - a.1).powi(2)).sqrt()
 }
@@ -1276,7 +1261,7 @@ mod tests {
             panic!("first child should be the per-path fill layer");
         };
         assert!(matches!(fill.children[0], Node::SingleGroup(_)));
-        assert!(node_is_empty(&fill.children[1]));
+        assert!(fill.children[1].is_empty());
 
         let Node::Group(stroke) = &root.children[1] else {
             panic!("second child should be the stroke reveal layer");

--- a/tellur-core/src/layer.rs
+++ b/tellur-core/src/layer.rs
@@ -180,9 +180,10 @@ pub(crate) fn render_vector_children(
 ) -> VectorGraphic {
     let nodes: Vec<Node> = children
         .iter()
-        .map(|child| {
+        .filter_map(|child| {
             let child_size = child.layout(child_constraints);
-            child.render(child_size).root
+            let node = child.render(child_size).root;
+            (!node.is_empty()).then_some(node)
         })
         .collect();
     VectorGraphic {
@@ -385,7 +386,7 @@ mod tests {
     use crate::raster::CpuRasterImage;
     use crate::render_context::{DropShadowInput, GpuPreference, GpuRasterBackend, OutlineInput};
     use crate::shapes::Rectangle;
-    use crate::vector::Paint;
+    use crate::vector::{Node, Paint};
 
     fn rect(w: f32, h: f32) -> Rectangle {
         Rectangle {
@@ -402,6 +403,26 @@ mod tests {
             children: vec![rect(80.0, 40.0).place_at(Vec2(10.0, 20.0)).into()],
         };
         assert_eq!(layer.layout(Constraints::UNBOUNDED), Vec2(500.0, 300.0));
+    }
+
+    #[test]
+    fn vector_layer_prunes_empty_child_nodes() {
+        let invisible = Rectangle {
+            size: Vec2(10.0, 10.0),
+            fill: Paint::Solid(Color::rgba_u8(255, 0, 0, 0)).into(),
+            stroke: None,
+        };
+        let layer = VectorLayer {
+            size: Vec2(100.0, 100.0),
+            children: vec![invisible.into(), rect(10.0, 10.0).into()],
+        };
+
+        let graphic = layer.render(Vec2(100.0, 100.0));
+        let Node::Group(root) = graphic.root else {
+            panic!("vector layer should render a root group");
+        };
+        assert_eq!(root.children.len(), 1);
+        assert!(matches!(root.children[0], Node::Path(_)));
     }
 
     #[derive(PartialEq, Eq, Hash)]

--- a/tellur-core/src/layer.rs
+++ b/tellur-core/src/layer.rs
@@ -21,11 +21,90 @@
 //! source-over compositing it onto the output at the corresponding pixel
 //! offset.
 
+use std::sync::{LazyLock, Mutex};
+
+use lru::LruCache;
+
 use crate::composite::composite_at;
 use crate::geometry::{Constraints, Rect, Transform, Vec2};
-use crate::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
+use crate::raster::{PixelFormat, RasterComponent, RasterImage, RasterStorageId, Resolution};
 use crate::render_context::{CompositeInput, RenderContext};
 use crate::vector::{Group, Node, VectorComponent, VectorGraphic};
+
+const COMPOSITE_CHILDREN_CACHE_ENTRIES: usize = 32;
+
+static COMPOSITE_CHILDREN_CACHE: LazyLock<
+    Mutex<LruCache<CompositeChildrenCacheKey, CompositeChildrenCacheEntry>>,
+> = LazyLock::new(|| Mutex::new(LruCache::unbounded()));
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct CompositeChildrenCacheInput {
+    image: RasterStorageId,
+    offset_x: i32,
+    offset_y: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CompositeChildrenCacheKey {
+    target: Resolution,
+    inputs: Vec<CompositeChildrenCacheInput>,
+}
+
+#[derive(Clone)]
+struct CompositeChildrenCacheEntry {
+    _inputs: Vec<RasterImage>,
+    output: RasterImage,
+}
+
+#[cfg(test)]
+fn clear_composite_children_cache_for_tests() {
+    if let Ok(mut cache) = COMPOSITE_CHILDREN_CACHE.lock() {
+        cache.clear();
+    }
+}
+
+fn composite_children_cache_key(
+    rendered: &[(RasterImage, i32, i32)],
+    target: Resolution,
+) -> CompositeChildrenCacheKey {
+    CompositeChildrenCacheKey {
+        target,
+        inputs: rendered
+            .iter()
+            .map(|(image, offset_x, offset_y)| CompositeChildrenCacheInput {
+                image: image.storage_id(),
+                offset_x: *offset_x,
+                offset_y: *offset_y,
+            })
+            .collect(),
+    }
+}
+
+fn cached_composite_children(key: &CompositeChildrenCacheKey) -> Option<RasterImage> {
+    COMPOSITE_CHILDREN_CACHE
+        .lock()
+        .ok()
+        .and_then(|mut cache| cache.get(key).map(|entry| entry.output.clone()))
+}
+
+fn cache_composite_children(
+    key: CompositeChildrenCacheKey,
+    inputs: Vec<RasterImage>,
+    output: RasterImage,
+) {
+    if let Ok(mut cache) = COMPOSITE_CHILDREN_CACHE.lock() {
+        cache.put(
+            key,
+            CompositeChildrenCacheEntry {
+                _inputs: inputs,
+                output,
+            },
+        );
+        while cache.len() > COMPOSITE_CHILDREN_CACHE_ENTRIES {
+            cache.pop_lru();
+        }
+    }
+}
 
 #[crate::component(vector)]
 #[derive(PartialEq, Hash)]
@@ -228,20 +307,29 @@ pub(crate) fn composite_children(
     let scale_y = target.height as f32 / paint_rect.size.1;
     let gpu_available = ctx.prefers_gpu() && ctx.gpu_backend().is_some();
 
-    if gpu_available {
-        let mut rendered = Vec::with_capacity(placed.len());
-        for (position, child_size, child) in placed {
-            let bounds = child.paint_bounds(*child_size);
-            let child_px_w = (bounds.size.0 * scale_x).round().max(1.0) as u32;
-            let child_px_h = (bounds.size.1 * scale_y).round().max(1.0) as u32;
-            let paint_x = position.0 + bounds.origin.0 - paint_rect.origin.0;
-            let paint_y = position.1 + bounds.origin.1 - paint_rect.origin.1;
-            let offset_x = (paint_x * scale_x).round() as i32;
-            let offset_y = (paint_y * scale_y).round() as i32;
-            let image = ctx.render(*child, *child_size, Resolution::new(child_px_w, child_px_h));
-            rendered.push((image, offset_x, offset_y));
-        }
+    let mut rendered = Vec::with_capacity(placed.len());
+    for (position, child_size, child) in placed {
+        let bounds = child.paint_bounds(*child_size);
+        let child_px_w = (bounds.size.0 * scale_x).round().max(1.0) as u32;
+        let child_px_h = (bounds.size.1 * scale_y).round().max(1.0) as u32;
+        let paint_x = position.0 + bounds.origin.0 - paint_rect.origin.0;
+        let paint_y = position.1 + bounds.origin.1 - paint_rect.origin.1;
+        let offset_x = (paint_x * scale_x).round() as i32;
+        let offset_y = (paint_y * scale_y).round() as i32;
+        let image = ctx.render(*child, *child_size, Resolution::new(child_px_w, child_px_h));
+        rendered.push((image, offset_x, offset_y));
+    }
 
+    let cache_key = composite_children_cache_key(&rendered, target);
+    if let Some(image) = cached_composite_children(&cache_key) {
+        return image;
+    }
+    let cache_inputs = rendered
+        .iter()
+        .map(|(image, _, _)| image.clone())
+        .collect::<Vec<_>>();
+
+    if gpu_available {
         let inputs: Vec<CompositeInput<'_>> = rendered
             .iter()
             .map(|(image, offset_x, offset_y)| CompositeInput {
@@ -252,37 +340,21 @@ pub(crate) fn composite_children(
             .collect();
         if let Some(gpu) = ctx.gpu_backend() {
             if let Some(image) = gpu.composite(target, &inputs) {
+                cache_composite_children(cache_key, cache_inputs, image.clone());
                 return image;
             }
         }
-
-        let mut accum = vec![0u8; (target.width as usize) * (target.height as usize) * 4];
-        for (image, offset_x, offset_y) in rendered {
-            let image = ctx.readback(image);
-            composite_at(&mut accum, target, &image, offset_x, offset_y);
-        }
-
-        return RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, accum);
     }
 
     let mut accum = vec![0u8; (target.width as usize) * (target.height as usize) * 4];
-    for (position, child_size, child) in placed {
-        let bounds = child.paint_bounds(*child_size);
-        let child_px_w = (bounds.size.0 * scale_x).round().max(1.0) as u32;
-        let child_px_h = (bounds.size.1 * scale_y).round().max(1.0) as u32;
-        let paint_x = position.0 + bounds.origin.0 - paint_rect.origin.0;
-        let paint_y = position.1 + bounds.origin.1 - paint_rect.origin.1;
-        let offset_x = (paint_x * scale_x).round() as i32;
-        let offset_y = (paint_y * scale_y).round() as i32;
-
-        // Route the child render through the context so cache lookups
-        // can intercept it before the underlying `render` runs.
-        let image = ctx.render(*child, *child_size, Resolution::new(child_px_w, child_px_h));
+    for (image, offset_x, offset_y) in rendered {
         let image = ctx.readback(image);
         composite_at(&mut accum, target, &image, offset_x, offset_y);
     }
 
-    RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, accum)
+    let image = RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, accum);
+    cache_composite_children(cache_key, cache_inputs, image.clone());
+    image
 }
 
 /// Smallest axis-aligned rectangle containing both `a` and `b`.
@@ -310,6 +382,8 @@ mod tests {
     use super::*;
     use crate::color::Color;
     use crate::placement::VectorPlacement;
+    use crate::raster::CpuRasterImage;
+    use crate::render_context::{DropShadowInput, GpuPreference, GpuRasterBackend, OutlineInput};
     use crate::shapes::Rectangle;
     use crate::vector::Paint;
 
@@ -328,5 +402,148 @@ mod tests {
             children: vec![rect(80.0, 40.0).place_at(Vec2(10.0, 20.0)).into()],
         };
         assert_eq!(layer.layout(Constraints::UNBOUNDED), Vec2(500.0, 300.0));
+    }
+
+    #[derive(PartialEq, Eq, Hash)]
+    struct DummyRaster;
+
+    impl RasterComponent for DummyRaster {
+        fn layout(&self, constraints: Constraints) -> Vec2 {
+            constraints.constrain(Vec2(1.0, 1.0))
+        }
+
+        fn render(
+            &self,
+            _size: Vec2,
+            _target: Resolution,
+            _ctx: &mut dyn RenderContext,
+        ) -> RasterImage {
+            panic!("test context intercepts renders")
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeGpu {
+        composites: usize,
+    }
+
+    impl GpuRasterBackend for FakeGpu {
+        fn composite(
+            &mut self,
+            target: Resolution,
+            _inputs: &[CompositeInput<'_>],
+        ) -> Option<RasterImage> {
+            self.composites += 1;
+            Some(RasterImage::cpu(
+                target.width,
+                target.height,
+                PixelFormat::Rgba8,
+                vec![7u8; (target.width as usize) * (target.height as usize) * 4],
+            ))
+        }
+
+        fn drop_shadow(&mut self, _input: DropShadowInput<'_>) -> Option<RasterImage> {
+            None
+        }
+
+        fn outline(&mut self, _input: OutlineInput<'_>) -> Option<RasterImage> {
+            None
+        }
+
+        fn rasterize(
+            &mut self,
+            _graphic: &VectorGraphic,
+            _target: Resolution,
+        ) -> Option<RasterImage> {
+            None
+        }
+
+        fn solid_fill(&mut self, _target: Resolution, _color: Color) -> Option<RasterImage> {
+            None
+        }
+
+        fn temporal_average(
+            &mut self,
+            _target: Resolution,
+            _frames: &[&RasterImage],
+            _total: u32,
+        ) -> Option<RasterImage> {
+            None
+        }
+
+        fn readback(&mut self, _image: RasterImage) -> Option<CpuRasterImage> {
+            None
+        }
+    }
+
+    struct FakeContext {
+        image: RasterImage,
+        gpu: FakeGpu,
+        renders: usize,
+        readbacks: usize,
+    }
+
+    impl FakeContext {
+        fn new() -> Self {
+            Self {
+                image: RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![1, 2, 3, 255]),
+                gpu: FakeGpu::default(),
+                renders: 0,
+                readbacks: 0,
+            }
+        }
+    }
+
+    impl RenderContext for FakeContext {
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
+        }
+
+        fn gpu_preference(&self) -> GpuPreference {
+            GpuPreference::PreferGpu
+        }
+
+        fn gpu_backend(&mut self) -> Option<&mut dyn GpuRasterBackend> {
+            Some(&mut self.gpu)
+        }
+
+        fn render(
+            &mut self,
+            _component: &dyn RasterComponent,
+            _size: Vec2,
+            _target: Resolution,
+        ) -> RasterImage {
+            self.renders += 1;
+            self.image.clone()
+        }
+
+        fn readback(&mut self, image: RasterImage) -> CpuRasterImage {
+            self.readbacks += 1;
+            image
+                .into_cpu()
+                .expect("fake context only returns CPU images")
+        }
+    }
+
+    #[test]
+    fn composite_children_reuses_cached_batch_for_same_input_storage() {
+        clear_composite_children_cache_for_tests();
+        let child = DummyRaster;
+        let placed = [(Vec2::ZERO, Vec2(1.0, 1.0), &child as &dyn RasterComponent)];
+        let paint_rect = Rect {
+            origin: Vec2::ZERO,
+            size: Vec2(1.0, 1.0),
+        };
+        let mut ctx = FakeContext::new();
+
+        let first = composite_children(paint_rect, Resolution::new(1, 1), &placed, &mut ctx);
+        let second = composite_children(paint_rect, Resolution::new(1, 1), &placed, &mut ctx);
+
+        assert_eq!(first.into_cpu().unwrap().pixels.as_ref(), &[7, 7, 7, 7]);
+        assert_eq!(second.into_cpu().unwrap().pixels.as_ref(), &[7, 7, 7, 7]);
+        assert_eq!(ctx.renders, 2);
+        assert_eq!(ctx.gpu.composites, 1);
+        assert_eq!(ctx.readbacks, 0);
+        clear_composite_children_cache_for_tests();
     }
 }

--- a/tellur-core/src/raster.rs
+++ b/tellur-core/src/raster.rs
@@ -21,6 +21,24 @@ pub enum RasterImage {
     Gpu(GpuSurface),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RasterStorageId {
+    Cpu {
+        width: u32,
+        height: u32,
+        format: PixelFormat,
+        ptr: usize,
+        len: usize,
+    },
+    Gpu {
+        width: u32,
+        height: u32,
+        format: PixelFormat,
+        backend: &'static str,
+        ptr: usize,
+    },
+}
+
 impl RasterImage {
     pub fn cpu(width: u32, height: u32, format: PixelFormat, pixels: impl Into<Bytes>) -> Self {
         Self::Cpu(CpuRasterImage {
@@ -87,6 +105,25 @@ impl RasterImage {
                 )
             }
             _ => false,
+        }
+    }
+
+    pub(crate) fn storage_id(&self) -> RasterStorageId {
+        match self {
+            Self::Cpu(image) => RasterStorageId::Cpu {
+                width: image.width,
+                height: image.height,
+                format: image.format,
+                ptr: image.pixels.as_ptr() as usize,
+                len: image.pixels.len(),
+            },
+            Self::Gpu(surface) => RasterStorageId::Gpu {
+                width: surface.width,
+                height: surface.height,
+                format: surface.format,
+                backend: surface.backend,
+                ptr: Arc::as_ptr(&surface.handle) as *const () as usize,
+            },
         }
     }
 }

--- a/tellur-core/src/timeline_component/resolve.rs
+++ b/tellur-core/src/timeline_component/resolve.rs
@@ -264,7 +264,8 @@ impl ResolvedTimeline {
         target: Resolution,
         ctx: &mut dyn RenderContext,
     ) -> Option<RasterImage> {
-        let clock = Clock::new(t, LocalTime::new(t.seconds()), self.triggers());
+        let clock = Clock::new(t, LocalTime::new(t.seconds()), self.triggers())
+            .with_local_window(LocalTime::new(t.seconds()), Some(self.duration));
         self.source().frame(clock, self.canvas, target, ctx)
     }
 

--- a/tellur-core/src/timeline_container/containers.rs
+++ b/tellur-core/src/timeline_container/containers.rs
@@ -1,7 +1,7 @@
 //! The overlay [`Timeline`] and the one-after-another [`Sequence`].
 
 use crate::audio::AudioMix;
-use crate::composite::{composite_frame_over, composite_frames_over};
+use crate::composite::composite_frames_over;
 use crate::geometry::Vec2;
 use crate::raster::{RasterImage, Resolution};
 use crate::render_context::RenderContext;
@@ -388,7 +388,7 @@ impl TimelineComponent for Sequence {
         // slot contributes nothing (`.sketch/02 §8`).
         let mut cursor = 0.0_f32;
         let mut placed_any = false;
-        let mut acc: Option<RasterImage> = None;
+        let mut frames = Vec::new();
         let local_t = clock.local().seconds();
         for child in &self.children {
             if Self::is_fill(child.as_ref()) {
@@ -408,13 +408,13 @@ impl TimelineComponent for Sequence {
             if active {
                 let child_clock = clock.with_local_window(LocalTime::new(local_t - cursor), slot);
                 if let Some(img) = child.frame(child_clock, canvas, target, ctx) {
-                    acc = Some(composite_frame_over(acc, img, target, ctx));
+                    frames.push(img);
                 }
             }
             cursor += slot.unwrap_or(0.0);
             placed_any = true;
         }
-        acc
+        composite_frames_over(frames, target, ctx)
     }
 
     fn samples(&self, clock: Clock<'_>, window: f32) -> Option<AudioBuffer> {

--- a/tellur-core/src/timeline_container/containers.rs
+++ b/tellur-core/src/timeline_container/containers.rs
@@ -190,7 +190,11 @@ impl TimelineComponent for Timeline {
         // determinate length to gate against and is left open (already a
         // resolve-time warning).
         let local_t = clock.local().seconds();
-        if let Some(length) = self.measure() {
+        let length = clock
+            .window()
+            .map(|window| window.width())
+            .or_else(|| self.measure());
+        if let Some(length) = length {
             if local_t < 0.0 || local_t >= length {
                 return None;
             }

--- a/tellur-core/src/timeline_container/containers.rs
+++ b/tellur-core/src/timeline_container/containers.rs
@@ -401,6 +401,11 @@ impl TimelineComponent for Sequence {
                 cursor += self.spacing;
             }
             let slot = child.measure();
+            // Children are ordered; once a finite future slot starts, no later
+            // finite child can be active at this local time.
+            if slot.is_some() && local_t < cursor {
+                break;
+            }
             let active = match slot {
                 Some(len) => local_t >= cursor && local_t < cursor + len,
                 None => true,
@@ -436,8 +441,22 @@ impl TimelineComponent for Sequence {
             if placed_any {
                 cursor += self.spacing;
             }
-            child.mix_into(mix, start_secs + cursor, speed);
-            cursor += child.measure().unwrap_or(0.0);
+            let slot = child.measure();
+            let child_start = start_secs + cursor;
+            if let Some(len) = slot {
+                // Windowed live audio should not even ask off-window clips to
+                // decode/conform; in long sequences this is the hot path.
+                if child_start + len <= 0.0 {
+                    cursor += len;
+                    placed_any = true;
+                    continue;
+                }
+                if child_start >= mix.duration() {
+                    break;
+                }
+            }
+            child.mix_into(mix, child_start, speed);
+            cursor += slot.unwrap_or(0.0);
             placed_any = true;
         }
     }

--- a/tellur-core/src/timeline_container/leaves.rs
+++ b/tellur-core/src/timeline_container/leaves.rs
@@ -168,12 +168,8 @@ impl AudioFile {
         // A trim fixes the length regardless of the source, as long as the
         // source is at least that long — but we still need the source length to
         // clamp. Decode to read the true length; fall back gracefully.
-        match audio::decode_file(&self.path, self.trim) {
-            Ok(buf) => {
-                let ch = buf.channels.max(1) as usize;
-                let frames = buf.samples.len() / ch;
-                frames as f32 / buf.rate.max(1) as f32
-            }
+        match audio::decoded_duration(&self.path, self.trim) {
+            Ok(duration) => duration,
             Err(_) => self
                 .trim
                 .map(|(a, b)| (b - a).max(0.0))
@@ -194,9 +190,9 @@ impl TimelineComponent for AudioFile {
     }
 
     fn mix_into(&self, mix: &mut AudioMix, start_secs: f32, speed: f32) {
-        // Decode only the source span that can land inside the current mix
-        // window, conform it to the mix's fixed rate / channel layout, and sum
-        // it in at the visible destination start. Decode failure ⇒ silence.
+        // Reuse a full-source conformed audio buffer, slice the part that can
+        // land inside this mix window, and sum it at the visible destination
+        // start. Decode/conform failure ⇒ silence.
         let speed = if speed.is_finite() && speed > 0.0 {
             speed
         } else {
@@ -219,9 +215,21 @@ impl TimelineComponent for AudioFile {
             return;
         }
 
-        if let Ok(buf) = audio::decode_file(&self.path, Some((decode_start, decode_end))) {
-            let conformed = audio::conform(buf, mix.rate(), mix.channels(), self.gain, speed);
-            mix.add(&conformed, visible_start);
+        if let Ok(buf) = audio::conform_file_cached(
+            &self.path,
+            self.trim,
+            mix.rate(),
+            mix.channels(),
+            self.gain,
+            speed,
+        ) {
+            let output_start = source_offset / speed;
+            let output_duration = (mix_duration - visible_start).max(0.0);
+            let window = audio::slice_audio_buffer(
+                &buf,
+                Some((output_start, output_start + output_duration)),
+            );
+            mix.add(&window.samples, visible_start);
         }
     }
 

--- a/tellur-core/src/timeline_container/tests.rs
+++ b/tellur-core/src/timeline_container/tests.rs
@@ -1,7 +1,9 @@
 use super::leaves::STUB_PROBE_SECONDS;
 use super::*;
 use crate::geometry::{Constraints, Vec2};
-use crate::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
+use crate::raster::{
+    CpuRasterImage, GpuSurface, PixelFormat, RasterComponent, RasterImage, Resolution,
+};
 use crate::render_context::RenderContext;
 use crate::timeline_component::{
     resolve, Arrangement, NodeKind, ResolveCtx, ResolveError, Timed, TimedBuilder,
@@ -570,6 +572,104 @@ fn sequence_gates_each_child_to_its_slot() {
             .frame(TimelineTime::new(4.0), Resolution::new(2, 2), &mut ctx)
             .is_none(),
         "past both slots: nothing",
+    );
+}
+
+#[derive(PartialEq, Hash)]
+struct GpuFrame;
+
+impl TimelineComponent for GpuFrame {
+    fn duration(&self) -> Option<f32> {
+        Some(1.0)
+    }
+
+    fn frame(
+        &self,
+        _clock: Clock<'_>,
+        _canvas: Vec2,
+        target: Resolution,
+        _ctx: &mut dyn RenderContext,
+    ) -> Option<RasterImage> {
+        Some(RasterImage::Gpu(GpuSurface::new(
+            target.width,
+            target.height,
+            PixelFormat::Rgba8,
+            "test-gpu",
+            Arc::new(()),
+        )))
+    }
+
+    fn arrangement(&self, offset: f32) -> Arrangement {
+        Arrangement {
+            kind: NodeKind::Video,
+            label: String::new(),
+            name: None,
+            source: None,
+            start: offset,
+            end: offset + 1.0,
+            trim: None,
+            triggers: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct CountingReadbackContext {
+    readbacks: usize,
+}
+
+impl RenderContext for CountingReadbackContext {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn render(
+        &mut self,
+        component: &dyn RasterComponent,
+        size: Vec2,
+        target: Resolution,
+    ) -> RasterImage {
+        component.render(size, target, self)
+    }
+
+    fn readback(&mut self, image: RasterImage) -> CpuRasterImage {
+        self.readbacks += 1;
+        match image {
+            RasterImage::Cpu(image) => image,
+            RasterImage::Gpu(surface) => {
+                let stride = match surface.format {
+                    PixelFormat::Rgba8 => 4,
+                    PixelFormat::Rgba16Float => 8,
+                };
+                let bytes = (surface.width as usize) * (surface.height as usize) * stride;
+                CpuRasterImage::new(
+                    surface.width,
+                    surface.height,
+                    surface.format,
+                    vec![0u8; bytes],
+                )
+            }
+        }
+    }
+}
+
+#[test]
+fn sequence_single_active_frame_preserves_gpu_image() {
+    let seq = Sequence::builder()
+        .child(Box::new(GpuFrame) as Box<dyn TimelineComponent + Send>)
+        .build();
+    let resolved = resolve_root(seq).expect("windowed, not timeless");
+    let mut ctx = CountingReadbackContext::default();
+
+    let frame = resolved
+        .frame(TimelineTime::new(0.5), Resolution::new(2, 2), &mut ctx)
+        .expect("active slot contributes");
+
+    assert_eq!(ctx.readbacks, 0, "single active slot should not read back");
+    assert!(
+        matches!(frame, RasterImage::Gpu(_)),
+        "sequence should preserve a target-sized GPU frame"
     );
 }
 

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -263,6 +263,19 @@ impl Node {
             children: Vec::new(),
         })
     }
+
+    /// `true` iff this node cannot produce visible ink.
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            Node::Group(group) => group.opacity <= 0.0 || group.children.iter().all(Node::is_empty),
+            Node::SingleGroup(group) => group.opacity <= 0.0 || group.child.is_empty(),
+            Node::ClipGroup(group) => group.child.is_empty(),
+            Node::Path(path) => {
+                !path.fill.as_ref().is_some_and(Fill::is_visible)
+                    && !path.stroke.as_ref().is_some_and(Stroke::is_visible)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Keyable)]

--- a/tellur-live/Cargo.toml
+++ b/tellur-live/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 ]
 
 [dependencies]
+lru = "0.12.5"
 png = "0.18.1"
 tellur-core = { path = "../tellur-core" }
 tellur-plugin = { path = "../tellur-plugin" }

--- a/tellur-live/src/main.rs
+++ b/tellur-live/src/main.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use tellur_core::raster::Resolution;
 use tellur_core::render_context::GpuPreference;
 use tellur_live::{serve, AutoBuildOptions, ServerOptions};
+use tellur_renderer::ColorRange;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -32,6 +33,7 @@ fn parse_args(mut args: impl Iterator<Item = String>) -> Result<ServerOptions, B
     let mut port = 4317u16;
     let mut resolution = Resolution::new(1280, 720);
     let mut fps = 30u32;
+    let mut color_range = ColorRange::Full;
     let mut gpu_preference = GpuPreference::Auto;
     let mut verbose = false;
     let mut auto_build_requested = false;
@@ -73,6 +75,10 @@ fn parse_args(mut args: impl Iterator<Item = String>) -> Result<ServerOptions, B
                 if fps == 0 {
                     return Err("--fps must be greater than zero".into());
                 }
+            }
+            "--color-range" => {
+                color_range =
+                    parse_color_range(&args.next().ok_or("--color-range requires a value")?)?;
             }
             "--verbose" => {
                 verbose = true;
@@ -149,6 +155,7 @@ fn parse_args(mut args: impl Iterator<Item = String>) -> Result<ServerOptions, B
         bind: bind.unwrap_or_else(|| format!("{host}:{port}")),
         resolution,
         fps,
+        color_range,
         gpu_preference,
         verbose,
         auto_build,
@@ -158,6 +165,10 @@ fn parse_args(mut args: impl Iterator<Item = String>) -> Result<ServerOptions, B
 fn parse_resolution(s: &str) -> Result<Resolution, Box<dyn Error>> {
     let (w, h) = s.split_once('x').ok_or("resolution must be WIDTHxHEIGHT")?;
     Ok(Resolution::new(w.parse()?, h.parse()?))
+}
+
+fn parse_color_range(s: &str) -> Result<ColorRange, Box<dyn Error>> {
+    s.parse().map_err(|e: String| e.into())
 }
 
 fn infer_example_name(path: &Path) -> Option<String> {
@@ -345,5 +356,5 @@ fn push_if_exists(paths: &mut Vec<PathBuf>, path: PathBuf) {
 }
 
 fn usage() -> String {
-    "usage: tellur-live serve (--plugin <path-to-cdylib> | -p <package> --example <example>) [--host 127.0.0.1] [--port 4317] [--bind 127.0.0.1:4317] [--fps 30] [--gpu|--no-gpu] [--verbose] [--watch] [--watch-path <path>] [--build-manifest <Cargo.toml>]".to_owned()
+    "usage: tellur-live serve (--plugin <path-to-cdylib> | -p <package> --example <example>) [--host 127.0.0.1] [--port 4317] [--bind 127.0.0.1:4317] [--fps 30] [--color-range full|limited] [--gpu|--no-gpu] [--verbose] [--watch] [--watch-path <path>] [--build-manifest <Cargo.toml>]".to_owned()
 }

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -637,7 +637,13 @@ impl PreviewApp {
         &mut self,
         query: &HashMap<String, String>,
     ) -> Result<RenderedFrame, Box<dyn Error>> {
-        let rendered = self.render_image(query)?;
+        let mut rendered = self.render_image(query)?;
+        if request_video_color(query) {
+            rendered.image = video_color_preview_image(
+                &rendered.image,
+                request_color_range(query, self.color_range),
+            )?;
+        }
 
         let encode_start = Instant::now();
         let mut body = Vec::new();
@@ -1599,6 +1605,16 @@ fn request_color_range(query: &HashMap<String, String>, default: ColorRange) -> 
         .unwrap_or(default)
 }
 
+fn request_video_color(query: &HashMap<String, String>) -> bool {
+    matches!(
+        query
+            .get("video_color")
+            .or_else(|| query.get("videoColor"))
+            .map(String::as_str),
+        Some("1") | Some("true") | Some("mp4") | Some("video")
+    )
+}
+
 fn request_resolution(query: &HashMap<String, String>, default: Resolution) -> Resolution {
     if let (Some(width), Some(height)) = (
         query
@@ -1629,6 +1645,115 @@ fn request_resolution(query: &HashMap<String, String>, default: Resolution) -> R
 
 fn scaled_dimension(value: u32, scale: f32) -> u32 {
     ((value as f32) * scale).round().clamp(1.0, u32::MAX as f32) as u32
+}
+
+fn video_color_preview_image(
+    image: &CpuRasterImage,
+    color_range: ColorRange,
+) -> Result<CpuRasterImage, Box<dyn Error>> {
+    if image.format != PixelFormat::Rgba8 {
+        return Err(format!("video-color preview requires Rgba8, got {:?}", image.format).into());
+    }
+
+    let width = image.width as usize;
+    let height = image.height as usize;
+    let expected = width * height * 4;
+    if image.pixels.len() != expected {
+        return Err(format!(
+            "video-color frame size mismatch: expected {expected} bytes, got {}",
+            image.pixels.len()
+        )
+        .into());
+    }
+
+    let mut out = vec![0u8; expected];
+    for y in (0..height).step_by(2) {
+        for x in (0..width).step_by(2) {
+            let mut chroma = [(0usize, 0.0_f32, 0.0_f32, 0.0_f32); 4];
+            let mut count = 0usize;
+            for dy in 0..2 {
+                let py = y + dy;
+                if py >= height {
+                    continue;
+                }
+                for dx in 0..2 {
+                    let px = x + dx;
+                    if px >= width {
+                        continue;
+                    }
+                    let idx = (py * width + px) * 4;
+                    let rgb = [
+                        image.pixels[idx] as f32,
+                        image.pixels[idx + 1] as f32,
+                        image.pixels[idx + 2] as f32,
+                    ];
+                    let (encoded_y, encoded_cb, encoded_cr) = bt709_rgb_to_ycbcr(rgb, color_range);
+                    chroma[count] = (idx, encoded_y, encoded_cb, encoded_cr);
+                    count += 1;
+                }
+            }
+            if count == 0 {
+                continue;
+            }
+
+            let cb = quantize_u8(
+                chroma[..count].iter().map(|(_, _, cb, _)| *cb).sum::<f32>() / count as f32,
+            ) as f32;
+            let cr = quantize_u8(
+                chroma[..count].iter().map(|(_, _, _, cr)| *cr).sum::<f32>() / count as f32,
+            ) as f32;
+            for &(idx, encoded_y, _, _) in &chroma[..count] {
+                let yy = quantize_u8(encoded_y) as f32;
+                let [r, g, b] = bt709_ycbcr_to_rgb(yy, cb, cr, color_range);
+                out[idx] = quantize_u8(r);
+                out[idx + 1] = quantize_u8(g);
+                out[idx + 2] = quantize_u8(b);
+                out[idx + 3] = image.pixels[idx + 3];
+            }
+        }
+    }
+
+    Ok(CpuRasterImage::new(
+        image.width,
+        image.height,
+        PixelFormat::Rgba8,
+        out,
+    ))
+}
+
+fn bt709_rgb_to_ycbcr(rgb: [f32; 3], color_range: ColorRange) -> (f32, f32, f32) {
+    let [r, g, b] = rgb;
+    let y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    let cb = (b - y) / 1.8556;
+    let cr = (r - y) / 1.5748;
+    match color_range {
+        ColorRange::Full => (y, 128.0 + cb, 128.0 + cr),
+        ColorRange::Limited => (
+            16.0 + y * (219.0 / 255.0),
+            128.0 + cb * (224.0 / 255.0),
+            128.0 + cr * (224.0 / 255.0),
+        ),
+    }
+}
+
+fn bt709_ycbcr_to_rgb(y: f32, cb: f32, cr: f32, color_range: ColorRange) -> [f32; 3] {
+    let (y, cb, cr) = match color_range {
+        ColorRange::Full => (y, cb - 128.0, cr - 128.0),
+        ColorRange::Limited => (
+            (y - 16.0) * (255.0 / 219.0),
+            (cb - 128.0) * (255.0 / 224.0),
+            (cr - 128.0) * (255.0 / 224.0),
+        ),
+    };
+    [
+        y + 1.5748 * cr,
+        y - 0.187_324 * cb - 0.468_124 * cr,
+        y + 1.8556 * cb,
+    ]
+}
+
+fn quantize_u8(value: f32) -> u8 {
+    value.round().clamp(0.0, 255.0) as u8
 }
 
 fn export_preview_png<W: Write>(image: &CpuRasterImage, writer: W) -> Result<(), Box<dyn Error>> {
@@ -2071,6 +2196,49 @@ mod tests {
             request_color_range(&query, ColorRange::Limited),
             ColorRange::Full
         );
+    }
+
+    #[test]
+    fn request_video_color_is_explicitly_opt_in() {
+        assert!(!request_video_color(&HashMap::new()));
+
+        let mut query = HashMap::new();
+        query.insert("video_color".to_owned(), "1".to_owned());
+        assert!(request_video_color(&query));
+
+        query.clear();
+        query.insert("videoColor".to_owned(), "mp4".to_owned());
+        assert!(request_video_color(&query));
+    }
+
+    #[test]
+    fn video_color_preview_preserves_gray_pixels() {
+        let image = CpuRasterImage::new(
+            2,
+            2,
+            PixelFormat::Rgba8,
+            vec![
+                64, 64, 64, 255, 128, 128, 128, 200, 200, 200, 200, 180, 255, 255, 255, 128,
+            ],
+        );
+
+        let out = video_color_preview_image(&image, ColorRange::Full).expect("convert");
+        assert_eq!(out.pixels, image.pixels);
+    }
+
+    #[test]
+    fn video_color_preview_shares_chroma_per_420_block() {
+        let image =
+            CpuRasterImage::new(2, 1, PixelFormat::Rgba8, vec![255, 0, 0, 77, 0, 0, 255, 88]);
+
+        let out = video_color_preview_image(&image, ColorRange::Full).expect("convert");
+        assert_eq!(out.width, 2);
+        assert_eq!(out.height, 1);
+        assert_eq!(out.format, PixelFormat::Rgba8);
+        assert_eq!(out.pixels[3], 77);
+        assert_eq!(out.pixels[7], 88);
+        assert_ne!(&out.pixels[..3], &image.pixels[..3]);
+        assert_ne!(&out.pixels[4..7], &image.pixels[4..7]);
     }
 
     #[test]

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -144,6 +144,7 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
         plugin: HotReloadPlugin::new(options.plugin_path),
         project_name: options.project_name,
         ctx: CachingRenderContext::with_capacity_bytes(LIVE_PREVIEW_CACHE_BYTES)
+            .with_volatile_large_admission()
             .with_gpu_preference(options.gpu_preference),
         resolution: options.resolution,
         fps: options.fps,
@@ -1447,7 +1448,7 @@ fn log_cache_metrics_delta(before: &CacheMetrics, after: &CacheMetrics) {
     let gpu_before = &before.gpu;
     let gpu_after = &after.gpu;
     println!(
-        "video-stream-cache-delta hits={} misses={} hit_rate={:.1}% cache_size={} evicted_delta={} pressure_skips_delta={} oversize_skips_delta={} gpu_ops={} gpu_composites={} gpu_shadows={} gpu_outlines={} gpu_rasterizes={} gpu_fills={} gpu_temporal_avg={} gpu_readbacks={}",
+        "video-stream-cache-delta hits={} misses={} hit_rate={:.1}% cache_size={} evicted_delta={} pressure_skips_delta={} oversize_skips_delta={} admission_skips_delta={} gpu_ops={} gpu_composites={} gpu_shadows={} gpu_outlines={} gpu_rasterizes={} gpu_fills={} gpu_temporal_avg={} gpu_readbacks={}",
         hits,
         misses,
         hit_rate * 100.0,
@@ -1455,6 +1456,7 @@ fn log_cache_metrics_delta(before: &CacheMetrics, after: &CacheMetrics) {
         format_bytes(after.bytes_evicted.saturating_sub(before.bytes_evicted)),
         after.pressure_skips.saturating_sub(before.pressure_skips),
         after.oversize_skips.saturating_sub(before.oversize_skips),
+        after.admission_skips.saturating_sub(before.admission_skips),
         gpu_after.total_ops().saturating_sub(gpu_before.total_ops()),
         gpu_after.composites.saturating_sub(gpu_before.composites),
         gpu_after.drop_shadows.saturating_sub(gpu_before.drop_shadows),

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -136,6 +136,7 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
         run_build_once(auto_build).map_err(|e| -> Box<dyn Error> { e.into() })?;
     }
 
+    let prewarm_gpu = options.gpu_preference.prefers_gpu();
     let compile_state = options
         .auto_build
         .clone()
@@ -160,6 +161,9 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
             .map_err(|_| -> Box<dyn Error> { "preview app lock poisoned".into() })?;
         app.reload_plugin_if_changed()?;
     }
+    if prewarm_gpu {
+        start_preview_prewarm(Arc::clone(&app));
+    }
 
     let video_epochs: Arc<Mutex<HashMap<String, Arc<AtomicU64>>>> =
         Arc::new(Mutex::new(HashMap::new()));
@@ -180,6 +184,67 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
         }
     }
     Ok(())
+}
+
+fn start_preview_prewarm(app: Arc<Mutex<PreviewApp>>) {
+    thread::spawn(move || {
+        let prewarm_start = Instant::now();
+        match preview_prewarm(&app) {
+            Ok(Some((timeline_id, audio_time, render_time, build_time, readback_time, true))) => {
+                println!(
+                    "preview-prewarm timeline={} audio={:.2}ms render={:.2}ms build={:.2}ms readback={:.2}ms total={:.2}ms",
+                    timeline_id,
+                    ms(audio_time),
+                    ms(render_time),
+                    ms(build_time),
+                    ms(readback_time),
+                    ms(prewarm_start.elapsed()),
+                );
+            }
+            Ok(_) => {}
+            Err(e) => eprintln!("preview prewarm failed: {e}"),
+        }
+    });
+}
+
+type PreviewPrewarmStats = (String, Duration, Duration, Duration, Duration, bool);
+
+fn preview_prewarm(
+    app: &Arc<Mutex<PreviewApp>>,
+) -> Result<Option<PreviewPrewarmStats>, Box<dyn Error>> {
+    let mut app = app
+        .lock()
+        .map_err(|_| -> Box<dyn Error> { "preview app lock poisoned".into() })?;
+    app.reload_plugin_if_changed()?;
+    let Some(info) = app
+        .plugin
+        .collection()?
+        .timelines()
+        .into_iter()
+        .find(|info| info.error.is_none() && info.duration > 0.0)
+    else {
+        return Ok(None);
+    };
+    let verbose = app.verbose;
+    let resolution = app.resolution;
+    let audio_start = Instant::now();
+    let _ = app.plugin.collection()?.render_audio_window(
+        &info.id,
+        0.0,
+        info.duration.min(1.0),
+        AUDIO_RATE,
+        AUDIO_CHANNELS,
+    );
+    let audio_time = audio_start.elapsed();
+    let frame = app.render_video_rgba(&info.id, 0.0, resolution, false, false)?;
+    Ok(Some((
+        info.id,
+        audio_time,
+        frame.render_time,
+        frame.build_time,
+        frame.readback_time,
+        verbose,
+    )))
 }
 
 fn handle_connection(

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::error::Error;
 use std::io::{Read, Write};
@@ -16,6 +17,7 @@ use tellur_core::raster::{CpuRasterImage, PixelFormat, Resolution};
 use tellur_core::render_context::{GpuPreference, RenderContext};
 use tellur_core::time::TimelineTime;
 use tellur_core::timeline_component::{Arrangement, AudioBuffer, NodeKind};
+use tellur_renderer::render_context::{CacheMetrics, TypeStats};
 use tellur_renderer::CachingRenderContext;
 
 use crate::build_watch::{
@@ -1165,6 +1167,16 @@ fn handle_video_stream(
     let mut render_total = Duration::ZERO;
     let mut stdin_write_total = Duration::ZERO;
     let mut end_reason = "complete";
+    let cache_metrics_before = if setup.verbose {
+        Some(
+            app.lock()
+                .map_err(|_| -> Box<dyn Error> { "preview app lock poisoned".into() })?
+                .ctx
+                .metrics(),
+        )
+    } else {
+        None
+    };
 
     for frame in 0..total_frames {
         if !client_alive.load(Ordering::Relaxed) {
@@ -1278,6 +1290,11 @@ fn handle_video_stream(
             status,
             stderr_text.len(),
         );
+        if let Some(before) = cache_metrics_before {
+            if let Ok(app) = app.lock() {
+                log_cache_metrics_delta(&before, &app.ctx.metrics());
+            }
+        }
     }
     if !status.success() && client_alive.load(Ordering::Relaxed) {
         return Err(format!("ffmpeg exited with {status}: {stderr_text}").into());
@@ -1393,6 +1410,105 @@ fn log_frame_stats(stats: &FrameRenderStats) {
         stats.gpu_ops,
         stats.gpu_readbacks,
     );
+}
+
+#[derive(Clone, Copy)]
+struct TypeStatsDelta {
+    hits: u64,
+    misses: u64,
+    inclusive_time: Duration,
+    self_time: Duration,
+}
+
+impl TypeStatsDelta {
+    fn total(self) -> u64 {
+        self.hits + self.misses
+    }
+
+    fn hit_rate(self) -> f64 {
+        let total = self.total();
+        if total == 0 {
+            0.0
+        } else {
+            self.hits as f64 / total as f64
+        }
+    }
+}
+
+fn log_cache_metrics_delta(before: &CacheMetrics, after: &CacheMetrics) {
+    let hits = after.hits.saturating_sub(before.hits);
+    let misses = after.misses.saturating_sub(before.misses);
+    let total = hits + misses;
+    let hit_rate = if total == 0 {
+        0.0
+    } else {
+        hits as f64 / total as f64
+    };
+    let gpu_before = &before.gpu;
+    let gpu_after = &after.gpu;
+    println!(
+        "video-stream-cache-delta hits={} misses={} hit_rate={:.1}% cache_size={} evicted_delta={} pressure_skips_delta={} oversize_skips_delta={} gpu_ops={} gpu_composites={} gpu_shadows={} gpu_outlines={} gpu_rasterizes={} gpu_fills={} gpu_temporal_avg={} gpu_readbacks={}",
+        hits,
+        misses,
+        hit_rate * 100.0,
+        format_bytes(after.bytes_cached as u64),
+        format_bytes(after.bytes_evicted.saturating_sub(before.bytes_evicted)),
+        after.pressure_skips.saturating_sub(before.pressure_skips),
+        after.oversize_skips.saturating_sub(before.oversize_skips),
+        gpu_after.total_ops().saturating_sub(gpu_before.total_ops()),
+        gpu_after.composites.saturating_sub(gpu_before.composites),
+        gpu_after.drop_shadows.saturating_sub(gpu_before.drop_shadows),
+        gpu_after.outlines.saturating_sub(gpu_before.outlines),
+        gpu_after.rasterizes.saturating_sub(gpu_before.rasterizes),
+        gpu_after.fills.saturating_sub(gpu_before.fills),
+        gpu_after
+            .temporal_averages
+            .saturating_sub(gpu_before.temporal_averages),
+        gpu_after.readbacks.saturating_sub(gpu_before.readbacks),
+    );
+
+    let mut rows: Vec<(&'static str, TypeStatsDelta)> = after
+        .per_type
+        .iter()
+        .map(|(name, stats)| {
+            let before_stats = before.per_type.get(name);
+            (*name, diff_type_stats(before_stats, stats))
+        })
+        .filter(|(_, stats)| stats.total() > 0 || !stats.self_time.is_zero())
+        .collect();
+    rows.sort_by_key(|(_, stats)| Reverse(stats.self_time));
+    for (name, stats) in rows.into_iter().take(12) {
+        println!(
+            "video-stream-cache-type name={} hits={} misses={} hit_rate={:.1}% self={} incl={}",
+            name,
+            stats.hits,
+            stats.misses,
+            stats.hit_rate() * 100.0,
+            format_duration(stats.self_time),
+            format_duration(stats.inclusive_time),
+        );
+    }
+}
+
+fn diff_type_stats(before: Option<&TypeStats>, after: &TypeStats) -> TypeStatsDelta {
+    let before = before.copied().unwrap_or_default();
+    TypeStatsDelta {
+        hits: after.hits.saturating_sub(before.hits),
+        misses: after.misses.saturating_sub(before.misses),
+        inclusive_time: after.inclusive_time.saturating_sub(before.inclusive_time),
+        self_time: after.self_time.saturating_sub(before.self_time),
+    }
+}
+
+fn format_duration(d: Duration) -> String {
+    let micros = d.as_micros();
+    if micros >= 1_000_000 {
+        format!("{:.2}s", d.as_secs_f64())
+    } else if micros >= 1_000 {
+        format!("{:.2}ms", micros as f64 / 1_000.0)
+    } else {
+        format!("{micros}us")
+    }
 }
 
 fn ms(d: Duration) -> f64 {

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -567,9 +567,10 @@ impl PreviewApp {
         seconds: f32,
         resolution: Resolution,
         motion_blur: bool,
+        collect_stats: bool,
     ) -> Result<VideoFrame, Box<dyn Error>> {
         self.ctx.set_motion_blur_enabled(motion_blur);
-        let before = self.ctx.metrics();
+        let before = collect_stats.then(|| self.ctx.metrics());
         let render_start = Instant::now();
         let image = self
             .plugin
@@ -586,21 +587,45 @@ impl PreviewApp {
         if image.format != PixelFormat::Rgba8 {
             return Err(format!("h264 stream requires Rgba8, got {:?}", image.format).into());
         }
-        let after = self.ctx.metrics();
-        let gpu_init_error = self.ctx.gpu_init_error().map(str::to_owned);
+        let stats = before.map(|before| {
+            let after = self.ctx.metrics();
+            let gpu_init_error = self.ctx.gpu_init_error().map(str::to_owned);
+            (
+                after.hits.saturating_sub(before.hits),
+                after.misses.saturating_sub(before.misses),
+                after.bytes_cached,
+                after.gpu_available,
+                after.gpu_init_attempted,
+                gpu_init_error,
+                format!("{:?}", after.gpu_preference),
+                after.gpu.total_ops().saturating_sub(before.gpu.total_ops()),
+                after.gpu.readbacks.saturating_sub(before.gpu.readbacks),
+            )
+        });
+        let (
+            cache_hits,
+            cache_misses,
+            bytes_cached,
+            gpu_available,
+            gpu_init_attempted,
+            gpu_init_error,
+            gpu_preference,
+            gpu_ops,
+            gpu_readbacks,
+        ) = stats.unwrap_or_else(|| (0, 0, 0, false, false, None, String::new(), 0, 0));
 
         Ok(VideoFrame {
             image,
             render_time,
-            cache_hits: after.hits.saturating_sub(before.hits),
-            cache_misses: after.misses.saturating_sub(before.misses),
-            bytes_cached: after.bytes_cached,
-            gpu_available: after.gpu_available,
-            gpu_init_attempted: after.gpu_init_attempted,
+            cache_hits,
+            cache_misses,
+            bytes_cached,
+            gpu_available,
+            gpu_init_attempted,
             gpu_init_error,
-            gpu_preference: format!("{:?}", after.gpu_preference),
-            gpu_ops: after.gpu.total_ops().saturating_sub(before.gpu.total_ops()),
-            gpu_readbacks: after.gpu.readbacks.saturating_sub(before.gpu.readbacks),
+            gpu_preference,
+            gpu_ops,
+            gpu_readbacks,
         })
     }
 
@@ -1204,13 +1229,15 @@ fn handle_video_stream(
             let mut app = app
                 .lock()
                 .map_err(|_| -> Box<dyn Error> { "preview app lock poisoned".into() })?;
+            let verbose = app.verbose;
             let frame = app.render_video_rgba(
                 &setup.timeline_id,
                 seconds,
                 setup.resolution,
                 setup.motion_blur,
+                verbose,
             )?;
-            if app.verbose {
+            if verbose {
                 println!(
                     "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={}",
                     setup.timeline_id,

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -576,6 +576,7 @@ impl PreviewApp {
         self.ctx.set_motion_blur_enabled(motion_blur);
         let before = collect_stats.then(|| self.ctx.metrics());
         let render_start = Instant::now();
+        let build_start = Instant::now();
         let image = self
             .plugin
             .collection()?
@@ -586,7 +587,10 @@ impl PreviewApp {
                 &mut self.ctx,
             )
             .ok_or("timeline did not produce a frame")?;
+        let build_time = build_start.elapsed();
+        let readback_start = Instant::now();
         let image = self.ctx.readback(image);
+        let readback_time = readback_start.elapsed();
         let render_time = render_start.elapsed();
         if image.format != PixelFormat::Rgba8 {
             return Err(format!("h264 stream requires Rgba8, got {:?}", image.format).into());
@@ -621,6 +625,8 @@ impl PreviewApp {
         Ok(VideoFrame {
             image,
             render_time,
+            build_time,
+            readback_time,
             cache_hits,
             cache_misses,
             bytes_cached,
@@ -816,6 +822,8 @@ fn write_video_stream_headers(
 struct VideoFrame {
     image: CpuRasterImage,
     render_time: Duration,
+    build_time: Duration,
+    readback_time: Duration,
     cache_hits: u64,
     cache_misses: u64,
     bytes_cached: usize,
@@ -1261,7 +1269,7 @@ fn handle_video_stream(
             )?;
             if verbose {
                 println!(
-                    "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={}",
+                    "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms build={:.2}ms readback={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={}",
                     setup.timeline_id,
                     seconds,
                     setup.resolution.width,
@@ -1269,6 +1277,8 @@ fn handle_video_stream(
                     setup.fps,
                     setup.gop,
                     ms(frame.render_time),
+                    ms(frame.build_time),
+                    ms(frame.readback_time),
                     frame.image.pixels.len(),
                     frame.cache_hits,
                     frame.cache_misses,

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -6,11 +6,12 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
-    Arc, Mutex,
+    Arc, LazyLock, Mutex,
 };
 use std::thread;
 use std::time::{Duration, Instant};
 
+use lru::LruCache;
 use tellur_core::raster::{CpuRasterImage, PixelFormat, Resolution};
 use tellur_core::render_context::{GpuPreference, RenderContext};
 use tellur_core::time::TimelineTime;
@@ -28,6 +29,85 @@ use tellur_plugin::TimelineInfo;
 /// cache below the renderer's export-oriented 1 GiB default avoids memory
 /// pressure and LRU churn making playback look stalled.
 const LIVE_PREVIEW_CACHE_BYTES: usize = 256 * 1024 * 1024;
+const VIDEO_SEGMENT_CACHE_BYTES: usize = 512 * 1024 * 1024;
+const VIDEO_SEGMENT_CACHE_ENTRIES: usize = 128;
+
+static VIDEO_SEGMENT_CACHE: LazyLock<Mutex<VideoSegmentCache>> =
+    LazyLock::new(|| Mutex::new(VideoSegmentCache::default()));
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct VideoSegmentCacheKey {
+    plugin_cache_key: String,
+    timeline_id: String,
+    start_seconds_bits: u32,
+    video_seconds_bits: u32,
+    width: u32,
+    height: u32,
+    fps: u32,
+    gop: u32,
+    crf: u8,
+    motion_blur: bool,
+}
+
+struct VideoSegmentCache {
+    entries: LruCache<VideoSegmentCacheKey, Arc<Vec<u8>>>,
+    bytes: usize,
+}
+
+impl Default for VideoSegmentCache {
+    fn default() -> Self {
+        Self {
+            entries: LruCache::unbounded(),
+            bytes: 0,
+        }
+    }
+}
+
+impl VideoSegmentCache {
+    fn get(&mut self, key: &VideoSegmentCacheKey) -> Option<Arc<Vec<u8>>> {
+        self.entries.get(key).cloned()
+    }
+
+    fn insert(&mut self, key: VideoSegmentCacheKey, body: Vec<u8>) {
+        let bytes = body.len();
+        if bytes > VIDEO_SEGMENT_CACHE_BYTES {
+            return;
+        }
+        while self.bytes + bytes > VIDEO_SEGMENT_CACHE_BYTES
+            || self.entries.len() >= VIDEO_SEGMENT_CACHE_ENTRIES
+        {
+            let Some((_, old)) = self.entries.pop_lru() else {
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(old.len());
+        }
+        if let Some(old) = self.entries.put(key, Arc::new(body)) {
+            self.bytes = self.bytes.saturating_sub(old.len());
+        }
+        self.bytes += bytes;
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.bytes = 0;
+    }
+}
+
+fn cached_video_segment(key: &VideoSegmentCacheKey) -> Option<Arc<Vec<u8>>> {
+    VIDEO_SEGMENT_CACHE.lock().ok()?.get(key)
+}
+
+fn cache_video_segment(key: VideoSegmentCacheKey, body: Vec<u8>) {
+    if let Ok(mut cache) = VIDEO_SEGMENT_CACHE.lock() {
+        cache.insert(key, body);
+    }
+}
+
+fn clear_video_segment_cache() {
+    if let Ok(mut cache) = VIDEO_SEGMENT_CACHE.lock() {
+        cache.clear();
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ServerOptions {
@@ -230,6 +310,7 @@ impl PreviewApp {
         if changed {
             self.ctx.clear();
             self.ctx.clear_metrics();
+            clear_video_segment_cache();
         }
         Ok(changed)
     }
@@ -649,6 +730,43 @@ struct VideoStreamSetup {
     verbose: bool,
 }
 
+fn video_segment_cache_key(
+    setup: &VideoStreamSetup,
+    plugin_cache_key: &str,
+    video_seconds: f32,
+) -> VideoSegmentCacheKey {
+    VideoSegmentCacheKey {
+        plugin_cache_key: plugin_cache_key.to_owned(),
+        timeline_id: setup.timeline_id.clone(),
+        start_seconds_bits: setup.start_seconds.to_bits(),
+        video_seconds_bits: video_seconds.to_bits(),
+        width: setup.resolution.width,
+        height: setup.resolution.height,
+        fps: setup.fps,
+        gop: setup.gop,
+        crf: setup.crf,
+        motion_blur: setup.motion_blur,
+    }
+}
+
+fn write_video_stream_headers(
+    stream: &mut TcpStream,
+    setup: &VideoStreamSetup,
+) -> std::io::Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: video/mp4\r\n\
+         X-Tellur-Width: {}\r\n\
+         X-Tellur-Height: {}\r\n\
+         X-Tellur-Fps: {}\r\n\
+         X-Tellur-Gop: {}\r\n\
+         Cache-Control: {}\r\n\
+         Connection: close\r\n\r\n",
+        setup.resolution.width, setup.resolution.height, setup.fps, setup.gop, setup.cache_control,
+    )
+}
+
 struct VideoFrame {
     image: CpuRasterImage,
     render_time: Duration,
@@ -805,6 +923,31 @@ fn handle_video_stream(
     // (instead of `-shortest`; see that arg). This is also the loop's frame count.
     let total_frames = (setup.duration * setup.fps as f32).ceil().max(0.0) as u64;
     let video_seconds = total_frames as f32 / setup.fps as f32;
+    let segment_cache_key = if setup.cache_control != "no-store" {
+        query
+            .get("v")
+            .map(|cache_key| video_segment_cache_key(&setup, cache_key, video_seconds))
+    } else {
+        None
+    };
+    if let Some(key) = &segment_cache_key {
+        if let Some(body) = cached_video_segment(key) {
+            write_video_stream_headers(&mut stream, &setup)?;
+            stream.write_all(&body)?;
+            stream.flush()?;
+            if setup.verbose {
+                println!(
+                    "video-stream-cache timeline={} start={:.3}s duration={:.3}s bytes={} total={:.2}ms",
+                    setup.timeline_id,
+                    setup.start_seconds,
+                    video_seconds,
+                    body.len(),
+                    ms(stream_start.elapsed()),
+                );
+            }
+            return Ok(());
+        }
+    }
 
     // Render only this stream's audio window and stage it as a temp WAV. Full
     // timeline audio can be huge, and live preview requests many short cache
@@ -843,18 +986,7 @@ fn handle_video_stream(
         return Ok(());
     }
 
-    write!(
-        stream,
-        "HTTP/1.1 200 OK\r\n\
-         Content-Type: video/mp4\r\n\
-         X-Tellur-Width: {}\r\n\
-         X-Tellur-Height: {}\r\n\
-         X-Tellur-Fps: {}\r\n\
-         X-Tellur-Gop: {}\r\n\
-         Cache-Control: {}\r\n\
-         Connection: close\r\n\r\n",
-        setup.resolution.width, setup.resolution.height, setup.fps, setup.gop, setup.cache_control,
-    )?;
+    write_video_stream_headers(&mut stream, &setup)?;
 
     // FLAC block size aligned to ONE video frame's worth of audio samples, applied
     // to the encoder below (only when the sample rate divides evenly by fps — the
@@ -984,6 +1116,7 @@ fn handle_video_stream(
     let mut stream_out = stream.try_clone()?;
     let client_alive = Arc::new(AtomicBool::new(true));
     let client_alive_for_stdout = Arc::clone(&client_alive);
+    let collect_segment_body = segment_cache_key.is_some();
 
     // Drain ffmpeg's stdout to the client until TRUE EOF. ffmpeg emits the tail
     // GOP/fragments only after stdin is closed (the EOF below `drop(stdin)`), so
@@ -994,6 +1127,7 @@ fn handle_video_stream(
     // bug). Only a real read error or a client write failure ends the drain.
     let stdout_thread = thread::spawn(move || {
         let mut buf = [0u8; 64 * 1024];
+        let mut segment_body = collect_segment_body.then(Vec::new);
         loop {
             let n = match stdout.read(&mut buf) {
                 Ok(0) => break,
@@ -1008,10 +1142,14 @@ fn handle_video_stream(
                 client_alive_for_stdout.store(false, Ordering::Relaxed);
                 break;
             }
+            if let Some(body) = &mut segment_body {
+                body.extend_from_slice(&buf[..n]);
+            }
         }
         // Flush the final fragments to the kernel before the connection's FIN so
         // the tail is not stranded in a userspace/socket buffer at close.
         let _ = stream_out.flush();
+        segment_body
     });
 
     let stderr_thread = thread::spawn(move || {
@@ -1109,12 +1247,17 @@ fn handle_video_stream(
     if !client_alive.load(Ordering::Relaxed) {
         let _ = child.kill();
     }
-    let _ = stdout_thread.join();
+    let segment_body = stdout_thread.join().unwrap_or(None);
     if !client_alive.load(Ordering::Relaxed) && end_reason == "complete" {
         end_reason = "client_closed";
     }
     let stderr_text = stderr_thread.join().unwrap_or_default();
     let status = child.wait()?;
+    if status.success() && client_alive.load(Ordering::Relaxed) && end_reason == "complete" {
+        if let (Some(key), Some(body)) = (segment_cache_key, segment_body) {
+            cache_video_segment(key, body);
+        }
+    }
     if setup.verbose {
         println!(
             "video-stream timeline={} start={:.3}s duration={:.3}s frames={}/{} written={} reason={} setup={:.2}ms audio={} audio_setup={:.2}ms ffmpeg_spawn={:.2}ms render_total={:.2}ms stdin_write={:.2}ms total={:.2}ms status={} stderr_bytes={}",

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -18,7 +18,7 @@ use tellur_core::render_context::{GpuPreference, RenderContext};
 use tellur_core::time::TimelineTime;
 use tellur_core::timeline_component::{Arrangement, AudioBuffer, NodeKind};
 use tellur_renderer::render_context::{CacheMetrics, TypeStats};
-use tellur_renderer::CachingRenderContext;
+use tellur_renderer::{CachingRenderContext, ColorRange};
 
 use crate::build_watch::{
     describe_build, run_build_once, start_build_watcher, AutoBuildOptions, CompileSnapshot,
@@ -49,6 +49,7 @@ struct VideoSegmentCacheKey {
     gop: u32,
     crf: u8,
     motion_blur: bool,
+    color_range: ColorRange,
 }
 
 struct VideoSegmentCache {
@@ -118,6 +119,7 @@ pub struct ServerOptions {
     pub bind: String,
     pub resolution: Resolution,
     pub fps: u32,
+    pub color_range: ColorRange,
     pub gpu_preference: GpuPreference,
     pub verbose: bool,
     pub auto_build: Option<AutoBuildOptions>,
@@ -148,6 +150,7 @@ pub fn serve(options: ServerOptions) -> Result<(), Box<dyn Error>> {
             .with_gpu_preference(options.gpu_preference),
         resolution: options.resolution,
         fps: options.fps,
+        color_range: options.color_range,
         verbose: options.verbose,
         compile_state,
     }));
@@ -303,6 +306,7 @@ struct PreviewApp {
     ctx: CachingRenderContext,
     resolution: Resolution,
     fps: u32,
+    color_range: ColorRange,
     verbose: bool,
     compile_state: CompileState,
 }
@@ -752,6 +756,7 @@ struct VideoStreamSetup {
     gop: u32,
     crf: u8,
     motion_blur: bool,
+    color_range: ColorRange,
     start_seconds: f32,
     cache_control: &'static str,
     realtime: bool,
@@ -774,6 +779,7 @@ fn video_segment_cache_key(
         gop: setup.gop,
         crf: setup.crf,
         motion_blur: setup.motion_blur,
+        color_range: setup.color_range,
     }
 }
 
@@ -789,9 +795,15 @@ fn write_video_stream_headers(
          X-Tellur-Height: {}\r\n\
          X-Tellur-Fps: {}\r\n\
          X-Tellur-Gop: {}\r\n\
+         X-Tellur-Color-Range: {}\r\n\
          Cache-Control: {}\r\n\
          Connection: close\r\n\r\n",
-        setup.resolution.width, setup.resolution.height, setup.fps, setup.gop, setup.cache_control,
+        setup.resolution.width,
+        setup.resolution.height,
+        setup.fps,
+        setup.gop,
+        setup.color_range.as_str(),
+        setup.cache_control,
     )
 }
 
@@ -932,6 +944,7 @@ fn handle_video_stream(
             gop,
             crf,
             motion_blur: request_motion_blur(&query),
+            color_range: request_color_range(&query, app.color_range),
             start_seconds,
             cache_control: if cacheable {
                 "public, max-age=31536000, immutable"
@@ -1055,10 +1068,16 @@ fn handle_video_stream(
             ));
         }
     }
+    let range = setup.color_range.ffmpeg_token();
+    let color_vf = format!(
+        "scale=out_range={range}:out_color_matrix=bt709,format=yuv420p,\
+         setparams=range={range}:color_primaries=bt709:colorspace=bt709:color_trc=bt709"
+    );
+
     cmd.args(["-c:v", "libx264"])
         .args(["-preset", "ultrafast"])
         .args(["-tune", "zerolatency"])
-        // Convert the rendered full-range RGB to (limited-range) BT.709 YUV and
+        // Convert the rendered full-range RGB to BT.709 YUV and
         // TAG the stream with that exact matrix/range. Without this, swscale
         // converts with its BT.601/limited defaults and writes NO color metadata,
         // so the browser falls back to its own guess (BT.709 for 720p+) and
@@ -1066,19 +1085,16 @@ fn handle_video_stream(
         // colors versus the paused PNG (which shows the raw full-range RGB with no
         // conversion). `scale` does the conversion, `setparams` stamps all four
         // color fields onto the frames (so primaries/transfer are written too,
-        // without codec-specific params), and the `-color_*` options mirror them
-        // at the stream level. Limited range matches the offline export default
-        // (`FfmpegEncoder`'s `ColorRange::Limited`) so preview and export agree.
-        .args([
-            "-vf",
-            "scale=out_range=tv:out_color_matrix=bt709,format=yuv420p,\
-             setparams=range=tv:color_primaries=bt709:colorspace=bt709:color_trc=bt709",
-        ])
+        // without codec-specific params), and the `-color_*` options mirror the
+        // same range at stream level. Full range is the default because paused
+        // PNG/RGBA frames are full-range too; use `color_range=limited` only when
+        // a downstream target requires TV range.
+        .args(["-vf", &color_vf])
         .args(["-pix_fmt", "yuv420p"])
         .args(["-color_primaries", "bt709"])
         .args(["-color_trc", "bt709"])
         .args(["-colorspace", "bt709"])
-        .args(["-color_range", "tv"])
+        .args(["-color_range", range])
         .args(["-g", &setup.gop.to_string()])
         .args(["-keyint_min", &setup.gop.to_string()])
         .args(["-sc_threshold", "0"])
@@ -1575,6 +1591,14 @@ fn request_motion_blur(query: &HashMap<String, String>) -> bool {
     )
 }
 
+fn request_color_range(query: &HashMap<String, String>, default: ColorRange) -> ColorRange {
+    query
+        .get("color_range")
+        .or_else(|| query.get("colorRange"))
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
 fn request_resolution(query: &HashMap<String, String>, default: Resolution) -> Resolution {
     if let (Some(width), Some(height)) = (
         query
@@ -2015,6 +2039,38 @@ mod tests {
 
         query.insert("motion_blur".to_owned(), "true".to_owned());
         assert!(request_motion_blur(&query));
+    }
+
+    #[test]
+    fn request_color_range_defaults_to_server_value() {
+        assert_eq!(
+            request_color_range(&HashMap::new(), ColorRange::Limited),
+            ColorRange::Limited
+        );
+
+        let mut query = HashMap::new();
+        query.insert("color_range".to_owned(), "bogus".to_owned());
+        assert_eq!(
+            request_color_range(&query, ColorRange::Full),
+            ColorRange::Full
+        );
+    }
+
+    #[test]
+    fn request_color_range_accepts_query_aliases() {
+        let mut query = HashMap::new();
+        query.insert("color_range".to_owned(), "limited".to_owned());
+        assert_eq!(
+            request_color_range(&query, ColorRange::Full),
+            ColorRange::Limited
+        );
+
+        query.clear();
+        query.insert("colorRange".to_owned(), "pc".to_owned());
+        assert_eq!(
+            request_color_range(&query, ColorRange::Limited),
+            ColorRange::Full
+        );
     }
 
     #[test]

--- a/tellur-live/web/src/api.ts
+++ b/tellur-live/web/src/api.ts
@@ -35,6 +35,7 @@ export interface FrameRequestParams {
   fps: number;
   motionBlur: boolean;
   cacheKey: string;
+  videoColor?: boolean;
 }
 
 export function frameUrl(params: FrameRequestParams): string {
@@ -48,6 +49,9 @@ export function frameUrl(params: FrameRequestParams): string {
     format: "png",
     v: params.cacheKey,
   });
+  if (params.videoColor) {
+    query.set("video_color", "1");
+  }
   return `/api/frame?${query}`;
 }
 

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -353,6 +353,7 @@ export class TimelinePlayer {
 
   pause(): void {
     if (this.disposed) return;
+    const hadPendingReveal = this.pendingReveal != null;
     this.position = this.currentPlaybackSeconds();
     this.video.pause();
     this.stopTicker();
@@ -361,9 +362,21 @@ export class TimelinePlayer {
     this.pendingReveal = null;
     this.events.onPlaying?.(false);
     this.emitTime(this.position);
-    // The video is parked on the correct frame: hold it and swap to the still only once a
-    // fresh still for THIS time decodes, so pausing never flashes a stale frame.
-    this.setDisplayMode("still", this.position, "hold");
+    // During normal playback the video is already parked on the correct frame.
+    // Keep displaying that decoded frame instead of swapping to a PNG still:
+    // H.264/YUV and PNG/RGBA are not byte-identical, so switching surfaces on
+    // pause creates a subtle color jump. If pause lands while a reveal is still
+    // pending, the element may be showing an old frame; use the still fallback.
+    const videoFrameStep = 1 / Math.max(this.config.fps, 1);
+    const videoOnFrame =
+      !hadPendingReveal &&
+      this.video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA &&
+      Math.abs(this.video.currentTime - this.position) <= videoFrameStep * 2;
+    if (videoOnFrame) {
+      this.setDisplayMode("video", this.position);
+    } else {
+      this.setDisplayMode("still", this.position, "hold");
+    }
     // Let short priming pieces finish and persist, but stop a long playback stream
     // when the user pauses. Otherwise pausing near the start of a long timeline would keep
     // the server encoding far past the now-still playhead.

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -105,7 +105,10 @@ export type DisplayMode = "video" | "still";
 //               recognizable stale frame — then show the fresh still when it decodes.
 // - "trailing": mount. Show the still layer immediately and refine it once the first
 //               frame loads.
-export type StillCover = "hold" | "blank" | "trailing";
+// - "hold-video": keep the current surface up without fetching a PNG still. Used when
+//                 the next reveal should come from MP4/video decode too, avoiding a
+//                 PNG/RGBA -> H.264/YUV color jump on play.
+export type StillCover = "hold" | "hold-video" | "blank" | "trailing";
 
 export interface TimelinePlayerEvents {
   onTime?: (seconds: number) => void;
@@ -301,12 +304,13 @@ export class TimelinePlayer {
         this.pendingReveal = { target, fillGen: this.fillGen };
         void this.revealFromCache(target, this.fillGen);
       } else {
-        // Cold frame: keep the current display (trailing still or held video
-        // frame) up for drag continuity and swap in the fresh server still once
-        // it decodes. The prime fetch is debounced so a drag doesn't storm the
-        // server.
-        this.pendingReveal = null;
-        this.setDisplayMode("still", target, "hold");
+        // Cold frame: keep the current display up for drag continuity, but do
+        // not fetch a PNG still. Instead, prime a short MP4 segment and reveal
+        // the parked <video> frame once it lands. That keeps paused and playing
+        // frames on the same browser decode path, so there is no PNG/RGBA ->
+        // H.264/YUV color jump when playback starts.
+        this.pendingReveal = { target, fillGen: this.fillGen };
+        this.setDisplayMode("still", target, "hold-video");
       }
       this.scheduleDebouncedFill();
     }
@@ -339,9 +343,9 @@ export class TimelinePlayer {
     this.mode = "playing";
     this.events.onPlaying?.(true);
     this.pendingReveal = { target: this.position, fillGen: this.fillGen };
-    // The element is parked on the play frame: hold it (don't flash the previous still)
-    // and let revealAt swap straight to running video, usually before any still loads.
-    this.setDisplayMode("still", this.position, "hold");
+    // Keep the current surface up without fetching a PNG still; revealAt swaps
+    // straight to running video once enough MP4 is buffered.
+    this.setDisplayMode("still", this.position, "hold-video");
     this.tryResolveReveal();
     this.kickFill();
   }

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -15,11 +15,12 @@ const PLAY_AHEAD = 10;
 // Buffered history kept behind the playhead before eviction frees it. The persistent
 // green bar comes from IndexedDB, so evicting MSE never shrinks it.
 const KEEP_BEHIND = 6;
-// Max seconds streamed (and cached) per paused/priming /api/video.mp4 request. Active
-// playback uses a much larger cap so ordinary short previews stream as one request, while
-// long timelines still retain a bounded memory/cache footprint.
+// Max seconds streamed (and cached) per /api/video.mp4 request. Active playback
+// uses a modestly larger cap than priming: long chunks delay durable cache
+// commits and make slow first-pass renders expensive to abort/retry, while very
+// small chunks pay too much ffmpeg/audio setup overhead.
 const PRIME_STREAM_PIECE = 3;
-const PLAY_STREAM_PIECE = 30;
+const PLAY_STREAM_PIECE = 5;
 // Minimum length for a cached segment row to be worth re-appending from IndexedDB.
 // Shorter rows (shards from the old lookahead-clamped frontier) are streamed over in
 // full pieces instead — putSegment's subsume then deletes them, so a fragmented store

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -181,6 +181,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
         fps,
         motionBlur,
         cacheKey: pluginKey,
+        videoColor: true,
       });
       const token = ++stillTokenRef.current;
       cancelStillRequest();

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -57,7 +57,8 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
   const duration = timeline?.duration ?? 0;
   const width = Math.max(1, Math.round(resolution.width));
   const height = Math.max(1, Math.round(resolution.height));
-  const gop = Math.max(1, Math.floor(fps / 4));
+  // Keep preview fragments short so MSE can reveal/play cold segments quickly.
+  const gop = Math.max(1, Math.floor(fps / 10));
 
   const groupKey = useMemo(
     () =>

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -263,6 +263,12 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
               // video by firing its revealOnLoad after we switched to video.
               stillTokenRef.current++;
               cancelStillRequest();
+            } else if (cover === "hold-video") {
+              // Hold the current surface but do NOT fetch a PNG still. The
+              // TimelinePlayer is priming/revealing an MP4 frame for this time,
+              // and staying on the video decode path avoids the PNG<->MP4 color jump.
+              stillTokenRef.current++;
+              cancelStillRequest();
             } else if (cover === "hold") {
               // The current display (parked video frame or trailing still) is the best
               // stand-in (pause / end / play / paused scrub over cold frames): keep it

--- a/tellur-renderer/Cargo.toml
+++ b/tellur-renderer/Cargo.toml
@@ -27,6 +27,7 @@ console = "0.16.3"
 indicatif = "0.18.4"
 lru = "0.12"
 pollster = "0.3"
+rustc-hash = "1.1.0"
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 tellur-core = { path = "../tellur-core" }
 thiserror = "2.0.18"

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use lru::LruCache;
 use tellur_core::color::Color;
 use tellur_core::geometry::{Transform, Vec2};
 use tellur_core::raster::{CpuRasterImage, GpuSurface, PixelFormat, RasterImage, Resolution};
@@ -16,6 +17,7 @@ use wgpu::util::DeviceExt;
 
 const BACKEND: &str = "tellur-wgpu-buffer-v1";
 const WORKGROUP: u32 = 16;
+const CPU_UPLOAD_CACHE_ENTRIES: usize = 64;
 
 pub struct GpuRenderer {
     device: wgpu::Device,
@@ -37,6 +39,7 @@ pub struct GpuRenderer {
     // their size has to match (recreated when the resolution changes).
     vello_target: Option<(u32, u32, wgpu::Texture)>,
     readback_staging: Option<wgpu::Buffer>,
+    cpu_upload_cache: LruCache<CpuUploadCacheKey, Arc<GpuBufferImage>>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -66,6 +69,27 @@ struct GpuBufferImage {
     height: u32,
     format: PixelFormat,
     buffer: wgpu::Buffer,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct CpuUploadCacheKey {
+    width: u32,
+    height: u32,
+    format: PixelFormat,
+    ptr: usize,
+    len: usize,
+}
+
+impl CpuUploadCacheKey {
+    fn new(image: &CpuRasterImage) -> Self {
+        Self {
+            width: image.width,
+            height: image.height,
+            format: image.format,
+            ptr: image.pixels.as_ptr() as usize,
+            len: image.pixels.len(),
+        }
+    }
 }
 
 #[repr(C)]
@@ -237,6 +261,10 @@ impl GpuRenderer {
             stats: GpuRenderStats::default(),
             vello_target: None,
             readback_staging: None,
+            cpu_upload_cache: LruCache::new(
+                NonZeroUsize::new(CPU_UPLOAD_CACHE_ENTRIES)
+                    .expect("CPU upload cache capacity must be non-zero"),
+            ),
         })
     }
 
@@ -244,9 +272,13 @@ impl GpuRenderer {
         self.stats
     }
 
-    fn upload(&self, image: &CpuRasterImage) -> Option<Arc<GpuBufferImage>> {
+    fn upload(&mut self, image: &CpuRasterImage) -> Option<Arc<GpuBufferImage>> {
         if image.format != PixelFormat::Rgba8 {
             return None;
+        }
+        let key = CpuUploadCacheKey::new(image);
+        if let Some(cached) = self.cpu_upload_cache.get(&key) {
+            return Some(Arc::clone(cached));
         }
         let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("tellur-gpu-upload"),
@@ -257,15 +289,17 @@ impl GpuRenderer {
             mapped_at_creation: false,
         });
         self.queue.write_buffer(&buffer, 0, &image.pixels);
-        Some(Arc::new(GpuBufferImage {
+        let uploaded = Arc::new(GpuBufferImage {
             width: image.width,
             height: image.height,
             format: image.format,
             buffer,
-        }))
+        });
+        self.cpu_upload_cache.put(key, Arc::clone(&uploaded));
+        Some(uploaded)
     }
 
-    fn image_ref(&self, image: &RasterImage) -> Option<Arc<GpuBufferImage>> {
+    fn image_ref(&mut self, image: &RasterImage) -> Option<Arc<GpuBufferImage>> {
         match image {
             RasterImage::Cpu(image) => self.upload(image),
             RasterImage::Gpu(surface) if surface.backend() == BACKEND => {

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -68,6 +68,7 @@ struct GpuBufferImage {
     width: u32,
     height: u32,
     format: PixelFormat,
+    known_opaque: bool,
     buffer: wgpu::Buffer,
 }
 
@@ -293,6 +294,7 @@ impl GpuRenderer {
             width: image.width,
             height: image.height,
             format: image.format,
+            known_opaque: false,
             buffer,
         });
         self.cpu_upload_cache.put(key, Arc::clone(&uploaded));
@@ -331,6 +333,14 @@ impl GpuRenderer {
     /// transparency from zero-init; the full-overwrite `texture_to_buffer` copy
     /// never depended on the contents at all).
     fn empty_image(&self, resolution: Resolution) -> Arc<GpuBufferImage> {
+        self.empty_image_with_opacity(resolution, false)
+    }
+
+    fn empty_image_with_opacity(
+        &self,
+        resolution: Resolution,
+        known_opaque: bool,
+    ) -> Arc<GpuBufferImage> {
         let len = (resolution.width as usize) * (resolution.height as usize) * 4;
         let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("tellur-gpu-target"),
@@ -344,6 +354,7 @@ impl GpuRenderer {
             width: resolution.width,
             height: resolution.height,
             format: PixelFormat::Rgba8,
+            known_opaque,
             buffer,
         })
     }
@@ -362,6 +373,7 @@ impl GpuRenderer {
             width,
             height,
             format: PixelFormat::Rgba8,
+            known_opaque: false,
             buffer,
         }
     }
@@ -659,6 +671,7 @@ impl GpuRenderer {
             width: target.width,
             height: target.height,
             format: PixelFormat::Rgba8,
+            known_opaque: (packed >> 24) == 255,
             buffer,
         });
 
@@ -720,25 +733,47 @@ impl GpuRasterBackend for GpuRenderer {
         target: Resolution,
         inputs: &[CompositeInput<'_>],
     ) -> Option<RasterImage> {
-        let target_image = self.empty_image(target);
+        let mut sources = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            let src = self.image_ref(input.image)?;
+            if src.format != PixelFormat::Rgba8 {
+                return None;
+            }
+            sources.push((src, input.offset_x, input.offset_y));
+        }
+
+        let fills_target = |src: &GpuBufferImage, offset_x: i32, offset_y: i32| {
+            src.known_opaque
+                && offset_x == 0
+                && offset_y == 0
+                && src.width == target.width
+                && src.height == target.height
+        };
+        let first_fills_target = sources
+            .first()
+            .is_some_and(|(src, offset_x, offset_y)| fills_target(src, *offset_x, *offset_y));
+        let known_opaque = sources
+            .iter()
+            .any(|(src, offset_x, offset_y)| fills_target(src, *offset_x, *offset_y));
+
+        let target_image = self.empty_image_with_opacity(target, known_opaque);
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some("tellur-gpu-composite"),
             });
 
-        for input in inputs {
-            let src = self.image_ref(input.image)?;
-            if src.format != PixelFormat::Rgba8 {
-                return None;
-            }
-            self.composite_one(
-                &mut encoder,
-                &target_image,
-                &src,
-                input.offset_x,
-                input.offset_y,
-            );
+        let start = if first_fills_target {
+            let (src, _, _) = &sources[0];
+            let len = (target.width as u64) * (target.height as u64) * 4;
+            encoder.copy_buffer_to_buffer(&src.buffer, 0, &target_image.buffer, 0, len);
+            1
+        } else {
+            0
+        };
+
+        for (src, offset_x, offset_y) in sources.iter().skip(start) {
+            self.composite_one(&mut encoder, &target_image, src, *offset_x, *offset_y);
         }
 
         self.queue.submit(Some(encoder.finish()));
@@ -1792,6 +1827,51 @@ mod tests {
         let rendered = readback(&mut gpu, rendered);
 
         let mut expected = vec![0u8; 3 * 2 * 4];
+        let src = match src {
+            RasterImage::Cpu(src) => src,
+            RasterImage::Gpu(_) => unreachable!(),
+        };
+        composite_at(&mut expected, target, &src, 1, 1);
+        assert_eq!(rendered.pixels.as_ref(), expected.as_slice());
+    }
+
+    #[test]
+    #[ignore = "requires a GPU adapter"]
+    fn composite_matches_cpu_with_opaque_full_frame_base() {
+        let Some(mut gpu) = gpu_or_skip() else {
+            return;
+        };
+        let target = Resolution::new(3, 2);
+        let base = GpuRasterBackend::solid_fill(&mut gpu, target, Color::rgb_u8(10, 20, 30))
+            .expect("solid fill should use GPU");
+        let src = image(
+            2,
+            1,
+            &[
+                100, 0, 0, 128, //
+                0, 255, 0, 255,
+            ],
+        );
+        let inputs = [
+            CompositeInput {
+                image: &base,
+                offset_x: 0,
+                offset_y: 0,
+            },
+            CompositeInput {
+                image: &src,
+                offset_x: 1,
+                offset_y: 1,
+            },
+        ];
+
+        let rendered = GpuRasterBackend::composite(&mut gpu, target, &inputs).unwrap();
+        let rendered = readback(&mut gpu, rendered);
+
+        let mut expected = Vec::new();
+        for _ in 0..(target.width as usize * target.height as usize) {
+            expected.extend_from_slice(&[10, 20, 30, 255]);
+        }
         let src = match src {
             RasterImage::Cpu(src) => src,
             RasterImage::Gpu(_) => unreachable!(),

--- a/tellur-renderer/src/render_context.rs
+++ b/tellur-renderer/src/render_context.rs
@@ -13,15 +13,15 @@
 //! further compositing) hold the same buffer the cache holds.
 
 use std::any::TypeId;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::hash::Hasher;
 use std::time::{Duration, Instant};
 
 use lru::LruCache;
+use rustc_hash::FxHasher;
 use sysinfo::System;
-use tellur_core::dyn_compare::DynEq;
+use tellur_core::dyn_compare::{DynEq, DynHash};
 use tellur_core::geometry::Vec2;
 use tellur_core::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
 use tellur_core::render_context::{CachePolicy, GpuPreference, GpuRasterBackend, RenderContext};
@@ -71,15 +71,16 @@ struct CacheKey {
 }
 
 impl CacheKey {
-    fn of(c: &dyn RasterComponent, size: Vec2, target: Resolution) -> Self {
-        // `dyn RasterComponent` implements `Hash` by mixing the concrete
-        // `TypeId` with the component's own content hash; reuse that
-        // exact hash for the cache key's `content_hash` slot.
-        let mut hasher = DefaultHasher::new();
-        c.hash(&mut hasher);
+    fn of(c: &dyn RasterComponent, type_id: TypeId, size: Vec2, target: Resolution) -> Self {
+        // The cache key stores `type_id` separately, so only hash the
+        // component's own fields here. Cache keys are internal and not exposed
+        // to untrusted input, so a fast non-cryptographic hasher is appropriate
+        // for this hot path.
+        let mut hasher = FxHasher::default();
+        DynHash::dyn_hash(c, &mut hasher);
         let content_hash = hasher.finish();
         Self {
-            type_id: c.as_any().type_id(),
+            type_id,
             content_hash,
             size_x_bits: size.0.to_bits(),
             size_y_bits: size.1.to_bits(),
@@ -598,7 +599,7 @@ impl RenderContext for CachingRenderContext {
         // visible and the child's time is attributed to the child.
         let key = match component.cache_policy() {
             CachePolicy::Transparent => None,
-            CachePolicy::Memoize => Some(CacheKey::of(component, size, target)),
+            CachePolicy::Memoize => Some(CacheKey::of(component, type_id, size, target)),
         };
 
         // `counted` gates the hit/miss tally so transparent passes (which

--- a/tellur-renderer/src/render_context.rs
+++ b/tellur-renderer/src/render_context.rs
@@ -36,6 +36,28 @@ pub const DEFAULT_CAPACITY_BYTES: usize = 1024 * 1024 * 1024;
 /// admitting new entries and starts shedding existing ones.
 pub const MEMORY_PRESSURE_THRESHOLD: f32 = 0.90;
 
+const DEFAULT_PROBATION_ENTRIES: usize = 4096;
+const VOLATILE_LARGE_IMAGE_BYTES: usize = 1024 * 1024;
+const VOLATILE_MIN_MISSES: u64 = 8;
+const VOLATILE_MAX_HIT_RATE: f64 = 0.75;
+
+/// Controls when a freshly-rendered image becomes a cache entry.
+///
+/// `Immediate` is the export-oriented default: every miss is admitted while
+/// capacity allows. `SecondUse` admits only keys that appear at least twice.
+/// `SkipVolatileLarge` starts with immediate admission, but stops admitting
+/// large images for component types that build up many misses with a weak hit
+/// rate. That keeps live previews from filling the cache with per-frame
+/// full-screen animation states while still letting static large entries warm
+/// immediately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CacheAdmissionPolicy {
+    #[default]
+    Immediate,
+    SecondUse,
+    SkipVolatileLarge,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct CacheKey {
     type_id: TypeId,
@@ -127,6 +149,9 @@ pub struct CacheMetrics {
     /// Misses where the freshly-produced image was not admitted
     /// because a single image exceeded the configured cap.
     pub oversize_skips: u64,
+    /// Misses where the freshly-produced image was not admitted by the
+    /// configured admission policy.
+    pub admission_skips: u64,
     /// Current GPU policy for this context.
     pub gpu_preference: GpuPreference,
     /// Whether the context has tried to create a GPU backend.
@@ -161,7 +186,7 @@ impl fmt::Display for CacheMetrics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "Cache  {} hits / {} misses ({:.1}% hit) — {} cached, {} evicted, {} pressure skips, {} oversize skips",
+            "Cache  {} hits / {} misses ({:.1}% hit) — {} cached, {} evicted, {} pressure skips, {} oversize skips, {} admission skips",
             self.hits,
             self.misses,
             self.hit_rate() * 100.0,
@@ -169,6 +194,7 @@ impl fmt::Display for CacheMetrics {
             format_bytes(self.bytes_evicted),
             self.pressure_skips,
             self.oversize_skips,
+            self.admission_skips,
         )?;
         writeln!(
             f,
@@ -252,6 +278,7 @@ fn pixel_stride(format: PixelFormat) -> usize {
 /// frames so any time-invariant subtree only re-renders once.
 pub struct CachingRenderContext {
     cache: LruCache<CacheKey, RasterImage>,
+    probation: LruCache<CacheKey, ()>,
     cur_bytes: usize,
     cap_bytes: usize,
     system: System,
@@ -263,7 +290,9 @@ pub struct CachingRenderContext {
     bytes_evicted: u64,
     pressure_skips: u64,
     oversize_skips: u64,
+    admission_skips: u64,
     per_type: HashMap<TypeId, (TypeStats, &'static str)>,
+    admission_policy: CacheAdmissionPolicy,
     gpu_preference: GpuPreference,
     gpu: Option<GpuRenderer>,
     gpu_init_attempted: bool,
@@ -287,6 +316,7 @@ impl CachingRenderContext {
     pub fn with_capacity_bytes(cap_bytes: usize) -> Self {
         Self {
             cache: LruCache::unbounded(),
+            probation: LruCache::unbounded(),
             cur_bytes: 0,
             cap_bytes,
             system: System::new(),
@@ -295,7 +325,9 @@ impl CachingRenderContext {
             bytes_evicted: 0,
             pressure_skips: 0,
             oversize_skips: 0,
+            admission_skips: 0,
             per_type: HashMap::new(),
+            admission_policy: CacheAdmissionPolicy::Immediate,
             gpu_preference: GpuPreference::Auto,
             gpu: None,
             gpu_init_attempted: false,
@@ -308,6 +340,19 @@ impl CachingRenderContext {
     pub fn with_gpu_preference(mut self, gpu_preference: GpuPreference) -> Self {
         self.gpu_preference = gpu_preference;
         self
+    }
+
+    pub fn with_cache_admission_policy(mut self, policy: CacheAdmissionPolicy) -> Self {
+        self.admission_policy = policy;
+        self
+    }
+
+    pub fn with_second_use_admission(self) -> Self {
+        self.with_cache_admission_policy(CacheAdmissionPolicy::SecondUse)
+    }
+
+    pub fn with_volatile_large_admission(self) -> Self {
+        self.with_cache_admission_policy(CacheAdmissionPolicy::SkipVolatileLarge)
     }
 
     pub fn set_gpu_preference(&mut self, gpu_preference: GpuPreference) {
@@ -377,6 +422,7 @@ impl CachingRenderContext {
             bytes_evicted: self.bytes_evicted,
             pressure_skips: self.pressure_skips,
             oversize_skips: self.oversize_skips,
+            admission_skips: self.admission_skips,
             gpu_preference: self.gpu_preference,
             gpu_init_attempted: self.gpu_init_attempted,
             gpu_available: self.gpu.is_some(),
@@ -396,6 +442,7 @@ impl CachingRenderContext {
         self.bytes_evicted = 0;
         self.pressure_skips = 0;
         self.oversize_skips = 0;
+        self.admission_skips = 0;
         self.per_type.clear();
         self.total_render_time = Duration::ZERO;
     }
@@ -403,7 +450,45 @@ impl CachingRenderContext {
     /// Drop all cached entries.
     pub fn clear(&mut self) {
         self.cache.clear();
+        self.probation.clear();
         self.cur_bytes = 0;
+    }
+
+    fn should_admit(&mut self, key: CacheKey, type_id: TypeId, bytes: usize) -> bool {
+        match self.admission_policy {
+            CacheAdmissionPolicy::Immediate => true,
+            CacheAdmissionPolicy::SecondUse => {
+                if self.probation.pop(&key).is_some() {
+                    true
+                } else {
+                    self.probation.put(key, ());
+                    while self.probation.len() > DEFAULT_PROBATION_ENTRIES {
+                        let _ = self.probation.pop_lru();
+                    }
+                    self.admission_skips = self.admission_skips.saturating_add(1);
+                    false
+                }
+            }
+            CacheAdmissionPolicy::SkipVolatileLarge => {
+                if bytes < VOLATILE_LARGE_IMAGE_BYTES {
+                    return true;
+                }
+                let volatile = self
+                    .per_type
+                    .get(&type_id)
+                    .map(|(stats, _)| {
+                        stats.misses >= VOLATILE_MIN_MISSES
+                            && stats.hit_rate() <= VOLATILE_MAX_HIT_RATE
+                    })
+                    .unwrap_or(false);
+                if volatile {
+                    self.admission_skips = self.admission_skips.saturating_add(1);
+                    false
+                } else {
+                    true
+                }
+            }
+        }
     }
 
     /// Refresh and check system-wide memory utilization.
@@ -534,6 +619,7 @@ impl RenderContext for CachingRenderContext {
 
                     if bytes > self.cap_bytes {
                         self.oversize_skips += 1;
+                    } else if !self.should_admit(key, type_id, bytes) {
                     } else {
                         self.evict_to_fit(bytes);
                         if self.under_memory_pressure() {
@@ -577,15 +663,15 @@ impl RenderContext for CachingRenderContext {
 #[cfg(test)]
 mod tests {
     use tellur_core::color::Color;
-    use tellur_core::geometry::Vec2;
+    use tellur_core::geometry::{Constraints, Vec2};
     use tellur_core::layer::Layer;
     use tellur_core::placement::RasterPlacement;
-    use tellur_core::raster::{RasterComponent, Resolution};
+    use tellur_core::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
     use tellur_core::render_context::{CachePolicy, GpuPreference, PassThrough, RenderContext};
     use tellur_core::shapes::Rectangle;
     use tellur_core::vector::Paint;
 
-    use super::CachingRenderContext;
+    use super::{CachingRenderContext, VOLATILE_MIN_MISSES};
     use crate::rasterize::Rasterizable;
 
     fn scene() -> Layer {
@@ -642,5 +728,97 @@ mod tests {
 
         assert_eq!(a.pixels, first.pixels);
         assert_eq!(a.pixels, second.pixels);
+    }
+
+    #[derive(PartialEq, Hash)]
+    struct SolidRaster {
+        id: u8,
+    }
+
+    impl RasterComponent for SolidRaster {
+        fn layout(&self, constraints: Constraints) -> Vec2 {
+            constraints.constrain(Vec2(1.0, 1.0))
+        }
+
+        fn render(
+            &self,
+            _size: Vec2,
+            target: Resolution,
+            _ctx: &mut dyn RenderContext,
+        ) -> RasterImage {
+            let pixels = (target.width as usize) * (target.height as usize);
+            let mut buf = Vec::with_capacity(pixels * 4);
+            for _ in 0..pixels {
+                buf.extend_from_slice(&[self.id, 0, 0, 255]);
+            }
+            RasterImage::cpu(target.width, target.height, PixelFormat::Rgba8, buf)
+        }
+    }
+
+    #[test]
+    fn second_use_admission_skips_one_off_keys() {
+        let size = Vec2(1.0, 1.0);
+        let target = Resolution::new(1, 1);
+        let one = SolidRaster { id: 1 };
+        let two = SolidRaster { id: 2 };
+        let mut cache = CachingRenderContext::with_capacity_bytes(1024)
+            .with_gpu_preference(GpuPreference::Disabled)
+            .with_second_use_admission();
+
+        render_and_readback(&mut cache, &one, size, target);
+        render_and_readback(&mut cache, &two, size, target);
+        let metrics = cache.metrics();
+        assert_eq!(metrics.hits, 0);
+        assert_eq!(metrics.misses, 2);
+        assert_eq!(metrics.admission_skips, 2);
+        assert_eq!(metrics.bytes_cached, 0);
+
+        render_and_readback(&mut cache, &one, size, target);
+        let metrics = cache.metrics();
+        assert_eq!(metrics.hits, 0);
+        assert_eq!(metrics.misses, 3);
+        assert_eq!(metrics.admission_skips, 2);
+        assert!(metrics.bytes_cached > 0);
+
+        render_and_readback(&mut cache, &one, size, target);
+        let metrics = cache.metrics();
+        assert_eq!(metrics.hits, 1);
+        assert_eq!(metrics.misses, 3);
+        assert_eq!(metrics.admission_skips, 2);
+    }
+
+    #[test]
+    fn volatile_large_admission_skips_repeated_large_misses() {
+        let size = Vec2(1.0, 1.0);
+        let target = Resolution::new(512, 512);
+        let mut cache = CachingRenderContext::with_capacity_bytes(64 * 1024 * 1024)
+            .with_gpu_preference(GpuPreference::Disabled)
+            .with_volatile_large_admission();
+
+        for id in 0..VOLATILE_MIN_MISSES {
+            render_and_readback(&mut cache, &SolidRaster { id: id as u8 }, size, target);
+        }
+        let warmed = cache.metrics();
+        assert_eq!(warmed.hits, 0);
+        assert_eq!(warmed.misses, VOLATILE_MIN_MISSES);
+        assert_eq!(warmed.admission_skips, 0);
+        assert!(warmed.bytes_cached > 0);
+
+        render_and_readback(&mut cache, &SolidRaster { id: 99 }, size, target);
+        let skipped = cache.metrics();
+        assert_eq!(skipped.hits, 0);
+        assert_eq!(skipped.misses, VOLATILE_MIN_MISSES + 1);
+        assert_eq!(skipped.admission_skips, 1);
+        assert_eq!(skipped.bytes_cached, warmed.bytes_cached);
+    }
+
+    fn render_and_readback(
+        cache: &mut CachingRenderContext,
+        component: &dyn RasterComponent,
+        size: Vec2,
+        target: Resolution,
+    ) {
+        let image = cache.render(component, size, target);
+        let _ = cache.readback(image);
     }
 }

--- a/tellur-renderer/src/video.rs
+++ b/tellur-renderer/src/video.rs
@@ -26,9 +26,11 @@
 //! terminal width; separators and the total count are dimmed so the
 //! live numbers stand out. Disable via [`FfmpegEncoder::progress`].
 
+use std::fmt;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{ChildStdout, Command, Stdio};
+use std::str::FromStr;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -52,26 +54,54 @@ const AUDIO_CHANNELS: u16 = 2;
 /// when encoding. The conversion and the color tag are always derived from the
 /// SAME value, so they cannot disagree — a conversion/tag mismatch is exactly
 /// what shifts the decoded colors away from the rendered source.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ColorRange {
-    /// Limited / "TV" range (luma 16–235). The safe, widely-compatible default:
-    /// effectively every player and editor decodes it correctly.
-    #[default]
+    /// Limited / "TV" range (luma 16–235). Useful for broad external-player
+    /// compatibility when a downstream target expects studio-range video.
     Limited,
-    /// Full / "PC" range (luma 0–255). Reproduces the full-range rendered source
-    /// most precisely, but full-range `yuv420p` is mishandled by some external
-    /// players/editors, so it is opt-in.
+    /// Full / "PC" range (luma 0–255). The default because rendered frames and
+    /// PNG stills are full-range RGB, so this keeps MP4 preview/export colors
+    /// aligned with paused frames.
+    #[default]
     Full,
 }
 
 impl ColorRange {
+    /// A stable user-facing token for CLI, manifest, query, and headers.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ColorRange::Limited => "limited",
+            ColorRange::Full => "full",
+        }
+    }
+
     /// The ffmpeg range token used for both the `scale`/`setparams` filter and
     /// the `-color_range` output tag.
-    fn token(self) -> &'static str {
+    pub fn ffmpeg_token(self) -> &'static str {
         match self {
             ColorRange::Limited => "tv",
             ColorRange::Full => "pc",
         }
+    }
+}
+
+impl FromStr for ColorRange {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "limited" | "limited-range" | "tv" => Ok(ColorRange::Limited),
+            "full" | "full-range" | "pc" => Ok(ColorRange::Full),
+            other => Err(format!(
+                "invalid color range `{other}`; expected `full` or `limited`"
+            )),
+        }
+    }
+}
+
+impl fmt::Display for ColorRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -134,9 +164,9 @@ impl FfmpegEncoder {
 
     /// Selects the YUV range the rendered full-range RGB is converted to AND the
     /// color metadata the output is tagged with. Both are derived from this one
-    /// value, so they can never disagree. Defaults to [`ColorRange::Limited`];
-    /// pass [`ColorRange::Full`] to reproduce the rendered source most precisely
-    /// at the cost of broad external-player compatibility.
+    /// value, so they can never disagree. Defaults to [`ColorRange::Full`] so
+    /// MP4 output matches full-range rendered frames and PNG stills; pass
+    /// [`ColorRange::Limited`] when a downstream target requires TV range.
     pub fn color_range(mut self, range: ColorRange) -> Self {
         self.color_range = range;
         self
@@ -316,7 +346,7 @@ impl FfmpegEncoder {
         // conversion (`out_range`) and the tag (`-color_range`) come from the SAME
         // token, so they can't drift apart — a mismatch is what would otherwise
         // shift decoded colors away from the rendered source.
-        let range = self.color_range.token();
+        let range = self.color_range.ffmpeg_token();
         let color_vf = format!(
             "scale=out_range={range}:out_color_matrix=bt709,format=yuv420p,\
              setparams=range={range}:color_primaries=bt709:colorspace=bt709:color_trc=bt709"
@@ -893,38 +923,38 @@ mod av_mux_tests {
         let tl = Timeline::builder().child(Solid.at(0.0..0.2)).build();
         let resolved = resolve(tl).expect("solid timeline resolves");
 
-        // Default: limited-range BT.709, every field tagged.
-        let mut lim = std::env::temp_dir();
-        lim.push(format!("tellur_color_lim_{}.mp4", std::process::id()));
-        FfmpegEncoder::new(Resolution::new(64, 64), 24)
-            .progress(false)
-            .args(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
-            .encode_timeline(&resolved, &lim)
-            .expect("limited-range encode succeeds");
-        assert_eq!(
-            probe_color(&lim),
-            "tv|bt709|bt709|bt709",
-            "default output is tagged limited-range BT.709 on all four fields"
-        );
-
-        // Opt-in full range flips ONLY the range; the matrix/primaries/transfer
-        // stay BT.709.
+        // Default: full-range BT.709, every field tagged.
         let mut full = std::env::temp_dir();
         full.push(format!("tellur_color_full_{}.mp4", std::process::id()));
         FfmpegEncoder::new(Resolution::new(64, 64), 24)
             .progress(false)
-            .color_range(ColorRange::Full)
             .args(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
             .encode_timeline(&resolved, &full)
             .expect("full-range encode succeeds");
         assert_eq!(
             probe_color(&full),
             "pc|bt709|bt709|bt709",
-            "color_range(Full) tags full range, keeping the BT.709 matrix"
+            "default output is tagged full-range BT.709 on all four fields"
         );
 
-        let _ = std::fs::remove_file(&lim);
+        // Limited range flips ONLY the range; the matrix/primaries/transfer stay
+        // BT.709.
+        let mut lim = std::env::temp_dir();
+        lim.push(format!("tellur_color_lim_{}.mp4", std::process::id()));
+        FfmpegEncoder::new(Resolution::new(64, 64), 24)
+            .progress(false)
+            .color_range(ColorRange::Limited)
+            .args(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
+            .encode_timeline(&resolved, &lim)
+            .expect("limited-range encode succeeds");
+        assert_eq!(
+            probe_color(&lim),
+            "tv|bt709|bt709|bt709",
+            "color_range(Limited) tags limited range, keeping the BT.709 matrix"
+        );
+
         let _ = std::fs::remove_file(&full);
+        let _ = std::fs::remove_file(&lim);
     }
 
     // End-to-end A/V: a REAL decoded video background (`testsrc` mp4 via

--- a/tellur/src/bin/tellur.rs
+++ b/tellur/src/bin/tellur.rs
@@ -26,6 +26,7 @@ use clap::{Args, Parser, Subcommand};
 
 use tellur::core::raster::Resolution;
 use tellur::core::render_context::GpuPreference;
+use tellur::renderer::ColorRange;
 use tellur_live::{run_build_once, serve, AutoBuildOptions, ServerOptions};
 
 #[derive(Parser)]
@@ -76,6 +77,10 @@ struct LiveArgs {
     /// 30.
     #[arg(long)]
     fps: Option<u32>,
+    /// MP4 preview color range. Defaults to
+    /// `package.metadata.tellur.live.color_range`, then `full`.
+    #[arg(long, value_name = "full|limited")]
+    color_range: Option<ColorRange>,
     /// Prefer GPU rendering.
     #[arg(long, conflicts_with = "no_gpu")]
     gpu: bool,
@@ -140,6 +145,7 @@ fn live(args: LiveArgs) -> Result<(), Box<dyn Error>> {
     if fps == 0 {
         return Err("fps must be greater than zero".into());
     }
+    let color_range = args.color_range.unwrap_or(live_defaults.color_range);
 
     let lib_name = cdylib_target_name(package).ok_or_else(|| {
         format!(
@@ -188,6 +194,7 @@ fn live(args: LiveArgs) -> Result<(), Box<dyn Error>> {
         bind: format!("{}:{}", args.host, args.port),
         resolution,
         fps,
+        color_range,
         gpu_preference,
         verbose: args.verbose,
         auto_build,
@@ -418,11 +425,13 @@ fn parse_resolution(s: &str) -> Result<Resolution, Box<dyn Error>> {
 struct LiveDefaults {
     resolution: Resolution,
     fps: u32,
+    color_range: ColorRange,
 }
 
 const FALLBACK_LIVE_DEFAULTS: LiveDefaults = LiveDefaults {
     resolution: Resolution::new(1280, 720),
     fps: 30,
+    color_range: ColorRange::Full,
 };
 
 const LIVE_DEFAULTS_TABLE: &str = "package.metadata.tellur.live";
@@ -470,6 +479,14 @@ fn live_defaults_from_manifest(contents: &str) -> Result<LiveDefaults, Box<dyn E
             return Err(format!("{LIVE_DEFAULTS_TABLE}.fps must be a positive integer").into());
         }
         defaults.fps = fps as u32;
+    }
+    if let Some(value) = live.get("color_range").or_else(|| live.get("color-range")) {
+        let color_range = value
+            .as_str()
+            .ok_or_else(|| format!("{LIVE_DEFAULTS_TABLE}.color_range must be a string"))?;
+        defaults.color_range = color_range
+            .parse()
+            .map_err(|e: String| format!("invalid {LIVE_DEFAULTS_TABLE}.color_range: {e}"))?;
     }
 
     Ok(defaults)
@@ -644,7 +661,8 @@ fn project_manifest(name: &str, workspace_dependency: bool) -> String {
          # Optional defaults for `tellur live`:\n\
          # [package.metadata.tellur.live]\n\
          # size = \"1280x720\"\n\
-         # fps = 30\n"
+         # fps = 30\n\
+         # color_range = \"full\"\n"
     )
 }
 
@@ -1109,12 +1127,14 @@ mod tests {
              \n\
              [package.metadata.tellur.live]\n\
              size = \"1920x1080\"\n\
-             fps = 60\n",
+             fps = 60\n\
+             color_range = \"limited\"\n",
         )
         .unwrap();
 
         assert_eq!(defaults.resolution, Resolution::new(1920, 1080));
         assert_eq!(defaults.fps, 60);
+        assert_eq!(defaults.color_range, ColorRange::Limited);
     }
 
     #[test]
@@ -1152,6 +1172,23 @@ mod tests {
     }
 
     #[test]
+    fn live_defaults_reject_invalid_color_range() {
+        let error = live_defaults_from_manifest(
+            "[package]\n\
+             name = \"demo\"\n\
+             version = \"0.1.0\"\n\
+             \n\
+             [package.metadata.tellur.live]\n\
+             color_range = \"narrow\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("package.metadata.tellur.live.color_range"));
+        assert!(error.contains("expected `full` or `limited`"));
+    }
+
+    #[test]
     fn project_manifest_uses_workspace_dependency_for_workspace_member() {
         let manifest = project_manifest("demo", true);
 
@@ -1173,6 +1210,7 @@ mod tests {
         assert!(manifest.contains("[package.metadata.tellur.live]"));
         assert!(manifest.contains("size = \"1280x720\""));
         assert!(manifest.contains("fps = 30"));
+        assert!(manifest.contains("color_range = \"full\""));
     }
 
     #[test]


### PR DESCRIPTION
Improves `tellur live` preview/render performance for dynamic timelines by caching expensive audio, vector outline, composite, video segment, and GPU upload work, while keeping the live video/still preview color path consistent. 23 files (+2197 / -257) across `tellur-core`, `tellur-renderer`, `tellur-live`, and `tellur`.

## Render and audio caching
- Cache vector outline geometry, conformed audio windows, raster composite batches, immutable video segments, and resolved timeline windows.
- Skip off-window sequence work and volatile large cache entries, prune empty vector nodes, and speed up render cache keys.
- Preserve GPU frames through timeline sequences and avoid repeated CPU-to-GPU uploads for cached images.

## Live preview streaming
- Shorten active playback chunks and preview GOPs so live requests complete sooner.
- Prewarm preview audio/render caches after startup and cache immutable MP4 segments.
- Add stream/readback/cache diagnostics while skipping verbose-only stats on normal preview paths.

## Preview color consistency
- Default preview video to full-range BT.709 output and tag the MP4 color metadata accordingly.
- Keep the video surface visible while paused and reveal cold stills from the video path so paused and playing frames stay visually aligned.

## Verification
- `cargo fmt --all`
- `nix develop /home/aspulse/.codex/worktrees/53ca/tellur -c cargo test -p tellur-core`
- `nix develop /home/aspulse/.codex/worktrees/53ca/tellur -c cargo test -p tellur-live --lib`
- `nix develop /home/aspulse/.codex/worktrees/53ca/tellur -c cargo test -p tellur-renderer --lib`
- `nix develop /home/aspulse/.codex/worktrees/53ca/tellur -c cargo test -p tellur-renderer --lib gpu::tests::composite_matches_cpu_blend -- --ignored`
- `nix develop /home/aspulse/.codex/worktrees/53ca/tellur -c cargo test -p tellur-renderer --lib gpu::tests::composite_matches_cpu_with_opaque_full_frame_base -- --ignored`
- `env CARGO_TARGET_DIR=/tmp/tellur-perf-root.UVWTr9/target-local nix develop /home/aspulse/.codex/worktrees/53ca/tellur -c cargo build --release -p tellur-live`
- `curl -sS http://127.0.0.1:45219/api/info`
- `curl -sS -D /tmp/tellur-45219-latest-seg12.headers -o /tmp/tellur-45219-latest-seg12.mp4 -w 'seg12_time=%{time_total} size=%{size_download}\n' 'http://127.0.0.1:45219/api/video.mp4?timeline=main&time=12&duration=1&fps=30&width=720&height=1280&gop=3&colorRange=full&v=181f5982fed55a6b-abda60'`
