### PR TITLE
feat: add cache memory budgets

### DIFF
--- a/tellur-core/src/audio.rs
+++ b/tellur-core/src/audio.rs
@@ -33,6 +33,7 @@ use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 use symphonia::core::units::Time as SymphoniaTime;
 
+use crate::cache_budget::{cache_ram_capacity, try_reserve_cache_ram, BudgetReservation};
 use crate::timeline_component::AudioBuffer;
 
 const AUDIO_CACHE_CAPACITY_BYTES: usize = 512 * 1024 * 1024;
@@ -51,8 +52,13 @@ struct AudioCacheKey {
 }
 
 struct AudioDecodeCache {
-    entries: LruCache<AudioCacheKey, Arc<AudioBuffer>>,
+    entries: LruCache<AudioCacheKey, CachedAudioBuffer>,
     bytes: usize,
+}
+
+struct CachedAudioBuffer {
+    buffer: Arc<AudioBuffer>,
+    _reservation: BudgetReservation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -66,7 +72,7 @@ struct ConformedAudioCacheKey {
 }
 
 struct ConformedAudioCache {
-    entries: LruCache<ConformedAudioCacheKey, Arc<AudioBuffer>>,
+    entries: LruCache<ConformedAudioCacheKey, CachedAudioBuffer>,
     bytes: usize,
 }
 
@@ -81,24 +87,32 @@ impl Default for AudioDecodeCache {
 
 impl AudioDecodeCache {
     fn get(&mut self, key: &AudioCacheKey) -> Option<Arc<AudioBuffer>> {
-        self.entries.get(key).cloned()
+        self.entries.get(key).map(|entry| Arc::clone(&entry.buffer))
     }
 
     fn insert(&mut self, key: AudioCacheKey, buffer: Arc<AudioBuffer>) {
         let bytes = audio_buffer_bytes(&buffer);
-        if bytes > AUDIO_CACHE_CAPACITY_BYTES {
+        let capacity = cache_ram_capacity(AUDIO_CACHE_CAPACITY_BYTES);
+        if bytes > capacity {
             return;
         }
 
-        while self.bytes + bytes > AUDIO_CACHE_CAPACITY_BYTES {
+        while self.bytes + bytes > capacity {
             let Some((_, old)) = self.entries.pop_lru() else {
                 break;
             };
-            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old.buffer));
         }
 
-        if let Some(old) = self.entries.put(key, buffer) {
-            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+        let Some(reservation) = try_reserve_cache_ram(bytes) else {
+            return;
+        };
+        let entry = CachedAudioBuffer {
+            buffer,
+            _reservation: reservation,
+        };
+        if let Some(old) = self.entries.put(key, entry) {
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old.buffer));
         }
         self.bytes += bytes;
     }
@@ -115,24 +129,32 @@ impl Default for ConformedAudioCache {
 
 impl ConformedAudioCache {
     fn get(&mut self, key: &ConformedAudioCacheKey) -> Option<Arc<AudioBuffer>> {
-        self.entries.get(key).cloned()
+        self.entries.get(key).map(|entry| Arc::clone(&entry.buffer))
     }
 
     fn insert(&mut self, key: ConformedAudioCacheKey, buffer: Arc<AudioBuffer>) {
         let bytes = audio_buffer_bytes(&buffer);
-        if bytes > AUDIO_CACHE_CAPACITY_BYTES {
+        let capacity = cache_ram_capacity(AUDIO_CACHE_CAPACITY_BYTES);
+        if bytes > capacity {
             return;
         }
 
-        while self.bytes + bytes > AUDIO_CACHE_CAPACITY_BYTES {
+        while self.bytes + bytes > capacity {
             let Some((_, old)) = self.entries.pop_lru() else {
                 break;
             };
-            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old.buffer));
         }
 
-        if let Some(old) = self.entries.put(key, buffer) {
-            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old));
+        let Some(reservation) = try_reserve_cache_ram(bytes) else {
+            return;
+        };
+        let entry = CachedAudioBuffer {
+            buffer,
+            _reservation: reservation,
+        };
+        if let Some(old) = self.entries.put(key, entry) {
+            self.bytes = self.bytes.saturating_sub(audio_buffer_bytes(&old.buffer));
         }
         self.bytes += bytes;
     }

--- a/tellur-core/src/cache_budget.rs
+++ b/tellur-core/src/cache_budget.rs
@@ -1,0 +1,162 @@
+//! Process-wide cache and GPU memory budgets.
+//!
+//! `TELLUR_CACHE_RAM` limits bytes held by Tellur-managed CPU-side caches.
+//! `TELLUR_VRAM` is a best-effort budget for GPU buffers/textures allocated by
+//! Tellur's wgpu backend. Driver-internal allocations are not directly visible,
+//! so VRAM accounting intentionally tracks the large allocations we create.
+
+use std::env;
+use std::sync::{LazyLock, Mutex};
+
+pub const DEFAULT_CACHE_RAM_BYTES: usize = 1024 * 1024 * 1024;
+pub const DEFAULT_VRAM_BYTES: usize = 1024 * 1024 * 1024;
+
+const TELLUR_CACHE_RAM: &str = "TELLUR_CACHE_RAM";
+const TELLUR_VRAM: &str = "TELLUR_VRAM";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetResource {
+    CacheRam,
+    Vram,
+}
+
+#[derive(Debug)]
+pub struct BudgetReservation {
+    resource: BudgetResource,
+    bytes: usize,
+}
+
+impl BudgetReservation {
+    pub fn bytes(&self) -> usize {
+        self.bytes
+    }
+}
+
+impl Drop for BudgetReservation {
+    fn drop(&mut self) {
+        release(self.resource, self.bytes);
+    }
+}
+
+#[derive(Debug, Default)]
+struct BudgetUse {
+    cache_ram: usize,
+    vram: usize,
+}
+
+static BUDGET_USE: LazyLock<Mutex<BudgetUse>> = LazyLock::new(|| Mutex::new(BudgetUse::default()));
+
+pub fn configured_cache_ram_bytes() -> usize {
+    env_byte_size(TELLUR_CACHE_RAM).unwrap_or(DEFAULT_CACHE_RAM_BYTES)
+}
+
+pub fn configured_vram_bytes() -> usize {
+    env_byte_size(TELLUR_VRAM).unwrap_or(DEFAULT_VRAM_BYTES)
+}
+
+/// Per-cache local capacity: when the user sets `TELLUR_CACHE_RAM`, local cache
+/// caps should not exceed it; otherwise they keep their historical defaults.
+pub fn cache_ram_capacity(default: usize) -> usize {
+    env_byte_size(TELLUR_CACHE_RAM).unwrap_or(default)
+}
+
+pub fn try_reserve_cache_ram(bytes: usize) -> Option<BudgetReservation> {
+    try_reserve(
+        BudgetResource::CacheRam,
+        bytes,
+        configured_cache_ram_bytes(),
+    )
+}
+
+pub fn try_reserve_vram(bytes: usize) -> Option<BudgetReservation> {
+    try_reserve(BudgetResource::Vram, bytes, configured_vram_bytes())
+}
+
+pub fn cache_ram_used_bytes() -> usize {
+    BUDGET_USE.lock().map(|usage| usage.cache_ram).unwrap_or(0)
+}
+
+pub fn vram_used_bytes() -> usize {
+    BUDGET_USE.lock().map(|usage| usage.vram).unwrap_or(0)
+}
+
+fn try_reserve(resource: BudgetResource, bytes: usize, limit: usize) -> Option<BudgetReservation> {
+    if bytes > limit {
+        return None;
+    }
+    let mut usage = BUDGET_USE.lock().ok()?;
+    let used = match resource {
+        BudgetResource::CacheRam => &mut usage.cache_ram,
+        BudgetResource::Vram => &mut usage.vram,
+    };
+    if used.saturating_add(bytes) > limit {
+        return None;
+    }
+    *used += bytes;
+    Some(BudgetReservation { resource, bytes })
+}
+
+fn release(resource: BudgetResource, bytes: usize) {
+    if bytes == 0 {
+        return;
+    }
+    if let Ok(mut usage) = BUDGET_USE.lock() {
+        let used = match resource {
+            BudgetResource::CacheRam => &mut usage.cache_ram,
+            BudgetResource::Vram => &mut usage.vram,
+        };
+        *used = used.saturating_sub(bytes);
+    }
+}
+
+fn env_byte_size(name: &str) -> Option<usize> {
+    match env::var(name) {
+        Ok(value) => match parse_byte_size(&value) {
+            Some(bytes) => Some(bytes),
+            None => {
+                eprintln!("ignoring invalid {name}={value:?}; expected bytes or k/m/g suffix");
+                None
+            }
+        },
+        Err(_) => None,
+    }
+}
+
+fn parse_byte_size(raw: &str) -> Option<usize> {
+    let value = raw.trim().to_ascii_lowercase();
+    if value.is_empty() || value == "auto" {
+        return None;
+    }
+    let split = value
+        .find(|c: char| !c.is_ascii_digit() && c != '_')
+        .unwrap_or(value.len());
+    let number = value[..split].replace('_', "");
+    if number.is_empty() {
+        return None;
+    }
+    let base: usize = number.parse().ok()?;
+    let suffix = value[split..].trim();
+    let scale = match suffix {
+        "" | "b" => 1usize,
+        "k" | "kb" | "kib" => 1024usize,
+        "m" | "mb" | "mib" => 1024usize.pow(2),
+        "g" | "gb" | "gib" => 1024usize.pow(3),
+        _ => return None,
+    };
+    base.checked_mul(scale)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_byte_size;
+
+    #[test]
+    fn parses_byte_sizes() {
+        assert_eq!(parse_byte_size("512"), Some(512));
+        assert_eq!(parse_byte_size("1k"), Some(1024));
+        assert_eq!(parse_byte_size("2MiB"), Some(2 * 1024 * 1024));
+        assert_eq!(parse_byte_size("3_gb"), Some(3 * 1024 * 1024 * 1024));
+        assert_eq!(parse_byte_size("auto"), None);
+        assert_eq!(parse_byte_size("nope"), None);
+    }
+}

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audio;
 pub mod builder;
+pub mod cache_budget;
 pub mod color;
 pub mod composite;
 pub mod dyn_compare;

--- a/tellur-live/README.md
+++ b/tellur-live/README.md
@@ -49,6 +49,16 @@ Open `http://127.0.0.1:4317/` for the minimal browser client.
 Use `--host 0.0.0.0` when the preview server should be reachable from other
 devices on the network.
 Pass `--verbose` to print per-frame timing and cache statistics to stdout.
+Set `TELLUR_CACHE_RAM` to cap Tellur-managed RAM caches (render images, audio
+decode/conform buffers, and server-side MP4 segment reuse). Set `TELLUR_VRAM` to
+cap large GPU backend allocations, including cached uploads, render targets,
+readback staging, and scratch buffers. Both accept byte counts with optional
+`k`, `m`, or `g` suffixes, for example `TELLUR_CACHE_RAM=1g TELLUR_VRAM=2g`.
+When unset, both default to 1 GiB. `TELLUR_VRAM` is the total Tellur-managed GPU
+allocation budget; GPU raster/upload caches keep separate internal byte caps
+inside that total. If render-critical GPU allocation fails, those cache caps are
+shrunk and LRU cache entries are evicted for subsequent frames. When VRAM stays
+spare across many successful allocations, the caps grow gradually again.
 
 Passing `-p <package> --example <example>` makes `tellur-live` infer the release
 cdylib path (`target/release/examples/lib<example>.so`) and run

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -13,6 +13,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use lru::LruCache;
+use tellur_core::cache_budget::{cache_ram_capacity, try_reserve_cache_ram, BudgetReservation};
 use tellur_core::raster::{CpuRasterImage, PixelFormat, Resolution};
 use tellur_core::render_context::{GpuPreference, RenderContext};
 use tellur_core::time::TimelineTime;
@@ -53,8 +54,13 @@ struct VideoSegmentCacheKey {
 }
 
 struct VideoSegmentCache {
-    entries: LruCache<VideoSegmentCacheKey, Arc<Vec<u8>>>,
+    entries: LruCache<VideoSegmentCacheKey, CachedVideoSegment>,
     bytes: usize,
+}
+
+struct CachedVideoSegment {
+    body: Arc<Vec<u8>>,
+    _reservation: BudgetReservation,
 }
 
 impl Default for VideoSegmentCache {
@@ -68,24 +74,30 @@ impl Default for VideoSegmentCache {
 
 impl VideoSegmentCache {
     fn get(&mut self, key: &VideoSegmentCacheKey) -> Option<Arc<Vec<u8>>> {
-        self.entries.get(key).cloned()
+        self.entries.get(key).map(|entry| Arc::clone(&entry.body))
     }
 
     fn insert(&mut self, key: VideoSegmentCacheKey, body: Vec<u8>) {
         let bytes = body.len();
-        if bytes > VIDEO_SEGMENT_CACHE_BYTES {
+        let capacity = cache_ram_capacity(VIDEO_SEGMENT_CACHE_BYTES);
+        if bytes > capacity {
             return;
         }
-        while self.bytes + bytes > VIDEO_SEGMENT_CACHE_BYTES
-            || self.entries.len() >= VIDEO_SEGMENT_CACHE_ENTRIES
-        {
+        while self.bytes + bytes > capacity || self.entries.len() >= VIDEO_SEGMENT_CACHE_ENTRIES {
             let Some((_, old)) = self.entries.pop_lru() else {
                 break;
             };
-            self.bytes = self.bytes.saturating_sub(old.len());
+            self.bytes = self.bytes.saturating_sub(old.body.len());
         }
-        if let Some(old) = self.entries.put(key, Arc::new(body)) {
-            self.bytes = self.bytes.saturating_sub(old.len());
+        let Some(reservation) = try_reserve_cache_ram(bytes) else {
+            return;
+        };
+        let entry = CachedVideoSegment {
+            body: Arc::new(body),
+            _reservation: reservation,
+        };
+        if let Some(old) = self.entries.put(key, entry) {
+            self.bytes = self.bytes.saturating_sub(old.body.len());
         }
         self.bytes += bytes;
     }
@@ -1572,7 +1584,7 @@ fn log_cache_metrics_delta(before: &CacheMetrics, after: &CacheMetrics) {
     let gpu_before = &before.gpu;
     let gpu_after = &after.gpu;
     println!(
-        "video-stream-cache-delta hits={} misses={} hit_rate={:.1}% cache_size={} evicted_delta={} pressure_skips_delta={} oversize_skips_delta={} admission_skips_delta={} gpu_ops={} gpu_composites={} gpu_shadows={} gpu_outlines={} gpu_rasterizes={} gpu_fills={} gpu_temporal_avg={} gpu_readbacks={}",
+        "video-stream-cache-delta hits={} misses={} hit_rate={:.1}% cache_size={} evicted_delta={} pressure_skips_delta={} oversize_skips_delta={} admission_skips_delta={} budget_skips_delta={} gpu_ops={} gpu_composites={} gpu_shadows={} gpu_outlines={} gpu_rasterizes={} gpu_fills={} gpu_temporal_avg={} gpu_readbacks={}",
         hits,
         misses,
         hit_rate * 100.0,
@@ -1581,6 +1593,7 @@ fn log_cache_metrics_delta(before: &CacheMetrics, after: &CacheMetrics) {
         after.pressure_skips.saturating_sub(before.pressure_skips),
         after.oversize_skips.saturating_sub(before.oversize_skips),
         after.admission_skips.saturating_sub(before.admission_skips),
+        after.budget_skips.saturating_sub(before.budget_skips),
         gpu_after.total_ops().saturating_sub(gpu_before.total_ops()),
         gpu_after.composites.saturating_sub(gpu_before.composites),
         gpu_after.drop_shadows.saturating_sub(gpu_before.drop_shadows),

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -3,6 +3,9 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use lru::LruCache;
+use tellur_core::cache_budget::{
+    configured_vram_bytes, try_reserve_vram, vram_used_bytes, BudgetReservation,
+};
 use tellur_core::color::Color;
 use tellur_core::geometry::{Transform, Vec2};
 use tellur_core::raster::{CpuRasterImage, GpuSurface, PixelFormat, RasterImage, Resolution};
@@ -18,6 +21,13 @@ use wgpu::util::DeviceExt;
 const BACKEND: &str = "tellur-wgpu-buffer-v1";
 const WORKGROUP: u32 = 16;
 const CPU_UPLOAD_CACHE_ENTRIES: usize = 64;
+const CPU_UPLOAD_CACHE_INITIAL_FRACTION_DIVISOR: usize = 8;
+const CPU_UPLOAD_CACHE_MAX_FRACTION_DIVISOR: usize = 4;
+const GPU_CACHE_SHRINK_NUMERATOR: usize = 3;
+const GPU_CACHE_SHRINK_DENOMINATOR: usize = 4;
+const GPU_CACHE_GROW_SUCCESS_STREAK: u8 = 64;
+const GPU_CACHE_GROW_FRACTION_DIVISOR: usize = 64;
+const MIB: usize = 1024 * 1024;
 
 pub struct GpuRenderer {
     device: wgpu::Device,
@@ -37,9 +47,13 @@ pub struct GpuRenderer {
     // call: the vello render-target texture and the readback staging buffer.
     // Both are fully overwritten on every use, so reuse is byte-identical; only
     // their size has to match (recreated when the resolution changes).
-    vello_target: Option<(u32, u32, wgpu::Texture)>,
-    readback_staging: Option<wgpu::Buffer>,
+    vello_target: Option<(u32, u32, wgpu::Texture, BudgetReservation)>,
+    readback_staging: Option<(wgpu::Buffer, BudgetReservation)>,
     cpu_upload_cache: LruCache<CpuUploadCacheKey, Arc<GpuBufferImage>>,
+    cpu_upload_cache_bytes: usize,
+    cpu_upload_cache_cap_bytes: usize,
+    cpu_upload_cache_max_bytes: usize,
+    vram_spare_successes: u8,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -51,6 +65,8 @@ pub struct GpuRenderStats {
     pub fills: u64,
     pub temporal_averages: u64,
     pub readbacks: u64,
+    pub vram_reserve_failures: u64,
+    pub vram_cache_evictions: u64,
 }
 
 impl GpuRenderStats {
@@ -70,6 +86,7 @@ struct GpuBufferImage {
     format: PixelFormat,
     known_opaque: bool,
     buffer: wgpu::Buffer,
+    _reservation: BudgetReservation,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -90,6 +107,20 @@ impl CpuUploadCacheKey {
             ptr: image.pixels.as_ptr() as usize,
             len: image.pixels.len(),
         }
+    }
+}
+
+fn upload_cache_limits() -> (usize, usize) {
+    let limit = configured_vram_bytes();
+    let max = limit / CPU_UPLOAD_CACHE_MAX_FRACTION_DIVISOR;
+    let cap = (limit / CPU_UPLOAD_CACHE_INITIAL_FRACTION_DIVISOR).min(max);
+    (cap, max)
+}
+
+fn pixel_stride(format: PixelFormat) -> usize {
+    match format {
+        PixelFormat::Rgba8 => 4,
+        PixelFormat::Rgba16Float => 8,
     }
 }
 
@@ -221,6 +252,7 @@ impl GpuRenderer {
             )
             .await
             .map_err(|e| format!("failed to create GPU device: {e}"))?;
+        let (cpu_upload_cache_cap_bytes, cpu_upload_cache_max_bytes) = upload_cache_limits();
 
         Ok(Self {
             composite_pipeline: compute_pipeline(
@@ -266,11 +298,105 @@ impl GpuRenderer {
                 NonZeroUsize::new(CPU_UPLOAD_CACHE_ENTRIES)
                     .expect("CPU upload cache capacity must be non-zero"),
             ),
+            cpu_upload_cache_bytes: 0,
+            cpu_upload_cache_cap_bytes,
+            cpu_upload_cache_max_bytes,
+            vram_spare_successes: 0,
         })
     }
 
     pub fn stats(&self) -> GpuRenderStats {
         self.stats
+    }
+
+    fn reserve_render_vram(&mut self, bytes: usize) -> Option<BudgetReservation> {
+        if let Some(reservation) = try_reserve_vram(bytes) {
+            self.note_vram_reserve_success();
+            return Some(reservation);
+        }
+
+        self.stats.vram_reserve_failures = self.stats.vram_reserve_failures.saturating_add(1);
+        self.shrink_upload_cache_budget();
+        if let Some(reservation) = try_reserve_vram(bytes) {
+            self.note_vram_reserve_success();
+            return Some(reservation);
+        }
+
+        self.cpu_upload_cache_cap_bytes = 0;
+        self.evict_upload_cache_to_fit(0);
+        let reservation = try_reserve_vram(bytes)?;
+        self.note_vram_reserve_success();
+        Some(reservation)
+    }
+
+    fn note_vram_reserve_success(&mut self) {
+        let limit = configured_vram_bytes();
+        let used = vram_used_bytes();
+        if self.cpu_upload_cache_cap_bytes >= self.cpu_upload_cache_max_bytes
+            || used.saturating_mul(4) >= limit.saturating_mul(3)
+        {
+            self.vram_spare_successes = 0;
+            return;
+        }
+
+        self.vram_spare_successes = self.vram_spare_successes.saturating_add(1);
+        if self.vram_spare_successes >= GPU_CACHE_GROW_SUCCESS_STREAK {
+            let step = (limit / GPU_CACHE_GROW_FRACTION_DIVISOR).max(MIB);
+            self.cpu_upload_cache_cap_bytes = self
+                .cpu_upload_cache_cap_bytes
+                .saturating_add(step)
+                .min(self.cpu_upload_cache_max_bytes);
+            self.vram_spare_successes = 0;
+        }
+    }
+
+    fn shrink_upload_cache_budget(&mut self) {
+        self.vram_spare_successes = 0;
+        let old = self.cpu_upload_cache_cap_bytes;
+        self.cpu_upload_cache_cap_bytes =
+            old.saturating_mul(GPU_CACHE_SHRINK_NUMERATOR) / GPU_CACHE_SHRINK_DENOMINATOR;
+        if old > 0 && self.cpu_upload_cache_cap_bytes == old {
+            self.cpu_upload_cache_cap_bytes = old - 1;
+        }
+        self.evict_upload_cache_to_fit(0);
+    }
+
+    fn evict_upload_cache_to_fit(&mut self, needed: usize) {
+        while self.cpu_upload_cache_bytes.saturating_add(needed) > self.cpu_upload_cache_cap_bytes {
+            match self.cpu_upload_cache.pop_lru() {
+                Some((_, image)) => {
+                    self.cpu_upload_cache_bytes = self
+                        .cpu_upload_cache_bytes
+                        .saturating_sub(Self::buffer_image_bytes(&image));
+                    self.stats.vram_cache_evictions =
+                        self.stats.vram_cache_evictions.saturating_add(1);
+                }
+                None => break,
+            }
+        }
+    }
+
+    fn insert_upload_cache(&mut self, key: CpuUploadCacheKey, image: Arc<GpuBufferImage>) {
+        let bytes = Self::buffer_image_bytes(&image);
+        if bytes > self.cpu_upload_cache_cap_bytes {
+            return;
+        }
+        self.evict_upload_cache_to_fit(bytes);
+        if self.cpu_upload_cache_bytes.saturating_add(bytes) > self.cpu_upload_cache_cap_bytes {
+            return;
+        }
+        if let Some(old) = self.cpu_upload_cache.put(key, image) {
+            self.cpu_upload_cache_bytes = self
+                .cpu_upload_cache_bytes
+                .saturating_sub(Self::buffer_image_bytes(&old));
+        }
+        self.cpu_upload_cache_bytes = self.cpu_upload_cache_bytes.saturating_add(bytes);
+    }
+
+    fn buffer_image_bytes(image: &GpuBufferImage) -> usize {
+        (image.width as usize)
+            .saturating_mul(image.height as usize)
+            .saturating_mul(pixel_stride(image.format))
     }
 
     fn upload(&mut self, image: &CpuRasterImage) -> Option<Arc<GpuBufferImage>> {
@@ -281,6 +407,7 @@ impl GpuRenderer {
         if let Some(cached) = self.cpu_upload_cache.get(&key) {
             return Some(Arc::clone(cached));
         }
+        let reservation = self.reserve_render_vram(image.pixels.len())?;
         let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("tellur-gpu-upload"),
             size: image.pixels.len() as u64,
@@ -296,8 +423,9 @@ impl GpuRenderer {
             format: image.format,
             known_opaque: false,
             buffer,
+            _reservation: reservation,
         });
-        self.cpu_upload_cache.put(key, Arc::clone(&uploaded));
+        self.insert_upload_cache(key, Arc::clone(&uploaded));
         Some(uploaded)
     }
 
@@ -332,16 +460,17 @@ impl GpuRenderer {
     /// the GPU render path, and it was entirely redundant (the blend paths get
     /// transparency from zero-init; the full-overwrite `texture_to_buffer` copy
     /// never depended on the contents at all).
-    fn empty_image(&self, resolution: Resolution) -> Arc<GpuBufferImage> {
+    fn empty_image(&mut self, resolution: Resolution) -> Option<Arc<GpuBufferImage>> {
         self.empty_image_with_opacity(resolution, false)
     }
 
     fn empty_image_with_opacity(
-        &self,
+        &mut self,
         resolution: Resolution,
         known_opaque: bool,
-    ) -> Arc<GpuBufferImage> {
+    ) -> Option<Arc<GpuBufferImage>> {
         let len = (resolution.width as usize) * (resolution.height as usize) * 4;
+        let reservation = self.reserve_render_vram(len)?;
         let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("tellur-gpu-target"),
             size: len as u64,
@@ -350,17 +479,19 @@ impl GpuRenderer {
                 | wgpu::BufferUsages::COPY_SRC,
             mapped_at_creation: false,
         });
-        Arc::new(GpuBufferImage {
+        Some(Arc::new(GpuBufferImage {
             width: resolution.width,
             height: resolution.height,
             format: PixelFormat::Rgba8,
             known_opaque,
             buffer,
-        })
+            _reservation: reservation,
+        }))
     }
 
-    fn alpha_image(&self, width: u32, height: u32) -> GpuBufferImage {
+    fn alpha_image(&mut self, width: u32, height: u32) -> Option<GpuBufferImage> {
         let len = (width as usize) * (height as usize) * 4;
+        let reservation = self.reserve_render_vram(len)?;
         let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("tellur-gpu-alpha"),
             size: len as u64,
@@ -369,13 +500,14 @@ impl GpuRenderer {
                 | wgpu::BufferUsages::COPY_SRC,
             mapped_at_creation: false,
         });
-        GpuBufferImage {
+        Some(GpuBufferImage {
             width,
             height,
             format: PixelFormat::Rgba8,
             known_opaque: false,
             buffer,
-        }
+            _reservation: reservation,
+        })
     }
 
     fn composite_one(
@@ -551,9 +683,11 @@ impl GpuRenderer {
         // Reuse a persisted vello render target; the resolution is stable across
         // frames, so the texture is allocated once. vello overwrites the whole
         // target each call (base_color TRANSPARENT), so reuse is byte-identical.
-        if self.vello_target.as_ref().map(|(w, h, _)| (*w, *h))
+        if self.vello_target.as_ref().map(|(w, h, _, _)| (*w, *h))
             != Some((target.width, target.height))
         {
+            let texture_bytes = (target.width as usize) * (target.height as usize) * 4;
+            let reservation = self.reserve_render_vram(texture_bytes)?;
             let texture = self.device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("tellur-vello-target"),
                 size: wgpu::Extent3d {
@@ -568,7 +702,7 @@ impl GpuRenderer {
                 usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             });
-            self.vello_target = Some((target.width, target.height, texture));
+            self.vello_target = Some((target.width, target.height, texture, reservation));
         }
         let view = self
             .vello_target
@@ -594,7 +728,7 @@ impl GpuRenderer {
             )
             .ok()?;
 
-        let target_image = self.empty_image(target);
+        let target_image = self.empty_image(target)?;
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -657,8 +791,9 @@ impl GpuRenderer {
         );
     }
 
-    fn filled_image(&self, target: Resolution, packed: u32) -> Arc<GpuBufferImage> {
+    fn filled_image(&mut self, target: Resolution, packed: u32) -> Option<Arc<GpuBufferImage>> {
         let len = (target.width as usize) * (target.height as usize) * 4;
+        let reservation = self.reserve_render_vram(len)?;
         let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("tellur-gpu-fill"),
             size: len as u64,
@@ -673,6 +808,7 @@ impl GpuRenderer {
             format: PixelFormat::Rgba8,
             known_opaque: (packed >> 24) == 255,
             buffer,
+            _reservation: reservation,
         });
 
         let params = FillParams {
@@ -723,7 +859,7 @@ impl GpuRenderer {
             );
         }
         self.queue.submit(Some(encoder.finish()));
-        image
+        Some(image)
     }
 }
 
@@ -756,7 +892,7 @@ impl GpuRasterBackend for GpuRenderer {
             .iter()
             .any(|(src, offset_x, offset_y)| fills_target(src, *offset_x, *offset_y));
 
-        let target_image = self.empty_image_with_opacity(target, known_opaque);
+        let target_image = self.empty_image_with_opacity(target, known_opaque)?;
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -789,9 +925,9 @@ impl GpuRasterBackend for GpuRenderer {
         let pad = input.blur_radius.saturating_mul(3);
         let shadow_w = child.width.checked_add(pad.checked_mul(2)?)?;
         let shadow_h = child.height.checked_add(pad.checked_mul(2)?)?;
-        let alpha_a = self.alpha_image(shadow_w, shadow_h);
-        let alpha_b = self.alpha_image(shadow_w, shadow_h);
-        let target = self.empty_image(input.target);
+        let alpha_a = self.alpha_image(shadow_w, shadow_h)?;
+        let alpha_b = self.alpha_image(shadow_w, shadow_h)?;
+        let target = self.empty_image(input.target)?;
 
         let mut encoder = self
             .device
@@ -826,8 +962,8 @@ impl GpuRasterBackend for GpuRenderer {
         if child.format != PixelFormat::Rgba8 {
             return None;
         }
-        let alpha = self.alpha_image(input.target.width, input.target.height);
-        let target = self.empty_image(input.target);
+        let alpha = self.alpha_image(input.target.width, input.target.height)?;
+        let target = self.empty_image(input.target)?;
 
         let mut encoder = self
             .device
@@ -871,7 +1007,7 @@ impl GpuRasterBackend for GpuRenderer {
     fn solid_fill(&mut self, target: Resolution, color: Color) -> Option<RasterImage> {
         let [r, g, b, a] = color_u8(color);
         let packed = r | (g << 8) | (b << 16) | (a << 24);
-        let image = self.filled_image(target, packed);
+        let image = self.filled_image(target, packed)?;
         self.stats.fills = self.stats.fills.saturating_add(1);
         Some(self.raster_image(image))
     }
@@ -903,13 +1039,14 @@ impl GpuRasterBackend for GpuRenderer {
         // buffer is zero-initialized, so accumulation starts from zero
         // without an explicit clear pass.
         let acc_len = (target.width as u64) * (target.height as u64) * 16;
+        let _acc_reservation = self.reserve_render_vram(acc_len as usize)?;
         let acc = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("tellur-gpu-motion-acc"),
             size: acc_len,
             usage: wgpu::BufferUsages::STORAGE,
             mapped_at_creation: false,
         });
-        let out = self.empty_image(target);
+        let out = self.empty_image(target)?;
 
         let params = MotionPassParams {
             width: target.width,
@@ -954,16 +1091,24 @@ impl GpuRasterBackend for GpuRenderer {
                 // Reuse a persisted MAP_READ staging buffer across frames (the
                 // resolution is stable), so this allocates once instead of every
                 // readback. The copy below fully overwrites it each time.
-                if self.readback_staging.as_ref().map(wgpu::Buffer::size) != Some(byte_len as u64) {
-                    self.readback_staging =
-                        Some(self.device.create_buffer(&wgpu::BufferDescriptor {
+                if self
+                    .readback_staging
+                    .as_ref()
+                    .map(|(buffer, _)| buffer.size())
+                    != Some(byte_len as u64)
+                {
+                    let reservation = self.reserve_render_vram(byte_len)?;
+                    self.readback_staging = Some((
+                        self.device.create_buffer(&wgpu::BufferDescriptor {
                             label: Some("tellur-gpu-readback"),
                             size: byte_len as u64,
                             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
                             mapped_at_creation: false,
-                        }));
+                        }),
+                        reservation,
+                    ));
                 }
-                let staging = self.readback_staging.as_ref()?;
+                let staging = &self.readback_staging.as_ref()?.0;
                 let mut encoder =
                     self.device
                         .create_command_encoder(&wgpu::CommandEncoderDescriptor {

--- a/tellur-renderer/src/render_context.rs
+++ b/tellur-renderer/src/render_context.rs
@@ -21,6 +21,10 @@ use std::time::{Duration, Instant};
 use lru::LruCache;
 use rustc_hash::FxHasher;
 use sysinfo::System;
+use tellur_core::cache_budget::{
+    cache_ram_capacity, configured_vram_bytes, try_reserve_cache_ram, vram_used_bytes,
+    BudgetReservation,
+};
 use tellur_core::dyn_compare::{DynEq, DynHash};
 use tellur_core::geometry::Vec2;
 use tellur_core::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
@@ -40,6 +44,13 @@ const DEFAULT_PROBATION_ENTRIES: usize = 4096;
 const VOLATILE_LARGE_IMAGE_BYTES: usize = 1024 * 1024;
 const VOLATILE_MIN_MISSES: u64 = 8;
 const VOLATILE_MAX_HIT_RATE: f64 = 0.75;
+const GPU_CACHE_INITIAL_FRACTION_DIVISOR: usize = 4;
+const GPU_CACHE_MAX_FRACTION_DIVISOR: usize = 2;
+const GPU_CACHE_SHRINK_NUMERATOR: usize = 3;
+const GPU_CACHE_SHRINK_DENOMINATOR: usize = 4;
+const GPU_CACHE_GROW_SUCCESS_STREAK: u8 = 64;
+const GPU_CACHE_GROW_FRACTION_DIVISOR: usize = 64;
+const MIB: usize = 1024 * 1024;
 
 /// Controls when a freshly-rendered image becomes a cache entry.
 ///
@@ -87,6 +98,18 @@ impl CacheKey {
             target_width: target.width,
             target_height: target.height,
         }
+    }
+}
+
+struct CachedRasterImage {
+    image: RasterImage,
+    bytes: usize,
+    _ram_reservation: Option<BudgetReservation>,
+}
+
+impl CachedRasterImage {
+    fn is_gpu(&self) -> bool {
+        matches!(self.image, RasterImage::Gpu(_))
     }
 }
 
@@ -153,6 +176,9 @@ pub struct CacheMetrics {
     /// Misses where the freshly-produced image was not admitted by the
     /// configured admission policy.
     pub admission_skips: u64,
+    /// Misses where the freshly-produced image was not admitted because the
+    /// process-wide cache RAM budget was exhausted.
+    pub budget_skips: u64,
     /// Current GPU policy for this context.
     pub gpu_preference: GpuPreference,
     /// Whether the context has tried to create a GPU backend.
@@ -187,7 +213,7 @@ impl fmt::Display for CacheMetrics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "Cache  {} hits / {} misses ({:.1}% hit) — {} cached, {} evicted, {} pressure skips, {} oversize skips, {} admission skips",
+            "Cache  {} hits / {} misses ({:.1}% hit) — {} cached, {} evicted, {} pressure skips, {} oversize skips, {} admission skips, {} budget skips",
             self.hits,
             self.misses,
             self.hit_rate() * 100.0,
@@ -196,10 +222,11 @@ impl fmt::Display for CacheMetrics {
             self.pressure_skips,
             self.oversize_skips,
             self.admission_skips,
+            self.budget_skips,
         )?;
         writeln!(
             f,
-            "GPU    preference={:?}, attempted={}, available={}, ops={} (composite {}, shadow {}, outline {}, rasterize {}, fill {}, temporal_avg {}, readback {})",
+            "GPU    preference={:?}, attempted={}, available={}, ops={} (composite {}, shadow {}, outline {}, rasterize {}, fill {}, temporal_avg {}, readback {}, vram_failures {}, cache_evictions {})",
             self.gpu_preference,
             self.gpu_init_attempted,
             self.gpu_available,
@@ -211,6 +238,8 @@ impl fmt::Display for CacheMetrics {
             self.gpu.fills,
             self.gpu.temporal_averages,
             self.gpu.readbacks,
+            self.gpu.vram_reserve_failures,
+            self.gpu.vram_cache_evictions,
         )?;
         if !self.per_type.is_empty() {
             writeln!(f, "Cache by type (sorted by self_time, descending):")?;
@@ -278,10 +307,16 @@ fn pixel_stride(format: PixelFormat) -> usize {
 /// [`tellur_core::timeline::Timeline::build`]; the cache persists across
 /// frames so any time-invariant subtree only re-renders once.
 pub struct CachingRenderContext {
-    cache: LruCache<CacheKey, RasterImage>,
+    cache: LruCache<CacheKey, CachedRasterImage>,
     probation: LruCache<CacheKey, ()>,
     cur_bytes: usize,
+    cpu_cache_bytes: usize,
     cap_bytes: usize,
+    gpu_cache_bytes: usize,
+    gpu_cache_cap_bytes: usize,
+    gpu_cache_max_bytes: usize,
+    gpu_cache_spare_successes: u8,
+    gpu_vram_failures_seen: u64,
     system: System,
     // Aggregate counters; `per_type` is keyed by `TypeId` for cheap
     // updates inside `render`, then projected onto `&'static str` names
@@ -292,6 +327,7 @@ pub struct CachingRenderContext {
     pressure_skips: u64,
     oversize_skips: u64,
     admission_skips: u64,
+    budget_skips: u64,
     per_type: HashMap<TypeId, (TypeStats, &'static str)>,
     admission_policy: CacheAdmissionPolicy,
     gpu_preference: GpuPreference,
@@ -315,11 +351,18 @@ impl CachingRenderContext {
 
     /// Create a context with a custom byte capacity.
     pub fn with_capacity_bytes(cap_bytes: usize) -> Self {
+        let (gpu_cache_cap_bytes, gpu_cache_max_bytes) = gpu_cache_limits();
         Self {
             cache: LruCache::unbounded(),
             probation: LruCache::unbounded(),
             cur_bytes: 0,
-            cap_bytes,
+            cpu_cache_bytes: 0,
+            cap_bytes: cache_ram_capacity(cap_bytes),
+            gpu_cache_bytes: 0,
+            gpu_cache_cap_bytes,
+            gpu_cache_max_bytes,
+            gpu_cache_spare_successes: 0,
+            gpu_vram_failures_seen: 0,
             system: System::new(),
             hits: 0,
             misses: 0,
@@ -327,6 +370,7 @@ impl CachingRenderContext {
             pressure_skips: 0,
             oversize_skips: 0,
             admission_skips: 0,
+            budget_skips: 0,
             per_type: HashMap::new(),
             admission_policy: CacheAdmissionPolicy::Immediate,
             gpu_preference: GpuPreference::Auto,
@@ -424,6 +468,7 @@ impl CachingRenderContext {
             pressure_skips: self.pressure_skips,
             oversize_skips: self.oversize_skips,
             admission_skips: self.admission_skips,
+            budget_skips: self.budget_skips,
             gpu_preference: self.gpu_preference,
             gpu_init_attempted: self.gpu_init_attempted,
             gpu_available: self.gpu.is_some(),
@@ -444,6 +489,7 @@ impl CachingRenderContext {
         self.pressure_skips = 0;
         self.oversize_skips = 0;
         self.admission_skips = 0;
+        self.budget_skips = 0;
         self.per_type.clear();
         self.total_render_time = Duration::ZERO;
     }
@@ -453,6 +499,8 @@ impl CachingRenderContext {
         self.cache.clear();
         self.probation.clear();
         self.cur_bytes = 0;
+        self.cpu_cache_bytes = 0;
+        self.gpu_cache_bytes = 0;
     }
 
     fn should_admit(&mut self, key: CacheKey, type_id: TypeId, bytes: usize) -> bool {
@@ -514,18 +562,63 @@ impl CachingRenderContext {
         }
     }
 
-    /// Evict least-recently-used entries until `needed` more bytes fit
-    /// under the configured cap.
-    fn evict_to_fit(&mut self, needed: usize) {
-        while self.cur_bytes + needed > self.cap_bytes {
+    fn cache_entry(image: RasterImage, bytes: usize) -> Option<CachedRasterImage> {
+        let ram_reservation = match &image {
+            RasterImage::Cpu(_) => Some(try_reserve_cache_ram(bytes)?),
+            RasterImage::Gpu(_) => None,
+        };
+        Some(CachedRasterImage {
+            image,
+            bytes,
+            _ram_reservation: ram_reservation,
+        })
+    }
+
+    fn account_evicted(&mut self, entry: &CachedRasterImage) {
+        self.cur_bytes = self.cur_bytes.saturating_sub(entry.bytes);
+        if entry.is_gpu() {
+            self.gpu_cache_bytes = self.gpu_cache_bytes.saturating_sub(entry.bytes);
+        } else {
+            self.cpu_cache_bytes = self.cpu_cache_bytes.saturating_sub(entry.bytes);
+        }
+        self.bytes_evicted = self.bytes_evicted.saturating_add(entry.bytes as u64);
+    }
+
+    fn evict_gpu_cache_to_fit(&mut self, needed: usize) {
+        if self.gpu_cache_bytes.saturating_add(needed) <= self.gpu_cache_cap_bytes {
+            return;
+        }
+
+        let mut keep = Vec::with_capacity(self.cache.len());
+        while self.gpu_cache_bytes.saturating_add(needed) > self.gpu_cache_cap_bytes {
             match self.cache.pop_lru() {
-                Some((_, img)) => {
-                    let b = Self::image_bytes(&img);
-                    self.cur_bytes = self.cur_bytes.saturating_sub(b);
-                    self.bytes_evicted = self.bytes_evicted.saturating_add(b as u64);
-                }
+                Some((_, entry)) if entry.is_gpu() => self.account_evicted(&entry),
+                Some((key, entry)) => keep.push((key, entry)),
                 None => break,
             }
+        }
+        for (key, entry) in keep {
+            self.cache.put(key, entry);
+        }
+    }
+
+    /// Evict least-recently-used entries until `needed` more bytes fit
+    /// under the configured cap.
+    fn evict_cpu_cache_to_fit(&mut self, needed: usize) {
+        if self.cpu_cache_bytes.saturating_add(needed) <= self.cap_bytes {
+            return;
+        }
+
+        let mut keep = Vec::with_capacity(self.cache.len());
+        while self.cpu_cache_bytes.saturating_add(needed) > self.cap_bytes {
+            match self.cache.pop_lru() {
+                Some((_, entry)) if !entry.is_gpu() => self.account_evicted(&entry),
+                Some((key, entry)) => keep.push((key, entry)),
+                None => break,
+            }
+        }
+        for (key, entry) in keep {
+            self.cache.put(key, entry);
         }
     }
 
@@ -533,16 +626,84 @@ impl CachingRenderContext {
     /// is empty.
     fn shed_under_pressure(&mut self) {
         while self.under_memory_pressure() {
+            let mut keep = Vec::with_capacity(self.cache.len());
+            let mut evicted = false;
             match self.cache.pop_lru() {
-                Some((_, img)) => {
-                    let b = Self::image_bytes(&img);
-                    self.cur_bytes = self.cur_bytes.saturating_sub(b);
-                    self.bytes_evicted = self.bytes_evicted.saturating_add(b as u64);
+                Some((_, entry)) if !entry.is_gpu() => {
+                    self.account_evicted(&entry);
+                    evicted = true;
                 }
+                Some((key, entry)) => keep.push((key, entry)),
                 None => break,
+            }
+            while !evicted {
+                match self.cache.pop_lru() {
+                    Some((_, entry)) if !entry.is_gpu() => {
+                        self.account_evicted(&entry);
+                        evicted = true;
+                    }
+                    Some((key, entry)) => keep.push((key, entry)),
+                    None => break,
+                }
+            }
+            for (key, entry) in keep {
+                self.cache.put(key, entry);
+            }
+            if !evicted {
+                break;
             }
         }
     }
+
+    fn adjust_gpu_cache_budget_after_render(&mut self) {
+        let failures = self
+            .gpu
+            .as_ref()
+            .map(|gpu| gpu.stats().vram_reserve_failures)
+            .unwrap_or(0);
+        if failures > self.gpu_vram_failures_seen {
+            self.gpu_vram_failures_seen = failures;
+            self.shrink_gpu_cache_budget();
+            return;
+        }
+
+        let limit = configured_vram_bytes();
+        let used = vram_used_bytes();
+        if self.gpu_cache_cap_bytes >= self.gpu_cache_max_bytes
+            || used.saturating_mul(4) >= limit.saturating_mul(3)
+        {
+            self.gpu_cache_spare_successes = 0;
+            return;
+        }
+
+        self.gpu_cache_spare_successes = self.gpu_cache_spare_successes.saturating_add(1);
+        if self.gpu_cache_spare_successes >= GPU_CACHE_GROW_SUCCESS_STREAK {
+            let step = (limit / GPU_CACHE_GROW_FRACTION_DIVISOR).max(MIB);
+            self.gpu_cache_cap_bytes = self
+                .gpu_cache_cap_bytes
+                .saturating_add(step)
+                .min(self.gpu_cache_max_bytes);
+            self.gpu_cache_spare_successes = 0;
+        }
+    }
+
+    fn shrink_gpu_cache_budget(&mut self) {
+        self.gpu_cache_spare_successes = 0;
+        let old = self.gpu_cache_cap_bytes;
+        self.gpu_cache_cap_bytes =
+            old.saturating_mul(GPU_CACHE_SHRINK_NUMERATOR) / GPU_CACHE_SHRINK_DENOMINATOR;
+        if old > 0 && self.gpu_cache_cap_bytes == old {
+            self.gpu_cache_cap_bytes = old - 1;
+        }
+        self.evict_gpu_cache_to_fit(0);
+    }
+}
+
+fn gpu_cache_limits() -> (usize, usize) {
+    let limit = configured_vram_bytes();
+    let max = limit / GPU_CACHE_MAX_FRACTION_DIVISOR;
+    let cap = (limit / GPU_CACHE_INITIAL_FRACTION_DIVISOR).min(max);
+    (cap, max)
 }
 
 impl Default for CachingRenderContext {
@@ -608,27 +769,47 @@ impl RenderContext for CachingRenderContext {
         let (img, was_hit, counted) = match key {
             None => (component.render(size, target, self), false, false),
             Some(key) => {
-                if let Some(img) = self.cache.get(&key).cloned() {
-                    (img, true, true)
+                if let Some(entry) = self.cache.get(&key) {
+                    (entry.image.clone(), true, true)
                 } else {
                     // Miss path: produce the image, then decide whether to
                     // admit it. Nested `ctx.render` calls happen inside
                     // `component.render`, which is why timing is wrapped
                     // around the whole block.
                     let img = component.render(size, target, self);
+                    self.adjust_gpu_cache_budget_after_render();
                     let bytes = Self::image_bytes(&img);
+                    let is_gpu = matches!(img, RasterImage::Gpu(_));
 
-                    if bytes > self.cap_bytes {
+                    if !is_gpu && bytes > self.cap_bytes {
                         self.oversize_skips += 1;
                     } else if !self.should_admit(key, type_id, bytes) {
                     } else {
-                        self.evict_to_fit(bytes);
-                        if self.under_memory_pressure() {
-                            self.shed_under_pressure();
-                            self.pressure_skips += 1;
+                        if is_gpu {
+                            self.evict_gpu_cache_to_fit(bytes);
+                        }
+                        if is_gpu
+                            && self.gpu_cache_bytes.saturating_add(bytes) > self.gpu_cache_cap_bytes
+                        {
+                            self.budget_skips += 1;
                         } else {
-                            self.cache.put(key, img.clone());
-                            self.cur_bytes += bytes;
+                            if !is_gpu {
+                                self.evict_cpu_cache_to_fit(bytes);
+                            }
+                            if self.under_memory_pressure() {
+                                self.shed_under_pressure();
+                                self.pressure_skips += 1;
+                            } else if let Some(entry) = Self::cache_entry(img.clone(), bytes) {
+                                self.cache.put(key, entry);
+                                self.cur_bytes += bytes;
+                                if is_gpu {
+                                    self.gpu_cache_bytes += bytes;
+                                } else {
+                                    self.cpu_cache_bytes += bytes;
+                                }
+                            } else {
+                                self.budget_skips += 1;
+                            }
                         }
                     }
                     (img, false, true)
@@ -663,16 +844,19 @@ impl RenderContext for CachingRenderContext {
 
 #[cfg(test)]
 mod tests {
+    use std::any::TypeId;
+    use std::sync::Arc;
+
     use tellur_core::color::Color;
     use tellur_core::geometry::{Constraints, Vec2};
     use tellur_core::layer::Layer;
     use tellur_core::placement::RasterPlacement;
-    use tellur_core::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
+    use tellur_core::raster::{GpuSurface, PixelFormat, RasterComponent, RasterImage, Resolution};
     use tellur_core::render_context::{CachePolicy, GpuPreference, PassThrough, RenderContext};
     use tellur_core::shapes::Rectangle;
     use tellur_core::vector::Paint;
 
-    use super::{CachingRenderContext, VOLATILE_MIN_MISSES};
+    use super::{CacheKey, CachedRasterImage, CachingRenderContext, VOLATILE_MIN_MISSES};
     use crate::rasterize::Rasterizable;
 
     fn scene() -> Layer {
@@ -811,6 +995,73 @@ mod tests {
         assert_eq!(skipped.misses, VOLATILE_MIN_MISSES + 1);
         assert_eq!(skipped.admission_skips, 1);
         assert_eq!(skipped.bytes_cached, warmed.bytes_cached);
+    }
+
+    #[test]
+    fn gpu_cache_cap_eviction_drops_only_gpu_entries() {
+        let mut cache = CachingRenderContext::with_capacity_bytes(1024 * 1024)
+            .with_gpu_preference(GpuPreference::PreferGpu);
+        let cpu = RasterImage::cpu(1, 1, PixelFormat::Rgba8, vec![1, 2, 3, 4]);
+        let gpu = RasterImage::Gpu(GpuSurface::new(
+            10,
+            10,
+            PixelFormat::Rgba8,
+            "test",
+            Arc::new(()),
+        ));
+        let cpu_key = CacheKey {
+            type_id: TypeId::of::<SolidRaster>(),
+            content_hash: 1,
+            size_x_bits: 1,
+            size_y_bits: 1,
+            target_width: 1,
+            target_height: 1,
+        };
+        let gpu_key = CacheKey {
+            type_id: TypeId::of::<SolidRaster>(),
+            content_hash: 2,
+            size_x_bits: 1,
+            size_y_bits: 1,
+            target_width: 10,
+            target_height: 10,
+        };
+        cache.cache.put(
+            cpu_key,
+            CachedRasterImage {
+                image: cpu,
+                bytes: 4,
+                _ram_reservation: None,
+            },
+        );
+        cache.cache.put(
+            gpu_key,
+            CachedRasterImage {
+                image: gpu,
+                bytes: 400,
+                _ram_reservation: None,
+            },
+        );
+        cache.cur_bytes = 404;
+        cache.gpu_cache_bytes = 400;
+        cache.gpu_cache_cap_bytes = 128;
+
+        cache.evict_gpu_cache_to_fit(1);
+
+        assert_eq!(cache.cache.len(), 1);
+        assert_eq!(cache.cur_bytes, 4);
+        assert_eq!(cache.gpu_cache_bytes, 0);
+        assert_eq!(cache.bytes_evicted, 400);
+    }
+
+    #[test]
+    fn gpu_cache_budget_shrinks_after_vram_pressure() {
+        let mut cache = CachingRenderContext::with_capacity_bytes(1024 * 1024)
+            .with_gpu_preference(GpuPreference::PreferGpu);
+        cache.gpu_cache_cap_bytes = 1024;
+
+        cache.shrink_gpu_cache_budget();
+
+        assert_eq!(cache.gpu_cache_cap_bytes, 768);
     }
 
     fn render_and_readback(


### PR DESCRIPTION
Adds process-wide cache budgeting for Tellur-managed RAM caches and GPU allocations. `TELLUR_CACHE_RAM` caps CPU-side caches, while `TELLUR_VRAM` caps large wgpu backend allocations and drives adaptive GPU cache limits. 7 files (+683 / -79) across `tellur-core`, `tellur-renderer`, and `tellur-live`.

## Cache budgets
- Add `tellur_core::cache_budget` with `TELLUR_CACHE_RAM` and `TELLUR_VRAM` parsing, defaults, accounting, and RAII reservations.
- Apply RAM reservations to render image, audio decode/conform, and live video segment caches.
- Document defaults and suffix parsing in `tellur-live`.

## GPU cache behavior
- Track wgpu buffer/texture reservations against the VRAM budget.
- Keep GPU raster/upload caches under internal byte caps instead of dropping them preemptively for rendering.
- Shrink GPU cache caps after render-critical VRAM reservation failures and grow them gradually while VRAM remains spare.

## Verification
- `cargo fmt --all -- --check`
- `nix develop -c cargo check -p tellur-renderer -p tellur-live`
- `nix develop -c cargo test -p tellur-renderer render_context::tests --lib`
- `nix develop -c cargo test -p tellur-core`
- `nix develop -c cargo test -p tellur-live --lib`
- `nix develop -c env TELLUR_CACHE_RAM=1 cargo test -p tellur-renderer render_context::tests::passthrough_and_cache_agree_through_positioned --lib`
- `git diff --check`