### PR TITLE
fix(renderer): reduce GPU cache thrashing

### DIFF
--- a/tellur-live/src/server.rs
+++ b/tellur-live/src/server.rs
@@ -685,6 +685,20 @@ impl PreviewApp {
                 format!("{:?}", after.gpu_preference),
                 after.gpu.total_ops().saturating_sub(before.gpu.total_ops()),
                 after.gpu.readbacks.saturating_sub(before.gpu.readbacks),
+                after
+                    .gpu
+                    .vram_reserve_failures
+                    .saturating_sub(before.gpu.vram_reserve_failures),
+                after
+                    .gpu
+                    .vram_cache_evictions
+                    .saturating_sub(before.gpu.vram_cache_evictions),
+                after.gpu_cache_bytes,
+                after.gpu_cache_cap_bytes,
+                after.gpu.upload_cache_bytes,
+                after.gpu.upload_cache_cap_bytes,
+                after.vram_used_bytes,
+                after.vram_budget_bytes,
             )
         });
         let (
@@ -697,7 +711,35 @@ impl PreviewApp {
             gpu_preference,
             gpu_ops,
             gpu_readbacks,
-        ) = stats.unwrap_or_else(|| (0, 0, 0, false, false, None, String::new(), 0, 0));
+            gpu_vram_failures,
+            gpu_cache_evictions,
+            gpu_cache_bytes,
+            gpu_cache_cap_bytes,
+            gpu_upload_cache_bytes,
+            gpu_upload_cache_cap_bytes,
+            vram_used_bytes,
+            vram_budget_bytes,
+        ) = stats.unwrap_or_else(|| {
+            (
+                0,
+                0,
+                0,
+                false,
+                false,
+                None,
+                String::new(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
+        });
 
         Ok(VideoFrame {
             image,
@@ -713,6 +755,14 @@ impl PreviewApp {
             gpu_preference,
             gpu_ops,
             gpu_readbacks,
+            gpu_vram_failures,
+            gpu_cache_evictions,
+            gpu_cache_bytes,
+            gpu_cache_cap_bytes,
+            gpu_upload_cache_bytes,
+            gpu_upload_cache_cap_bytes,
+            vram_used_bytes,
+            vram_budget_bytes,
         })
     }
 
@@ -828,6 +878,20 @@ impl PreviewApp {
                 gpu_preference: format!("{:?}", after.gpu_preference),
                 gpu_ops: after.gpu.total_ops().saturating_sub(before.gpu.total_ops()),
                 gpu_readbacks: after.gpu.readbacks.saturating_sub(before.gpu.readbacks),
+                gpu_vram_failures: after
+                    .gpu
+                    .vram_reserve_failures
+                    .saturating_sub(before.gpu.vram_reserve_failures),
+                gpu_cache_evictions: after
+                    .gpu
+                    .vram_cache_evictions
+                    .saturating_sub(before.gpu.vram_cache_evictions),
+                gpu_cache_bytes: after.gpu_cache_bytes,
+                gpu_cache_cap_bytes: after.gpu_cache_cap_bytes,
+                gpu_upload_cache_bytes: after.gpu.upload_cache_bytes,
+                gpu_upload_cache_cap_bytes: after.gpu.upload_cache_cap_bytes,
+                vram_used_bytes: after.vram_used_bytes,
+                vram_budget_bytes: after.vram_budget_bytes,
             },
             total_start,
         })
@@ -910,6 +974,14 @@ struct VideoFrame {
     gpu_preference: String,
     gpu_ops: u64,
     gpu_readbacks: u64,
+    gpu_vram_failures: u64,
+    gpu_cache_evictions: u64,
+    gpu_cache_bytes: usize,
+    gpu_cache_cap_bytes: usize,
+    gpu_upload_cache_bytes: usize,
+    gpu_upload_cache_cap_bytes: usize,
+    vram_used_bytes: usize,
+    vram_budget_bytes: usize,
 }
 
 /// The fixed audio layout the preview mux uses (matches the encoder boundary).
@@ -1347,7 +1419,7 @@ fn handle_video_stream(
             )?;
             if verbose {
                 println!(
-                    "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms build={:.2}ms readback={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={}",
+                    "video timeline={} t={:.3}s size={}x{} fps={} gop={} render={:.2}ms build={:.2}ms readback={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={} gpu_vram_failures={} gpu_cache_evictions={} gpu_cache={}/{} gpu_upload_cache={}/{} vram={}/{}",
                     setup.timeline_id,
                     seconds,
                     setup.resolution.width,
@@ -1367,6 +1439,14 @@ fn handle_video_stream(
                     frame.gpu_available,
                     frame.gpu_ops,
                     frame.gpu_readbacks,
+                    frame.gpu_vram_failures,
+                    frame.gpu_cache_evictions,
+                    format_bytes(frame.gpu_cache_bytes as u64),
+                    format_bytes(frame.gpu_cache_cap_bytes as u64),
+                    format_bytes(frame.gpu_upload_cache_bytes as u64),
+                    format_bytes(frame.gpu_upload_cache_cap_bytes as u64),
+                    format_bytes(frame.vram_used_bytes as u64),
+                    format_bytes(frame.vram_budget_bytes as u64),
                 );
             }
             render_total += frame.render_time;
@@ -1470,6 +1550,14 @@ struct FrameRenderStats {
     gpu_available: bool,
     gpu_ops: u64,
     gpu_readbacks: u64,
+    gpu_vram_failures: u64,
+    gpu_cache_evictions: u64,
+    gpu_cache_bytes: usize,
+    gpu_cache_cap_bytes: usize,
+    gpu_upload_cache_bytes: usize,
+    gpu_upload_cache_cap_bytes: usize,
+    vram_used_bytes: usize,
+    vram_budget_bytes: usize,
 }
 
 impl FrameRenderStats {
@@ -1496,6 +1584,32 @@ impl FrameRenderStats {
             ("X-Tellur-GPU-Active", (self.gpu_ops > 0).to_string()),
             ("X-Tellur-GPU-Ops", self.gpu_ops.to_string()),
             ("X-Tellur-GPU-Readbacks", self.gpu_readbacks.to_string()),
+            (
+                "X-Tellur-GPU-VRAM-Failures",
+                self.gpu_vram_failures.to_string(),
+            ),
+            (
+                "X-Tellur-GPU-Cache-Evictions",
+                self.gpu_cache_evictions.to_string(),
+            ),
+            ("X-Tellur-GPU-Cache-Bytes", self.gpu_cache_bytes.to_string()),
+            (
+                "X-Tellur-GPU-Cache-Cap-Bytes",
+                self.gpu_cache_cap_bytes.to_string(),
+            ),
+            (
+                "X-Tellur-GPU-Upload-Cache-Bytes",
+                self.gpu_upload_cache_bytes.to_string(),
+            ),
+            (
+                "X-Tellur-GPU-Upload-Cache-Cap-Bytes",
+                self.gpu_upload_cache_cap_bytes.to_string(),
+            ),
+            ("X-Tellur-VRAM-Used-Bytes", self.vram_used_bytes.to_string()),
+            (
+                "X-Tellur-VRAM-Budget-Bytes",
+                self.vram_budget_bytes.to_string(),
+            ),
         ];
         if let Some(error) = &self.gpu_init_error {
             headers.push(("X-Tellur-GPU-Init-Error", sanitize_header_value(error)));
@@ -1528,7 +1642,7 @@ impl FrameFormat {
 
 fn log_frame_stats(stats: &FrameRenderStats) {
     println!(
-        "frame timeline={} t={:.3}s size={}x{} format={} render={:.2}ms encode={:.2}ms total={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={}",
+        "frame timeline={} t={:.3}s size={}x{} format={} render={:.2}ms encode={:.2}ms total={:.2}ms bytes={} cache_delta={}h/{}m cache_size={} gpu_preference={} gpu_init_attempted={} gpu_init_error={} gpu_available={} gpu_ops={} gpu_readbacks={} gpu_vram_failures={} gpu_cache_evictions={} gpu_cache={}/{} gpu_upload_cache={}/{} vram={}/{}",
         stats.timeline_id,
         stats.seconds,
         stats.resolution.width,
@@ -1547,6 +1661,14 @@ fn log_frame_stats(stats: &FrameRenderStats) {
         stats.gpu_available,
         stats.gpu_ops,
         stats.gpu_readbacks,
+        stats.gpu_vram_failures,
+        stats.gpu_cache_evictions,
+        format_bytes(stats.gpu_cache_bytes as u64),
+        format_bytes(stats.gpu_cache_cap_bytes as u64),
+        format_bytes(stats.gpu_upload_cache_bytes as u64),
+        format_bytes(stats.gpu_upload_cache_cap_bytes as u64),
+        format_bytes(stats.vram_used_bytes as u64),
+        format_bytes(stats.vram_budget_bytes as u64),
     );
 }
 
@@ -1585,7 +1707,7 @@ fn log_cache_metrics_delta(before: &CacheMetrics, after: &CacheMetrics) {
     let gpu_before = &before.gpu;
     let gpu_after = &after.gpu;
     println!(
-        "video-stream-cache-delta hits={} misses={} hit_rate={:.1}% cache_size={} evicted_delta={} pressure_skips_delta={} oversize_skips_delta={} admission_skips_delta={} budget_skips_delta={} gpu_ops={} gpu_composites={} gpu_shadows={} gpu_outlines={} gpu_rasterizes={} gpu_fills={} gpu_temporal_avg={} gpu_readbacks={}",
+        "video-stream-cache-delta hits={} misses={} hit_rate={:.1}% cache_size={} evicted_delta={} pressure_skips_delta={} oversize_skips_delta={} admission_skips_delta={} budget_skips_delta={} gpu_ops={} gpu_composites={} gpu_shadows={} gpu_outlines={} gpu_rasterizes={} gpu_fills={} gpu_temporal_avg={} gpu_readbacks={} gpu_vram_failures={} gpu_cache_evictions={} gpu_cache={}/{} gpu_upload_cache={}/{} vram={}/{}",
         hits,
         misses,
         hit_rate * 100.0,
@@ -1605,6 +1727,18 @@ fn log_cache_metrics_delta(before: &CacheMetrics, after: &CacheMetrics) {
             .temporal_averages
             .saturating_sub(gpu_before.temporal_averages),
         gpu_after.readbacks.saturating_sub(gpu_before.readbacks),
+        gpu_after
+            .vram_reserve_failures
+            .saturating_sub(gpu_before.vram_reserve_failures),
+        gpu_after
+            .vram_cache_evictions
+            .saturating_sub(gpu_before.vram_cache_evictions),
+        format_bytes(after.gpu_cache_bytes as u64),
+        format_bytes(after.gpu_cache_cap_bytes as u64),
+        format_bytes(gpu_after.upload_cache_bytes as u64),
+        format_bytes(gpu_after.upload_cache_cap_bytes as u64),
+        format_bytes(after.vram_used_bytes as u64),
+        format_bytes(after.vram_budget_bytes as u64),
     );
 
     let mut rows: Vec<(&'static str, TypeStatsDelta)> = after

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::hash::{BuildHasher, Hash};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -67,6 +68,10 @@ pub struct GpuRenderStats {
     pub readbacks: u64,
     pub vram_reserve_failures: u64,
     pub vram_cache_evictions: u64,
+    pub upload_cache_entries: usize,
+    pub upload_cache_bytes: usize,
+    pub upload_cache_cap_bytes: usize,
+    pub upload_cache_max_bytes: usize,
 }
 
 impl GpuRenderStats {
@@ -122,6 +127,28 @@ fn pixel_stride(format: PixelFormat) -> usize {
         PixelFormat::Rgba8 => 4,
         PixelFormat::Rgba16Float => 8,
     }
+}
+
+fn push_lru_accounted<K, V, S, F>(
+    cache: &mut LruCache<K, V, S>,
+    current_bytes: &mut usize,
+    key: K,
+    value: V,
+    value_bytes: usize,
+    old_bytes: F,
+) -> bool
+where
+    K: Hash + Eq,
+    S: BuildHasher,
+    F: FnOnce(&V) -> usize,
+{
+    let evicted = cache.push(key, value);
+    let had_eviction = evicted.is_some();
+    if let Some((_, old)) = evicted {
+        *current_bytes = current_bytes.saturating_sub(old_bytes(&old));
+    }
+    *current_bytes = current_bytes.saturating_add(value_bytes);
+    had_eviction
 }
 
 #[repr(C)]
@@ -306,7 +333,12 @@ impl GpuRenderer {
     }
 
     pub fn stats(&self) -> GpuRenderStats {
-        self.stats
+        let mut stats = self.stats;
+        stats.upload_cache_entries = self.cpu_upload_cache.len();
+        stats.upload_cache_bytes = self.cpu_upload_cache_bytes;
+        stats.upload_cache_cap_bytes = self.cpu_upload_cache_cap_bytes;
+        stats.upload_cache_max_bytes = self.cpu_upload_cache_max_bytes;
+        stats
     }
 
     /// Drops reusable GPU allocations so a later required allocation, usually
@@ -315,8 +347,7 @@ impl GpuRenderer {
     pub fn release_cached_resources(&mut self) {
         self.vello_target = None;
         self.readback_staging = None;
-        self.cpu_upload_cache_cap_bytes = 0;
-        self.evict_upload_cache_to_fit(0);
+        self.clear_upload_cache();
     }
 
     fn reserve_render_vram(&mut self, bytes: usize) -> Option<BudgetReservation> {
@@ -333,7 +364,7 @@ impl GpuRenderer {
         }
 
         self.cpu_upload_cache_cap_bytes = 0;
-        self.evict_upload_cache_to_fit(0);
+        self.clear_upload_cache();
         let reservation = try_reserve_vram(bytes)?;
         self.note_vram_reserve_success();
         Some(reservation)
@@ -381,9 +412,19 @@ impl GpuRenderer {
                     self.stats.vram_cache_evictions =
                         self.stats.vram_cache_evictions.saturating_add(1);
                 }
-                None => break,
+                None => {
+                    self.cpu_upload_cache_bytes = 0;
+                    break;
+                }
             }
         }
+    }
+
+    fn clear_upload_cache(&mut self) {
+        let evicted = self.cpu_upload_cache.len() as u64;
+        self.cpu_upload_cache.clear();
+        self.cpu_upload_cache_bytes = 0;
+        self.stats.vram_cache_evictions = self.stats.vram_cache_evictions.saturating_add(evicted);
     }
 
     fn insert_upload_cache(&mut self, key: CpuUploadCacheKey, image: Arc<GpuBufferImage>) {
@@ -395,12 +436,16 @@ impl GpuRenderer {
         if self.cpu_upload_cache_bytes.saturating_add(bytes) > self.cpu_upload_cache_cap_bytes {
             return;
         }
-        if let Some(old) = self.cpu_upload_cache.put(key, image) {
-            self.cpu_upload_cache_bytes = self
-                .cpu_upload_cache_bytes
-                .saturating_sub(Self::buffer_image_bytes(&old));
+        if push_lru_accounted(
+            &mut self.cpu_upload_cache,
+            &mut self.cpu_upload_cache_bytes,
+            key,
+            image,
+            bytes,
+            |image| Self::buffer_image_bytes(image.as_ref()),
+        ) {
+            self.stats.vram_cache_evictions = self.stats.vram_cache_evictions.saturating_add(1);
         }
-        self.cpu_upload_cache_bytes = self.cpu_upload_cache_bytes.saturating_add(bytes);
     }
 
     fn buffer_image_bytes(image: &GpuBufferImage) -> usize {
@@ -1916,6 +1961,43 @@ mod tests {
 
     fn readback(gpu: &mut GpuRenderer, image: RasterImage) -> CpuRasterImage {
         GpuRasterBackend::readback(gpu, image).expect("GPU image should read back")
+    }
+
+    #[test]
+    fn accounted_lru_subtracts_capacity_evictions() {
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+        let mut bytes = 0usize;
+
+        assert!(!push_lru_accounted(
+            &mut cache,
+            &mut bytes,
+            1u8,
+            10usize,
+            10,
+            |v| *v
+        ));
+        assert!(!push_lru_accounted(
+            &mut cache,
+            &mut bytes,
+            2u8,
+            20usize,
+            20,
+            |v| *v
+        ));
+        assert_eq!(bytes, 30);
+
+        assert!(push_lru_accounted(
+            &mut cache,
+            &mut bytes,
+            3u8,
+            30usize,
+            30,
+            |v| *v
+        ));
+
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(&1).is_none());
+        assert_eq!(bytes, 50);
     }
 
     #[test]

--- a/tellur-renderer/src/render_context.rs
+++ b/tellur-renderer/src/render_context.rs
@@ -165,6 +165,16 @@ pub struct CacheMetrics {
     pub misses: u64,
     /// Bytes currently held by the cache.
     pub bytes_cached: usize,
+    /// Bytes currently held by cached GPU render entries.
+    pub gpu_cache_bytes: usize,
+    /// Current Tellur-managed VRAM allowance for cached GPU render entries.
+    pub gpu_cache_cap_bytes: usize,
+    /// Maximum Tellur-managed VRAM allowance the GPU render cache can grow back to.
+    pub gpu_cache_max_bytes: usize,
+    /// Process-wide Tellur-managed VRAM currently reserved.
+    pub vram_used_bytes: usize,
+    /// Configured process-wide Tellur-managed VRAM budget.
+    pub vram_budget_bytes: usize,
     /// Bytes released through LRU eviction (capacity-driven).
     pub bytes_evicted: u64,
     /// Misses where the freshly-produced image was not admitted
@@ -240,6 +250,19 @@ impl fmt::Display for CacheMetrics {
             self.gpu.readbacks,
             self.gpu.vram_reserve_failures,
             self.gpu.vram_cache_evictions,
+        )?;
+        writeln!(
+            f,
+            "VRAM   used {} / {}, render_cache {} / {} (max {}), upload_cache {} / {} ({} entries, max {})",
+            format_bytes(self.vram_used_bytes as u64),
+            format_bytes(self.vram_budget_bytes as u64),
+            format_bytes(self.gpu_cache_bytes as u64),
+            format_bytes(self.gpu_cache_cap_bytes as u64),
+            format_bytes(self.gpu_cache_max_bytes as u64),
+            format_bytes(self.gpu.upload_cache_bytes as u64),
+            format_bytes(self.gpu.upload_cache_cap_bytes as u64),
+            self.gpu.upload_cache_entries,
+            format_bytes(self.gpu.upload_cache_max_bytes as u64),
         )?;
         if !self.per_type.is_empty() {
             writeln!(f, "Cache by type (sorted by self_time, descending):")?;
@@ -464,6 +487,11 @@ impl CachingRenderContext {
             hits: self.hits,
             misses: self.misses,
             bytes_cached: self.cur_bytes,
+            gpu_cache_bytes: self.gpu_cache_bytes,
+            gpu_cache_cap_bytes: self.gpu_cache_cap_bytes,
+            gpu_cache_max_bytes: self.gpu_cache_max_bytes,
+            vram_used_bytes: vram_used_bytes(),
+            vram_budget_bytes: configured_vram_bytes(),
             bytes_evicted: self.bytes_evicted,
             pressure_skips: self.pressure_skips,
             oversize_skips: self.oversize_skips,
@@ -688,17 +716,26 @@ impl CachingRenderContext {
     }
 
     fn shrink_gpu_cache_budget(&mut self) {
+        self.shrink_gpu_cache_budget_for_pressure(0);
+    }
+
+    fn shrink_gpu_cache_budget_for_pressure(&mut self, needed: usize) {
         self.gpu_cache_spare_successes = 0;
         let old = self.gpu_cache_cap_bytes;
-        self.gpu_cache_cap_bytes =
+        let mut next =
             old.saturating_mul(GPU_CACHE_SHRINK_NUMERATOR) / GPU_CACHE_SHRINK_DENOMINATOR;
-        if old > 0 && self.gpu_cache_cap_bytes == old {
-            self.gpu_cache_cap_bytes = old - 1;
+        if old > 0 && next == old {
+            next = old - 1;
         }
+        let non_cache_vram = vram_used_bytes().saturating_sub(self.gpu_cache_bytes);
+        let pressure_cap =
+            configured_vram_bytes().saturating_sub(non_cache_vram.saturating_add(needed));
+        self.gpu_cache_cap_bytes = next.min(pressure_cap);
         self.evict_gpu_cache_to_fit(0);
     }
 
     fn evict_gpu_cache_until_vram_available(&mut self, needed: usize) {
+        self.shrink_gpu_cache_budget_for_pressure(needed);
         if vram_used_bytes().saturating_add(needed) <= configured_vram_bytes() {
             return;
         }


### PR DESCRIPTION
Stabilizes GPU cache behavior under VRAM pressure by fixing upload-cache byte accounting, shrinking render-cache allowance around readback headroom, and surfacing live diagnostics. 3 files (+270 / -17) across `tellur-renderer` and `tellur-live`.

## GPU cache budgets
- Track LRU capacity evictions in upload-cache byte accounting.
- Clear upload-cache bytes when releasing cached GPU resources.
- Shrink the render GPU cache cap against needed readback/critical VRAM headroom.

## Live diagnostics
- Add VRAM failure and cache eviction counters to frame headers and verbose logs.
- Surface render-cache, upload-cache, and VRAM budget usage in live diagnostics.

## Verification
- `cargo fmt --all`
- `nix develop -c cargo check -p tellur-renderer -p tellur-live`
- `nix develop -c cargo test -p tellur-renderer --lib`
- `nix develop -c cargo test -p tellur-live --lib`
