### PR TITLE
feat: pass float audio to ffmpeg

### DIFF
--- a/tellur-core/src/audio.rs
+++ b/tellur-core/src/audio.rs
@@ -615,7 +615,7 @@ pub fn conform(buf: AudioBuffer, rate: u32, channels: u16, gain: f32, speed: f32
 
 /// The eager mix-down target: one interleaved f32 buffer at a fixed `rate` /
 /// `channels`, sized to the resolved timeline length. Leaves [`add`](Self::add)
-/// their conformed buffers at a resolved sample offset; sums clamp on overflow.
+/// their conformed buffers at a resolved sample offset; sums keep f32 headroom.
 #[derive(Debug, Clone)]
 pub struct AudioMix {
     samples: Vec<f32>,
@@ -652,10 +652,10 @@ impl AudioMix {
     }
 
     /// Sums an already-conformed (rate/channels/gain/speed-matched) interleaved
-    /// buffer into the mix starting at `start_secs`, clamping each summed sample
-    /// to `[-1, 1]` so overlapping tracks never wrap. Frames before the mix
-    /// start and past the mix end are dropped (the resolved length is
-    /// authoritative).
+    /// buffer into the mix starting at `start_secs`. Values may exceed
+    /// `[-1, 1]`; limiting/clipping belongs at the ffmpeg output stage. Frames
+    /// before the mix start and past the mix end are dropped (the resolved
+    /// length is authoritative).
     pub fn add(&mut self, conformed: &[f32], start_secs: f32) {
         let ch = self.channels.max(1) as usize;
         let start_frame = (start_secs * self.rate as f32).round() as isize;
@@ -670,7 +670,7 @@ impl AudioMix {
             if idx >= self.samples.len() {
                 break;
             }
-            self.samples[idx] = (self.samples[idx] + s).clamp(-1.0, 1.0);
+            self.samples[idx] += s;
         }
     }
 
@@ -753,14 +753,15 @@ mod tests {
     }
 
     #[test]
-    fn mix_add_sums_and_clamps() {
+    fn mix_add_preserves_float_headroom() {
         let mut mix = AudioMix::new(1.0, 4, 1);
-        // Two unit tracks at frame 0 sum to 2.0 then clamp to 1.0.
+        // Two unit tracks at frame 0 sum to 2.0; output limiting is a later
+        // encoder concern, not a mix-stage concern.
         mix.add(&[1.0, 1.0], 0.0);
         mix.add(&[1.0, 1.0], 0.0);
         let buf = mix.into_buffer();
-        assert_eq!(buf.samples[0], 1.0);
-        assert_eq!(buf.samples[1], 1.0);
+        assert_eq!(buf.samples[0], 2.0);
+        assert_eq!(buf.samples[1], 2.0);
     }
 
     #[test]

--- a/tellur-core/src/timeline_component/resolve.rs
+++ b/tellur-core/src/timeline_component/resolve.rs
@@ -287,8 +287,8 @@ impl ResolvedTimeline {
     /// then walks the source tree via [`mix_into`](TimelineComponent::mix_into):
     /// each [`AudioFile`](crate::timeline_container::AudioFile) decodes (honoring
     /// its `.trim`), resamples / re-channels / gain-scales into the fixed layout
-    /// at the placement speed, and SUMS into the mix at its resolved start
-    /// (clamping on overflow). The encoder feeds the result to ffmpeg as a temp
+    /// at the placement speed, and SUMS into the mix at its resolved start while
+    /// preserving f32 headroom. The encoder feeds the result to ffmpeg as a temp
     /// WAV second input.
     pub fn render_audio(&self, rate: u32, channels: u16) -> AudioBuffer {
         let mut mix = crate::audio::AudioMix::new(self.duration, rate, channels);

--- a/tellur-core/src/timeline_container/tests.rs
+++ b/tellur-core/src/timeline_container/tests.rs
@@ -1168,6 +1168,26 @@ fn gain_scales_audio() {
     let _ = std::fs::remove_file(&path);
 }
 
+#[test]
+fn gain_can_exceed_unit_range_before_ffmpeg_output() {
+    let frames = (TEST_RATE / 2) as usize;
+    let level = (0.8 * i16::MAX as f32) as i16;
+    let path = const_wav("hot_gain", TEST_RATE, frames, level);
+
+    let tl = Timeline::builder()
+        .child(AudioFile::builder().path(path.to_str().unwrap()).gain(2.0))
+        .build();
+    let resolved = resolve_audio(tl).expect("media-backed");
+    let mixed = resolved.render_audio(TEST_RATE, 1);
+
+    let mid = mixed.samples[frames / 2];
+    assert!(
+        (mid - 1.6).abs() < 0.04,
+        "gain 2.0 over 0.8 should keep f32 headroom (~1.6), got {mid}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
 // (mix) `.at(window)` speed changes the SAMPLE COUNT: a 1.0s source placed
 // into a 0.5s window plays at 2× (half as many output frames for that clip).
 #[test]

--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -928,8 +928,9 @@ impl Drop for TempFile {
     }
 }
 
-/// Writes `buf` (interleaved f32) as a 16-bit PCM WAV to a unique temp path, so
-/// ffmpeg can take it as a second input and mux it into the preview stream.
+/// Writes `buf` (interleaved f32) as a 32-bit IEEE float WAV to a unique temp
+/// path, so ffmpeg can take it as a second input and mux it into the preview
+/// stream.
 fn write_temp_wav(buf: &AudioBuffer) -> std::io::Result<PathBuf> {
     let seq = AUDIO_TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let mut path = std::env::temp_dir();
@@ -941,18 +942,19 @@ fn write_temp_wav(buf: &AudioBuffer) -> std::io::Result<PathBuf> {
 
     let channels = buf.channels.max(1);
     let rate = buf.rate.max(1);
-    let bits: u16 = 16;
-    let byte_rate = rate * channels as u32 * (bits as u32 / 8);
-    let block_align = channels * (bits / 8);
-    let data_bytes = (buf.samples.len() * 2) as u32;
+    let bits: u16 = 32;
+    let bytes_per_sample = (bits as u32 / 8) as usize;
+    let byte_rate = rate * channels as u32 * bytes_per_sample as u32;
+    let block_align = channels * bytes_per_sample as u16;
+    let data_bytes = (buf.samples.len() * bytes_per_sample) as u32;
 
-    let mut bytes = Vec::with_capacity(44 + buf.samples.len() * 2);
+    let mut bytes = Vec::with_capacity(44 + buf.samples.len() * bytes_per_sample);
     bytes.extend_from_slice(b"RIFF");
     bytes.extend_from_slice(&(36 + data_bytes).to_le_bytes());
     bytes.extend_from_slice(b"WAVE");
     bytes.extend_from_slice(b"fmt ");
     bytes.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
-    bytes.extend_from_slice(&1u16.to_le_bytes()); // audio format = PCM
+    bytes.extend_from_slice(&3u16.to_le_bytes()); // audio format = IEEE float
     bytes.extend_from_slice(&channels.to_le_bytes());
     bytes.extend_from_slice(&rate.to_le_bytes());
     bytes.extend_from_slice(&byte_rate.to_le_bytes());
@@ -961,8 +963,7 @@ fn write_temp_wav(buf: &AudioBuffer) -> std::io::Result<PathBuf> {
     bytes.extend_from_slice(b"data");
     bytes.extend_from_slice(&data_bytes.to_le_bytes());
     for &s in &buf.samples {
-        let v = (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
-        bytes.extend_from_slice(&v.to_le_bytes());
+        bytes.extend_from_slice(&s.to_le_bytes());
     }
     std::fs::write(&path, &bytes)?;
     Ok(path)
@@ -2186,6 +2187,25 @@ fn json_escape(s: &str) -> String {
 mod tests {
     use super::*;
     use tellur_core::timeline_component::{SourceLoc, TriggerMark};
+
+    #[test]
+    fn temp_wav_uses_f32le_and_preserves_headroom() {
+        let buf = AudioBuffer {
+            samples: vec![1.5, -2.0],
+            rate: 48_000,
+            channels: 1,
+        };
+        let path = write_temp_wav(&buf).expect("write temp float wav");
+        let bytes = std::fs::read(&path).expect("read temp float wav");
+
+        assert_eq!(&bytes[20..22], &3u16.to_le_bytes());
+        assert_eq!(&bytes[34..36], &32u16.to_le_bytes());
+        assert_eq!(&bytes[40..44], &8u32.to_le_bytes());
+        assert_eq!(&bytes[44..48], &1.5_f32.to_le_bytes());
+        assert_eq!(&bytes[48..52], &(-2.0_f32).to_le_bytes());
+
+        let _ = std::fs::remove_file(path);
+    }
 
     // A request for exactly `duration` must clamp into the half-open renderable
     // range: `< duration` (so the core's `t < end` clip gate stays active) AND

--- a/tellur-renderer/src/video.rs
+++ b/tellur-renderer/src/video.rs
@@ -223,7 +223,7 @@ impl FfmpegEncoder {
     /// A/V encode for the timeline subsystem (`.sketch/01` A.7 / B4 v1). Does NOT
     /// touch the old [`encode`](Self::encode) path.
     ///
-    /// Pre-renders the whole mixed audio track to a temp WAV
+    /// Pre-renders the whole mixed audio track to a temp 32-bit float WAV
     /// ([`ResolvedTimeline::render_audio`]), then spawns ffmpeg with the video on
     /// stdin (`-i -`, as today) AND the temp WAV as a SECOND input — the audio
     /// `-i <tmp.wav>` plus the `-c:a aac` / `-map` flags are injected through the
@@ -260,7 +260,7 @@ impl FfmpegEncoder {
             video_seconds,
         );
         let wav_path = unique_temp_wav();
-        write_wav_s16le(&wav_path, &mixed.samples, AUDIO_RATE, AUDIO_CHANNELS)
+        write_wav_f32le(&wav_path, &mixed.samples, AUDIO_RATE, AUDIO_CHANNELS)
             .map_err(FfmpegError::Spawn)?;
 
         // The second input + stream maps, injected through the SAME arg slot the
@@ -570,20 +570,21 @@ fn fit_audio_to_seconds(samples: &mut Vec<f32>, rate: u32, channels: u16, second
     samples.resize(target_frames * ch, 0.0);
 }
 
-/// Writes interleaved f32 `samples` as a canonical 44-byte-header s16le PCM WAV.
-fn write_wav_s16le(path: &Path, samples: &[f32], rate: u32, channels: u16) -> std::io::Result<()> {
-    let bits: u16 = 16;
-    let byte_rate = rate * channels as u32 * (bits as u32 / 8);
-    let block_align = channels * (bits / 8);
-    let data_bytes = (samples.len() * 2) as u32;
+/// Writes interleaved f32 `samples` as a 32-bit IEEE float WAV.
+fn write_wav_f32le(path: &Path, samples: &[f32], rate: u32, channels: u16) -> std::io::Result<()> {
+    let bits: u16 = 32;
+    let bytes_per_sample = (bits as u32 / 8) as usize;
+    let byte_rate = rate * channels as u32 * bytes_per_sample as u32;
+    let block_align = channels * bytes_per_sample as u16;
+    let data_bytes = (samples.len() * bytes_per_sample) as u32;
 
-    let mut bytes = Vec::with_capacity(44 + samples.len() * 2);
+    let mut bytes = Vec::with_capacity(44 + samples.len() * bytes_per_sample);
     bytes.extend_from_slice(b"RIFF");
     bytes.extend_from_slice(&(36 + data_bytes).to_le_bytes());
     bytes.extend_from_slice(b"WAVE");
     bytes.extend_from_slice(b"fmt ");
     bytes.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
-    bytes.extend_from_slice(&1u16.to_le_bytes()); // audio format = PCM
+    bytes.extend_from_slice(&3u16.to_le_bytes()); // audio format = IEEE float
     bytes.extend_from_slice(&channels.to_le_bytes());
     bytes.extend_from_slice(&rate.to_le_bytes());
     bytes.extend_from_slice(&byte_rate.to_le_bytes());
@@ -592,8 +593,7 @@ fn write_wav_s16le(path: &Path, samples: &[f32], rate: u32, channels: u16) -> st
     bytes.extend_from_slice(b"data");
     bytes.extend_from_slice(&data_bytes.to_le_bytes());
     for &s in samples {
-        let v = (s.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16;
-        bytes.extend_from_slice(&v.to_le_bytes());
+        bytes.extend_from_slice(&s.to_le_bytes());
     }
     std::fs::write(path, &bytes)
 }
@@ -806,7 +806,7 @@ mod av_mux_tests {
         }
     }
 
-    // Synthesizes a 1s 440 Hz mono sine WAV (s16le) to a temp path.
+    // Synthesizes a 1s 440 Hz mono sine WAV (f32le) to a temp path.
     fn sine_wav() -> PathBuf {
         let rate = 48_000u32;
         let frames = rate as usize;
@@ -814,16 +814,30 @@ mod av_mux_tests {
         for i in 0..frames {
             let t = i as f32 / rate as f32;
             let v = (2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.5;
-            samples.push((v * i16::MAX as f32) as i16);
-        }
-        let mut f32_samples = Vec::with_capacity(frames);
-        for s in &samples {
-            f32_samples.push(*s as f32 / i16::MAX as f32);
+            samples.push(v);
         }
         let mut path = std::env::temp_dir();
         path.push(format!("tellur_av_src_{}.wav", std::process::id()));
-        write_wav_s16le(&path, &f32_samples, rate, 1).expect("write sine wav");
+        write_wav_f32le(&path, &samples, rate, 1).expect("write sine wav");
         path
+    }
+
+    #[test]
+    fn wav_f32le_preserves_samples_outside_unit_range() {
+        let mut path = std::env::temp_dir();
+        path.push(format!("tellur_float_wav_{}.wav", std::process::id()));
+
+        let samples = [1.5_f32, -2.0_f32];
+        write_wav_f32le(&path, &samples, 48_000, 1).expect("write float wav");
+        let bytes = std::fs::read(&path).expect("read float wav");
+
+        assert_eq!(&bytes[20..22], &3u16.to_le_bytes());
+        assert_eq!(&bytes[34..36], &32u16.to_le_bytes());
+        assert_eq!(&bytes[40..44], &8u32.to_le_bytes());
+        assert_eq!(&bytes[44..48], &1.5_f32.to_le_bytes());
+        assert_eq!(&bytes[48..52], &(-2.0_f32).to_le_bytes());
+
+        let _ = std::fs::remove_file(&path);
     }
 
     // Asserts the encoded mp4 has a stream of `kind` ("a" audio / "v" video).


### PR DESCRIPTION
Preserves f32 audio headroom through timeline mixing and passes mixed audio to ffmpeg as 32-bit float WAVs for both export and live preview. 5 files (+96 / -41) across `tellur-core`, `tellur-renderer`, and `tellur-live`.

## Float audio path
- Stop clamping `AudioMix::add` to `[-1, 1]`, keeping gain/overlap peaks in f32 until ffmpeg.
- Write export and live-preview temp WAV inputs as IEEE float PCM instead of 16-bit PCM.
- Add tests for >1.0 samples through gain and temp WAV writers.

## Verification
- `cargo fmt --all`
- `nix develop -c cargo test -p tellur-core -- --test-threads=1`
- `nix develop -c cargo test -p tellur-renderer`
- `nix develop -c cargo test -p tellur-live --lib`
- `nix develop -c cargo check -p tellur-live --examples`
- `git diff --check`
