### PR TITLE
feat(core): add AudioFile fades

### DIFF
--- a/tellur-core/src/timeline_container/leaves.rs
+++ b/tellur-core/src/timeline_container/leaves.rs
@@ -118,7 +118,7 @@ impl TimelineComponent for VideoFile {
 }
 
 /// Decoded audio — the audio channel. Built with
-/// `AudioFile::builder().path("v.wav").gain(0.25)`.
+/// `AudioFile::builder().path("v.wav").gain(0.25).fade_out(0.4)`.
 ///
 /// Its intrinsic length is the file's, read once by the resolve pass via a
 /// `symphonia` decode (`probe`). An injected `duration` (or, if decode
@@ -135,6 +135,15 @@ pub struct AudioFile {
     /// Linear gain applied to the decoded samples (`1.0` = unity).
     #[builder(default = 1.0)]
     pub gain: f32,
+    /// Linear fade-in duration in clip-local output seconds. A non-positive or
+    /// non-finite value disables the fade.
+    #[builder(default = 0.0)]
+    pub fade_in: f32,
+    /// Linear fade-out duration in clip-local output seconds, ending at the
+    /// clip's resolved audio end. A non-positive or non-finite value disables
+    /// the fade.
+    #[builder(default = 0.0)]
+    pub fade_out: f32,
     /// Optional override for the probed duration. Test-injectable; `None` reads
     /// the real decoded length (with the stub as a last-resort fallback).
     #[builder(into)]
@@ -224,12 +233,31 @@ impl TimelineComponent for AudioFile {
             speed,
         ) {
             let output_start = source_offset / speed;
-            let output_duration = (mix_duration - visible_start).max(0.0);
+            let clip_duration = self
+                .duration
+                .map(|duration| (duration / speed).max(0.0))
+                .unwrap_or_else(|| audio_buffer_duration(&buf));
+            let output_duration = (mix_duration - visible_start)
+                .max(0.0)
+                .min((clip_duration - output_start).max(0.0));
+            if output_duration <= 0.0 {
+                return;
+            }
             let window = audio::slice_audio_buffer(
                 &buf,
                 Some((output_start, output_start + output_duration)),
             );
-            mix.add(&window.samples, visible_start);
+            let mut samples = window.samples;
+            apply_audio_fade(
+                &mut samples,
+                mix.rate(),
+                mix.channels(),
+                output_start,
+                clip_duration,
+                self.fade_in,
+                self.fade_out,
+            );
+            mix.add(&samples, visible_start);
         }
     }
 
@@ -246,6 +274,61 @@ impl TimelineComponent for AudioFile {
             children: Vec::new(),
         }
     }
+}
+
+fn audio_buffer_duration(buffer: &AudioBuffer) -> f32 {
+    let channels = buffer.channels.max(1) as usize;
+    let frames = buffer.samples.len() / channels;
+    frames as f32 / buffer.rate.max(1) as f32
+}
+
+fn apply_audio_fade(
+    samples: &mut [f32],
+    rate: u32,
+    channels: u16,
+    local_start: f32,
+    clip_duration: f32,
+    fade_in: f32,
+    fade_out: f32,
+) {
+    let fade_in = fade_seconds(fade_in);
+    let fade_out = fade_seconds(fade_out);
+    if fade_in == 0.0 && fade_out == 0.0 {
+        return;
+    }
+
+    let channels = channels.max(1) as usize;
+    let frames = samples.len() / channels;
+    let rate = rate.max(1) as f32;
+    for frame in 0..frames {
+        let local_time = local_start + frame as f32 / rate;
+        let gain = audio_fade_gain(local_time, clip_duration, fade_in, fade_out);
+        for channel in 0..channels {
+            samples[frame * channels + channel] *= gain;
+        }
+    }
+}
+
+fn fade_seconds(seconds: f32) -> f32 {
+    if seconds.is_finite() {
+        seconds.max(0.0)
+    } else {
+        0.0
+    }
+}
+
+fn audio_fade_gain(local_time: f32, clip_duration: f32, fade_in: f32, fade_out: f32) -> f32 {
+    let rise = if fade_in <= 0.0 {
+        1.0
+    } else {
+        (local_time / fade_in).clamp(0.0, 1.0)
+    };
+    let fall = if fade_out <= 0.0 {
+        1.0
+    } else {
+        ((clip_duration - local_time) / fade_out).clamp(0.0, 1.0)
+    };
+    rise.min(fall)
 }
 
 /// 字幕 — the subtitle channel only (written to .srt/.vtt, NOT a burned-in

--- a/tellur-core/src/timeline_container/tests.rs
+++ b/tellur-core/src/timeline_container/tests.rs
@@ -1188,6 +1188,77 @@ fn gain_can_exceed_unit_range_before_ffmpeg_output() {
     let _ = std::fs::remove_file(&path);
 }
 
+#[test]
+fn audiofile_applies_linear_fade_envelope() {
+    let frames = TEST_RATE as usize;
+    let level = (0.8 * i16::MAX as f32) as i16;
+    let path = const_wav("fade", TEST_RATE, frames, level);
+
+    let tl = Timeline::builder()
+        .child(
+            AudioFile::builder()
+                .path(path.to_str().unwrap())
+                .fade_in(0.25)
+                .fade_out(0.25),
+        )
+        .build();
+    let resolved = resolve_audio(tl).expect("media-backed");
+    let mixed = resolved.render_audio(TEST_RATE, 1);
+
+    let full = mixed.samples[(TEST_RATE / 2) as usize];
+    let half_rise = mixed.samples[(TEST_RATE / 8) as usize];
+    let half_fall = mixed.samples[(TEST_RATE * 7 / 8) as usize];
+    let tail = mixed.samples[frames - 1];
+
+    assert!(
+        mixed.samples[0].abs() < 1e-6,
+        "fade-in starts silent, got {}",
+        mixed.samples[0]
+    );
+    assert!(
+        (half_rise - full * 0.5).abs() < 0.02,
+        "halfway through fade-in should be half gain: {half_rise} vs {full}",
+    );
+    assert!(
+        (half_fall - full * 0.5).abs() < 0.02,
+        "halfway through fade-out should be half gain: {half_fall} vs {full}",
+    );
+    assert!(tail.abs() < 0.001, "fade-out ends near silence, got {tail}");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn audiofile_fade_matches_full_mix_when_rendering_window() {
+    let frames = TEST_RATE as usize;
+    let level = (0.7 * i16::MAX as f32) as i16;
+    let path = const_wav("fade_window", TEST_RATE, frames, level);
+
+    let tl = Timeline::builder()
+        .child(
+            AudioFile::builder()
+                .path(path.to_str().unwrap())
+                .fade_in(0.2)
+                .fade_out(0.3),
+        )
+        .build();
+    let resolved = resolve_audio(tl).expect("media-backed");
+    let full = resolved.render_audio(TEST_RATE, 1);
+    let window = resolved.render_audio_window(0.75, 0.2, TEST_RATE, 1);
+
+    let start = (TEST_RATE * 3 / 4) as usize;
+    let end = start + (TEST_RATE / 5) as usize;
+    assert_eq!(window.samples.len(), end - start);
+    for (a, b) in window.samples.iter().zip(&full.samples[start..end]) {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "window sample {a} should match full mix slice sample {b}"
+        );
+    }
+
+    let _ = std::fs::remove_file(&path);
+}
+
 // (mix) `.at(window)` speed changes the SAMPLE COUNT: a 1.0s source placed
 // into a 0.5s window plays at 2× (half as many output frames for that clip).
 #[test]


### PR DESCRIPTION
Adds `fade_in` and `fade_out` builder properties to `AudioFile`, applying a linear clip-local envelope during audio mixdown while preserving cached decode/conform buffers. 2 files (+157 / -3) in `tellur-core`.

## Audio fades
- Add default-off `fade_in` and `fade_out` durations to `AudioFile`.
- Apply the fade envelope after slicing each render window so live-preview window audio matches full mixes.
- Cap mixed output to the clip duration when duration overrides are used.

## Verification
- `cargo fmt --all -- --check`
- `nix develop -c cargo test -p tellur-core`
- `git diff --check`
