### PR TITLE
feat(core): add vector drawing primitives

### DIFF
--- a/tellur-core/src/clip.rs
+++ b/tellur-core/src/clip.rs
@@ -1,0 +1,283 @@
+//! [`Clip`]: restricts a child's paint to a region.
+//!
+//! `Clip` is layout-transparent (it reports the child's own size unchanged)
+//! but wraps the rendered output in a [`Node::ClipGroup`], so anything the
+//! child paints outside the region is cut away rather than merely excluded
+//! from `paint_bounds`.
+
+use crate::geometry::{Constraints, Rect, Transform, Vec2};
+use crate::vector::{ClipGroup, Node, PathCommand, VectorComponent, VectorGraphic};
+use crate::Keyable;
+
+/// The region a [`Clip`] restricts its child to: an axis-aligned rectangle,
+/// or an arbitrary path (filled with the nonzero winding rule, the same as
+/// any other filled path).
+///
+/// Construct with [`ClipRegion::rect`] / [`ClipRegion::path`], or pass a bare
+/// [`Rect`] to `Clip::builder().region(...)` — the common rectangular case
+/// converts automatically.
+#[derive(Debug, Clone, Keyable)]
+pub enum ClipRegion {
+    Rect(Rect),
+    Path(Vec<PathCommand>),
+}
+
+impl ClipRegion {
+    pub fn rect(rect: Rect) -> Self {
+        Self::Rect(rect)
+    }
+
+    pub fn path(commands: impl Into<Vec<PathCommand>>) -> Self {
+        Self::Path(commands.into())
+    }
+
+    /// The region's own bounding box, in the same local coordinate space the
+    /// clipped child paints in.
+    fn bounds(&self) -> Rect {
+        match self {
+            Self::Rect(rect) => *rect,
+            Self::Path(commands) => path_command_bounds(commands).unwrap_or(Rect {
+                origin: Vec2::ZERO,
+                size: Vec2::ZERO,
+            }),
+        }
+    }
+
+    /// The region expressed as path commands, ready for [`ClipGroup::commands`].
+    fn to_commands(&self) -> Vec<PathCommand> {
+        match self {
+            Self::Rect(rect) => rect_path_commands(*rect),
+            Self::Path(commands) => commands.clone(),
+        }
+    }
+}
+
+impl From<Rect> for ClipRegion {
+    fn from(rect: Rect) -> Self {
+        Self::Rect(rect)
+    }
+}
+
+/// Clips `child` to [`region`](Clip::region): the union of the region and the
+/// child's layout box is not painted outside the region's bounds.
+///
+/// Transparent to layout — `layout` and the reported size are exactly the
+/// child's own — so `Clip` only ever shrinks what is visible, never the
+/// space a parent reserves for it.
+#[crate::component(vector)]
+#[derive(Keyable)]
+pub struct Clip {
+    #[builder(into)]
+    pub region: ClipRegion,
+    #[builder(into)]
+    pub child: Box<dyn VectorComponent>,
+}
+
+impl VectorComponent for Clip {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        self.child.layout(constraints)
+    }
+
+    fn paint_bounds(&self, size: Vec2) -> Rect {
+        intersect_rect(self.region.bounds(), self.child.paint_bounds(size))
+    }
+
+    fn render(&self, size: Vec2) -> VectorGraphic {
+        let inner = self.child.render(size);
+        VectorGraphic {
+            view_box: self.paint_bounds(size),
+            root: Node::ClipGroup(ClipGroup {
+                commands: self.region.to_commands(),
+                transform: Transform::IDENTITY,
+                child: Box::new(inner.root),
+            }),
+        }
+    }
+}
+
+fn rect_path_commands(rect: Rect) -> Vec<PathCommand> {
+    let Rect {
+        origin: Vec2(x, y),
+        size: Vec2(w, h),
+    } = rect;
+    vec![
+        PathCommand::MoveTo(Vec2(x, y)),
+        PathCommand::LineTo(Vec2(x + w, y)),
+        PathCommand::LineTo(Vec2(x + w, y + h)),
+        PathCommand::LineTo(Vec2(x, y + h)),
+        PathCommand::Close,
+    ]
+}
+
+/// Bounding box of a path's on-curve and control points. For curves this is a
+/// conservative superset (a Bezier segment always lies within the convex hull
+/// of its control points), which is exactly what an intersection-based
+/// `paint_bounds` needs. `None` for an empty command list.
+fn path_command_bounds(commands: &[PathCommand]) -> Option<Rect> {
+    let mut min = Vec2(f32::INFINITY, f32::INFINITY);
+    let mut max = Vec2(f32::NEG_INFINITY, f32::NEG_INFINITY);
+    let mut found = false;
+    let mut include = |p: Vec2| {
+        min = Vec2(min.0.min(p.0), min.1.min(p.1));
+        max = Vec2(max.0.max(p.0), max.1.max(p.1));
+        found = true;
+    };
+    for &command in commands {
+        match command {
+            PathCommand::MoveTo(p) | PathCommand::LineTo(p) => include(p),
+            PathCommand::QuadTo { control, to } => {
+                include(control);
+                include(to);
+            }
+            PathCommand::CubicTo { c1, c2, to } => {
+                include(c1);
+                include(c2);
+                include(to);
+            }
+            PathCommand::Close => {}
+        }
+    }
+    found.then_some(Rect {
+        origin: min,
+        size: Vec2(max.0 - min.0, max.1 - min.1),
+    })
+}
+
+/// Largest rectangle contained in both `a` and `b`; zero-size (but not
+/// necessarily zero-origin) when they do not overlap.
+fn intersect_rect(a: Rect, b: Rect) -> Rect {
+    let a_end = Vec2(a.origin.0 + a.size.0, a.origin.1 + a.size.1);
+    let b_end = Vec2(b.origin.0 + b.size.0, b.origin.1 + b.size.1);
+    let origin = Vec2(a.origin.0.max(b.origin.0), a.origin.1.max(b.origin.1));
+    let end = Vec2(a_end.0.min(b_end.0), a_end.1.min(b_end.1));
+    Rect {
+        origin,
+        size: Vec2((end.0 - origin.0).max(0.0), (end.1 - origin.1).max(0.0)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::Color;
+    use crate::placement::VectorPlacement;
+    use crate::shapes::Rectangle;
+    use crate::vector::{Node, Paint};
+
+    fn rect(w: f32, h: f32) -> Rectangle {
+        Rectangle {
+            size: Vec2(w, h),
+            fill: Paint::Solid(Color::rgb_u8(10, 20, 30)).into(),
+            stroke: None,
+        }
+    }
+
+    #[test]
+    fn layout_passes_through_to_the_child_unchanged() {
+        let clip = Clip::builder()
+            .region(Rect {
+                origin: Vec2::ZERO,
+                size: Vec2(5.0, 5.0),
+            })
+            .child(rect(80.0, 40.0))
+            .build();
+        assert_eq!(clip.layout(Constraints::UNBOUNDED), Vec2(80.0, 40.0));
+    }
+
+    #[test]
+    fn render_wraps_the_child_in_a_clip_group() {
+        let clip = Clip::builder()
+            .region(Rect {
+                origin: Vec2(2.0, 2.0),
+                size: Vec2(6.0, 6.0),
+            })
+            .child(rect(10.0, 10.0))
+            .build();
+        let graphic = clip.render(Vec2(10.0, 10.0));
+        let Node::ClipGroup(group) = graphic.root else {
+            panic!("Clip should render a ClipGroup");
+        };
+        assert_eq!(
+            group.commands,
+            vec![
+                PathCommand::MoveTo(Vec2(2.0, 2.0)),
+                PathCommand::LineTo(Vec2(8.0, 2.0)),
+                PathCommand::LineTo(Vec2(8.0, 8.0)),
+                PathCommand::LineTo(Vec2(2.0, 8.0)),
+                PathCommand::Close,
+            ]
+        );
+        assert!(matches!(*group.child, Node::Path(_)));
+    }
+
+    #[test]
+    fn paint_bounds_is_the_intersection_of_region_and_child() {
+        // The clip rect only partially overlaps the (0,0)..(10,10) child box.
+        let clip = Clip::builder()
+            .region(Rect {
+                origin: Vec2(5.0, 2.0),
+                size: Vec2(20.0, 20.0),
+            })
+            .child(rect(10.0, 10.0))
+            .build();
+        assert_eq!(
+            clip.paint_bounds(Vec2(10.0, 10.0)),
+            Rect {
+                origin: Vec2(5.0, 2.0),
+                size: Vec2(5.0, 8.0),
+            }
+        );
+    }
+
+    #[test]
+    fn paint_bounds_is_empty_when_region_and_child_do_not_overlap() {
+        let clip = Clip::builder()
+            .region(Rect {
+                origin: Vec2(100.0, 100.0),
+                size: Vec2(5.0, 5.0),
+            })
+            .child(rect(10.0, 10.0))
+            .build();
+        let bounds = clip.paint_bounds(Vec2(10.0, 10.0));
+        assert_eq!(bounds.size, Vec2::ZERO);
+    }
+
+    #[test]
+    fn path_region_bounds_come_from_its_control_points() {
+        let clip = Clip::builder()
+            .region(ClipRegion::path(vec![
+                PathCommand::MoveTo(Vec2(1.0, 1.0)),
+                PathCommand::LineTo(Vec2(9.0, 1.0)),
+                PathCommand::CubicTo {
+                    c1: Vec2(9.0, 12.0),
+                    c2: Vec2(1.0, 12.0),
+                    to: Vec2(1.0, 9.0),
+                },
+                PathCommand::Close,
+            ]))
+            .child(rect(20.0, 20.0).place_at(Vec2::ZERO))
+            .build();
+        assert_eq!(
+            clip.paint_bounds(Vec2(20.0, 20.0)),
+            Rect {
+                origin: Vec2(1.0, 1.0),
+                size: Vec2(8.0, 11.0),
+            }
+        );
+    }
+
+    #[test]
+    fn placed_child_offset_is_reflected_in_render_size_pass_through() {
+        // Sanity check that Clip forwards the exact size a parent gives it —
+        // it must not silently reinterpret or clamp the child's dimensions.
+        let clip = Clip::builder()
+            .region(Rect {
+                origin: Vec2::ZERO,
+                size: Vec2(1000.0, 1000.0),
+            })
+            .child(rect(30.0, 15.0))
+            .build();
+        let child_size = clip.child.layout(Constraints::UNBOUNDED);
+        assert_eq!(clip.render(child_size).view_box.size, Vec2(30.0, 15.0));
+    }
+}

--- a/tellur-core/src/effect/write.rs
+++ b/tellur-core/src/effect/write.rs
@@ -614,6 +614,7 @@ fn write_stroke(path: &Path, fallback_stroke_width: f32) -> Option<Stroke> {
         .map(|fill| Stroke {
             paint: fill.paint.clone(),
             width: fallback_stroke_width,
+            dash: None,
         })
         .filter(|stroke| stroke.is_visible())
 }
@@ -1176,6 +1177,7 @@ mod tests {
             Some(Stroke {
                 paint: paint(),
                 width: DEFAULT_STROKE_WIDTH,
+                dash: None,
             })
         );
         assert_eq!(path.transform, Transform::IDENTITY);

--- a/tellur-core/src/lib.rs
+++ b/tellur-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod audio;
 pub mod builder;
 pub mod cache_budget;
+pub mod clip;
 pub mod color;
 pub mod composite;
 pub mod dyn_compare;

--- a/tellur-core/src/shapes.rs
+++ b/tellur-core/src/shapes.rs
@@ -6,6 +6,8 @@
 //! adapt if the parent imposes tight constraints — e.g. a `Circle` placed
 //! under tight non-square constraints renders as an ellipse.
 
+use std::f32::consts::{FRAC_PI_2, PI, TAU};
+
 use crate::geometry::{Constraints, Rect, Transform, Vec2};
 use crate::vector::{Fill, Node, Path, PathCommand, Stroke, VectorComponent, VectorGraphic};
 use crate::Keyable;
@@ -109,6 +111,223 @@ impl VectorComponent for Ellipse {
     }
 }
 
+/// A circular or elliptical arc from `start_angle` to `end_angle` (radians, in
+/// this project's y-down coordinate system: `0` points along +x, `-PI/2`
+/// points straight up, and the sweep runs clockwise on screen as the angle
+/// increases).
+///
+/// Traced as cubic Bezier segments split at most every 90° — the same
+/// technique [`Circle`] and [`Ellipse`] use for a full turn — so it is a
+/// genuine curve rather than a polyline approximation, and effects that walk
+/// path geometry (like [`Write`](crate::effect::Write)) work on it unchanged.
+///
+/// With a visible `fill`, the arc's chord is closed with a straight line
+/// (like SVG's implicit closepath-on-fill), producing a circular segment
+/// rather than a pie slice to the center. With `stroke` only, the path stays
+/// open — the two endpoints are not connected.
+#[crate::component(vector)]
+#[derive(Debug, Clone, Keyable)]
+pub struct Arc {
+    pub radius: f32,
+    pub start_angle: f32,
+    pub end_angle: f32,
+    #[builder(into)]
+    pub fill: Option<Fill>,
+    #[builder(into)]
+    pub stroke: Option<Stroke>,
+}
+
+impl VectorComponent for Arc {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        constraints.constrain(Vec2(self.radius * 2.0, self.radius * 2.0))
+    }
+
+    fn paint_bounds(&self, size: Vec2) -> Rect {
+        stroked_bounds(size, &self.stroke)
+    }
+
+    fn render(&self, size: Vec2) -> VectorGraphic {
+        let Some((fill, stroke)) = visible_paints(size, &self.fill, &self.stroke) else {
+            return empty_graphic(size);
+        };
+        let center = Vec2(size.0 * 0.5, size.1 * 0.5);
+        let radii = center;
+        let mut commands = arc_path_commands(center, radii, self.start_angle, self.end_angle);
+        if commands.is_empty() {
+            return empty_graphic(size);
+        }
+        if fill.is_some() {
+            commands.push(PathCommand::Close);
+        }
+        VectorGraphic {
+            view_box: stroked_bounds(size, &stroke),
+            root: Node::Path(Path {
+                commands,
+                fill,
+                stroke,
+                transform: Transform::IDENTITY,
+            }),
+        }
+    }
+}
+
+/// Which radius [`RegularPolygon`]'s `radius` parameter measures.
+#[derive(Debug, Clone, Copy, Keyable)]
+pub enum PolygonRadius {
+    /// Distance from the center to each vertex — the circumscribed circle.
+    Circumradius(f32),
+    /// Distance from the center to the midpoint of each edge — the inscribed
+    /// circle (also called the apothem).
+    Apothem(f32),
+}
+
+impl PolygonRadius {
+    pub fn circumradius(radius: f32) -> Self {
+        Self::Circumradius(radius)
+    }
+
+    pub fn apothem(radius: f32) -> Self {
+        Self::Apothem(radius)
+    }
+
+    /// Resolves to the circumradius for a polygon of `sides` sides.
+    fn resolve(self, sides: usize) -> f32 {
+        match self {
+            Self::Circumradius(r) => r,
+            Self::Apothem(r) => r / (PI / sides as f32).cos(),
+        }
+    }
+}
+
+/// A bare `f32` is a circumradius — the common case (`.radius(100.0)`).
+impl From<f32> for PolygonRadius {
+    fn from(circumradius: f32) -> Self {
+        Self::Circumradius(circumradius)
+    }
+}
+
+/// A regular polygon (equal sides and angles) inscribed in a circle.
+///
+/// `radius` accepts either [`PolygonRadius::circumradius`] (distance to each
+/// vertex) or [`PolygonRadius::apothem`] (distance to each edge's midpoint) —
+/// or a bare `f32`, which is shorthand for a circumradius. `rotation`
+/// defaults to `-PI/2`, putting a vertex straight up (a flat-bottomed
+/// triangle, a pointy-top hexagon, etc.).
+///
+/// Panics (in `layout`/`render`) if `sides < 3`.
+#[crate::component(vector)]
+#[derive(Debug, Clone, Keyable)]
+pub struct RegularPolygon {
+    pub sides: usize,
+    #[builder(into)]
+    pub radius: PolygonRadius,
+    #[builder(default = -FRAC_PI_2)]
+    pub rotation: f32,
+    #[builder(into)]
+    pub fill: Option<Fill>,
+    #[builder(into)]
+    pub stroke: Option<Stroke>,
+}
+
+impl VectorComponent for RegularPolygon {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        assert_valid_sides(self.sides);
+        let diameter = self.radius.resolve(self.sides) * 2.0;
+        constraints.constrain(Vec2(diameter, diameter))
+    }
+
+    fn paint_bounds(&self, size: Vec2) -> Rect {
+        stroked_bounds(size, &self.stroke)
+    }
+
+    fn render(&self, size: Vec2) -> VectorGraphic {
+        assert_valid_sides(self.sides);
+        let Some((fill, stroke)) = visible_paints(size, &self.fill, &self.stroke) else {
+            return empty_graphic(size);
+        };
+        let center = Vec2(size.0 * 0.5, size.1 * 0.5);
+        let radii = center;
+        let mut commands = Vec::with_capacity(self.sides + 1);
+        for i in 0..self.sides {
+            let angle = self.rotation + TAU * i as f32 / self.sides as f32;
+            let p = Vec2(
+                center.0 + radii.0 * angle.cos(),
+                center.1 + radii.1 * angle.sin(),
+            );
+            commands.push(if i == 0 {
+                PathCommand::MoveTo(p)
+            } else {
+                PathCommand::LineTo(p)
+            });
+        }
+        commands.push(PathCommand::Close);
+        VectorGraphic {
+            view_box: stroked_bounds(size, &stroke),
+            root: Node::Path(Path {
+                commands,
+                fill,
+                stroke,
+                transform: Transform::IDENTITY,
+            }),
+        }
+    }
+}
+
+fn assert_valid_sides(sides: usize) {
+    assert!(
+        sides >= 3,
+        "RegularPolygon requires at least 3 sides, got {sides}"
+    );
+}
+
+/// Draws an arbitrary set of [`PathCommand`]s over a fixed logical canvas.
+///
+/// `size` is both the `layout` size and the graphic's `view_box` — unlike the
+/// other shapes here, it is not auto-outset for the stroke width, since a
+/// caller-supplied path has no shape-specific bounds to derive an outset
+/// from. Size the canvas to fit whatever the path (and its stroke) paints.
+///
+/// This is the escape hatch for geometry the other shapes cannot express
+/// (freeform outlines, letter/glyph-style paths, etc.) without having to hand
+/// -write a `VectorComponent` impl.
+#[crate::component(vector)]
+#[derive(Debug, Clone, Keyable)]
+pub struct PathShape {
+    pub size: Vec2,
+    pub commands: Vec<PathCommand>,
+    #[builder(into)]
+    pub fill: Option<Fill>,
+    #[builder(into)]
+    pub stroke: Option<Stroke>,
+}
+
+impl VectorComponent for PathShape {
+    fn layout(&self, constraints: Constraints) -> Vec2 {
+        constraints.constrain(self.size)
+    }
+
+    fn render(&self, size: Vec2) -> VectorGraphic {
+        let Some((fill, stroke)) = visible_paints(size, &self.fill, &self.stroke) else {
+            return empty_graphic(size);
+        };
+        if self.commands.is_empty() {
+            return empty_graphic(size);
+        }
+        VectorGraphic {
+            view_box: Rect {
+                origin: Vec2::ZERO,
+                size,
+            },
+            root: Node::Path(Path {
+                commands: self.commands.clone(),
+                fill,
+                stroke,
+                transform: Transform::IDENTITY,
+            }),
+        }
+    }
+}
+
 // Magic constant for approximating a quarter-circle with a cubic Bezier:
 // 4 * (sqrt(2) - 1) / 3. The maximum error is around 0.027% of the radius.
 const KAPPA: f32 = 0.552_284_8;
@@ -205,6 +424,66 @@ fn ellipse_to_graphic(radii: Vec2, fill: Option<Fill>, stroke: Option<Stroke>) -
     }
 }
 
+/// A point on an ellipse centered at `center` with semi-axes `radii`, at
+/// `angle` radians (this project's y-down convention: `0` is +x, `-PI/2` is
+/// straight up).
+fn ellipse_point(center: Vec2, radii: Vec2, angle: f32) -> Vec2 {
+    Vec2(
+        center.0 + radii.0 * angle.cos(),
+        center.1 + radii.1 * angle.sin(),
+    )
+}
+
+/// Cubic-Bezier control points approximating the elliptical arc from `a0` to
+/// `a1` (should be at most 90° apart — [`arc_path_commands`] splits larger
+/// sweeps before calling this). `p0` is `ellipse_point(center, radii, a0)`;
+/// returns `(c1, c2, p1)`.
+///
+/// Generalizes the [`KAPPA`] control-point offset used above for a 90° quarter
+/// turn to an arbitrary sweep: `k = (4/3) * tan(sweep/4)` is the standard
+/// closed-form single-cubic approximation of a circular/elliptical arc.
+fn ellipse_arc_segment(center: Vec2, radii: Vec2, a0: f32, a1: f32) -> (Vec2, Vec2, Vec2) {
+    let p0 = ellipse_point(center, radii, a0);
+    let p1 = ellipse_point(center, radii, a1);
+    let k = (4.0 / 3.0) * ((a1 - a0) * 0.25).tan();
+    let c1 = Vec2(p0.0 - k * radii.0 * a0.sin(), p0.1 + k * radii.1 * a0.cos());
+    let c2 = Vec2(p1.0 + k * radii.0 * a1.sin(), p1.1 - k * radii.1 * a1.cos());
+    (c1, c2, p1)
+}
+
+/// Path commands for the elliptical arc from `start_angle` to `end_angle`
+/// (the sweep may be negative or exceed a full turn), split into at-most-90°
+/// cubic Bezier segments. Empty if the sweep is zero, non-finite, or the
+/// ellipse is degenerate. Does not close the path — callers append
+/// [`PathCommand::Close`] for a filled sector.
+fn arc_path_commands(
+    center: Vec2,
+    radii: Vec2,
+    start_angle: f32,
+    end_angle: f32,
+) -> Vec<PathCommand> {
+    let sweep = end_angle - start_angle;
+    if sweep == 0.0 || !sweep.is_finite() {
+        return Vec::new();
+    }
+    let segments = (sweep.abs() / FRAC_PI_2).ceil().max(1.0) as usize;
+    let step = sweep / segments as f32;
+    let mut commands = Vec::with_capacity(segments + 1);
+    commands.push(PathCommand::MoveTo(ellipse_point(
+        center,
+        radii,
+        start_angle,
+    )));
+    let mut angle = start_angle;
+    for _ in 0..segments {
+        let next_angle = angle + step;
+        let (c1, c2, to) = ellipse_arc_segment(center, radii, angle, next_angle);
+        commands.push(PathCommand::CubicTo { c1, c2, to });
+        angle = next_angle;
+    }
+    commands
+}
+
 #[cfg(test)]
 mod builder_tests {
     use super::*;
@@ -273,6 +552,7 @@ mod builder_tests {
             .stroke(Stroke {
                 paint: paint(),
                 width: 4.0,
+                dash: None,
             })
             .build();
         assert_eq!(
@@ -289,6 +569,7 @@ mod builder_tests {
         let stroke = Stroke {
             paint: paint(),
             width: 4.0,
+            dash: None,
         };
         let expected = Rect {
             origin: Vec2(-2.0, -2.0),
@@ -315,5 +596,216 @@ mod builder_tests {
                 size: Vec2(14.0, 14.0),
             }
         );
+    }
+
+    #[test]
+    fn arc_layout_matches_circle_diameter_square() {
+        let arc = Arc::builder()
+            .radius(5.0)
+            .start_angle(0.0)
+            .end_angle(FRAC_PI_2)
+            .stroke(Stroke::new(paint(), 1.0))
+            .build();
+        assert_eq!(arc.layout(Constraints::UNBOUNDED), Vec2(10.0, 10.0));
+    }
+
+    #[test]
+    fn arc_quarter_turn_is_a_single_cubic_segment() {
+        // A 90° sweep needs exactly one Bezier segment, matching the
+        // per-quadrant construction `Circle`/`Ellipse` use for a full turn.
+        let arc = Arc::builder()
+            .radius(5.0)
+            .start_angle(0.0)
+            .end_angle(FRAC_PI_2)
+            .stroke(Stroke::new(paint(), 1.0))
+            .build();
+        let Node::Path(path) = arc.render(Vec2(10.0, 10.0)).root else {
+            panic!("a stroked arc renders as a single path");
+        };
+        assert_eq!(path.commands.len(), 2, "{:?}", path.commands);
+        assert!(matches!(path.commands[0], PathCommand::MoveTo(_)));
+        assert!(matches!(path.commands[1], PathCommand::CubicTo { .. }));
+        // No fill: the chord must not be closed.
+        assert!(!path
+            .commands
+            .iter()
+            .any(|c| matches!(c, PathCommand::Close)));
+    }
+
+    #[test]
+    fn arc_half_turn_needs_two_segments() {
+        let arc = Arc::builder()
+            .radius(5.0)
+            .start_angle(0.0)
+            .end_angle(PI)
+            .stroke(Stroke::new(paint(), 1.0))
+            .build();
+        let Node::Path(path) = arc.render(Vec2(10.0, 10.0)).root else {
+            panic!("a stroked arc renders as a single path");
+        };
+        let cubic_count = path
+            .commands
+            .iter()
+            .filter(|c| matches!(c, PathCommand::CubicTo { .. }))
+            .count();
+        assert_eq!(cubic_count, 2);
+    }
+
+    #[test]
+    fn arc_with_fill_closes_the_chord() {
+        let arc = Arc::builder()
+            .radius(5.0)
+            .start_angle(0.0)
+            .end_angle(FRAC_PI_2)
+            .fill(paint())
+            .build();
+        let Node::Path(path) = arc.render(Vec2(10.0, 10.0)).root else {
+            panic!("a filled arc renders as a single path");
+        };
+        assert_eq!(path.commands.last(), Some(&PathCommand::Close));
+    }
+
+    #[test]
+    fn arc_zero_sweep_renders_no_ink() {
+        let arc = Arc::builder()
+            .radius(5.0)
+            .start_angle(0.3)
+            .end_angle(0.3)
+            .stroke(Stroke::new(paint(), 1.0))
+            .build();
+        assert_eq!(arc.render(Vec2(10.0, 10.0)).root, Node::empty());
+    }
+
+    #[test]
+    fn arc_write_on_reveals_a_partial_stroke() {
+        use crate::effect::VectorWrite;
+        use crate::phase::Phase;
+
+        let arc = Arc::builder()
+            .radius(5.0)
+            .start_angle(0.0)
+            .end_angle(PI)
+            .stroke(Stroke::new(paint(), 1.0))
+            .build();
+        let full = arc.clone().write_on(Phase::ONE).render(Vec2(10.0, 10.0));
+        assert_eq!(full, arc.render(Vec2(10.0, 10.0)));
+
+        let half = arc.write_on(Phase::HALF).render(Vec2(10.0, 10.0));
+        assert_ne!(half.root, Node::empty());
+        assert_ne!(half, full);
+    }
+
+    #[test]
+    fn regular_polygon_apothem_resolves_to_circumradius() {
+        // For a hexagon, circumradius = apothem / cos(PI/6).
+        let hexagon = RegularPolygon::builder()
+            .sides(6)
+            .radius(PolygonRadius::apothem(10.0))
+            .build();
+        let expected_diameter = 2.0 * 10.0 / (PI / 6.0).cos();
+        let size = hexagon.layout(Constraints::UNBOUNDED);
+        assert!((size.0 - expected_diameter).abs() < 0.001, "{size:?}");
+        assert_eq!(size.0, size.1);
+    }
+
+    #[test]
+    fn regular_polygon_bare_f32_radius_is_circumradius() {
+        let triangle = RegularPolygon::builder().sides(3).radius(10.0).build();
+        assert_eq!(triangle.layout(Constraints::UNBOUNDED), Vec2(20.0, 20.0));
+    }
+
+    #[test]
+    fn regular_polygon_default_rotation_points_a_vertex_up() {
+        let square = RegularPolygon::builder()
+            .sides(4)
+            .radius(10.0)
+            .stroke(Stroke::new(paint(), 1.0))
+            .build();
+        let Node::Path(path) = square.render(Vec2(20.0, 20.0)).root else {
+            panic!("a stroked polygon renders as a single path");
+        };
+        let Some(PathCommand::MoveTo(first)) = path.commands.first() else {
+            panic!("polygon path should start with MoveTo");
+        };
+        // Center (10, 10), radius 10: straight up is (10, 0).
+        assert!((first.0 - 10.0).abs() < 0.001, "{first:?}");
+        assert!((first.1 - 0.0).abs() < 0.001, "{first:?}");
+    }
+
+    #[test]
+    fn regular_polygon_closes_its_outline() {
+        let pentagon = RegularPolygon::builder()
+            .sides(5)
+            .radius(10.0)
+            .fill(paint())
+            .build();
+        let Node::Path(path) = pentagon.render(Vec2(20.0, 20.0)).root else {
+            panic!("a filled polygon renders as a single path");
+        };
+        assert_eq!(path.commands.len(), 6); // MoveTo + 4 LineTo + Close
+        assert_eq!(path.commands.last(), Some(&PathCommand::Close));
+    }
+
+    #[test]
+    #[should_panic(expected = "at least 3 sides")]
+    fn regular_polygon_rejects_fewer_than_three_sides() {
+        let degenerate = RegularPolygon::builder().sides(2).radius(10.0).build();
+        degenerate.layout(Constraints::UNBOUNDED);
+    }
+
+    #[test]
+    fn path_shape_layout_matches_declared_size() {
+        let shape = PathShape::builder()
+            .size(Vec2(40.0, 30.0))
+            .commands(vec![])
+            .build();
+        assert_eq!(shape.layout(Constraints::UNBOUNDED), Vec2(40.0, 30.0));
+    }
+
+    #[test]
+    fn path_shape_renders_the_given_commands_untouched() {
+        let commands = vec![
+            PathCommand::MoveTo(Vec2(0.0, 0.0)),
+            PathCommand::LineTo(Vec2(40.0, 0.0)),
+            PathCommand::LineTo(Vec2(20.0, 30.0)),
+            PathCommand::Close,
+        ];
+        let shape = PathShape::builder()
+            .size(Vec2(40.0, 30.0))
+            .commands(commands.clone())
+            .fill(paint())
+            .build();
+        let graphic = shape.render(Vec2(40.0, 30.0));
+        assert_eq!(
+            graphic.view_box,
+            Rect {
+                origin: Vec2::ZERO,
+                size: Vec2(40.0, 30.0),
+            }
+        );
+        let Node::Path(path) = graphic.root else {
+            panic!("PathShape renders as a single path");
+        };
+        assert_eq!(path.commands, commands);
+        assert_eq!(path.fill, Some(Fill { paint: paint() }));
+    }
+
+    #[test]
+    fn path_shape_with_no_commands_or_paint_renders_no_ink() {
+        let empty_commands = PathShape::builder()
+            .size(Vec2(10.0, 10.0))
+            .commands(vec![
+                PathCommand::MoveTo(Vec2::ZERO),
+                PathCommand::LineTo(Vec2(10.0, 10.0)),
+            ])
+            .build();
+        assert_eq!(empty_commands.render(Vec2(10.0, 10.0)).root, Node::empty());
+
+        let no_commands = PathShape::builder()
+            .size(Vec2(10.0, 10.0))
+            .commands(vec![])
+            .fill(paint())
+            .build();
+        assert_eq!(no_commands.render(Vec2(10.0, 10.0)).root, Node::empty());
     }
 }

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -332,6 +332,9 @@ impl Fill {
 pub struct Stroke {
     pub paint: Paint,
     pub width: f32,
+    /// Optional dash pattern (SVG `stroke-dasharray`/`stroke-dashoffset`
+    /// equivalent). `None` strokes solid.
+    pub dash: Option<DashPattern>,
 }
 
 impl Stroke {
@@ -339,12 +342,63 @@ impl Stroke {
         Self {
             paint: paint.into(),
             width,
+            dash: None,
         }
     }
 
     /// `true` iff this stroke can produce visible ink.
     pub fn is_visible(&self) -> bool {
         self.width > 0.0 && self.paint.is_visible()
+    }
+
+    /// Returns this stroke with the given dash pattern.
+    pub fn with_dash(mut self, dash: DashPattern) -> Self {
+        self.dash = Some(dash);
+        self
+    }
+}
+
+/// A dash pattern for [`Stroke`], mirroring SVG's `stroke-dasharray` /
+/// `stroke-dashoffset`: `lengths` alternates visible ("on") and gap ("off")
+/// run lengths in logical units, starting `offset` units into the pattern.
+///
+/// An odd number of lengths is a valid SVG dasharray (it is conceptually
+/// repeated once so the pattern still alternates on/off) — renderers should
+/// read the pattern through [`DashPattern::normalized_lengths`] rather than
+/// `lengths` directly, so they see the doubled, always-even sequence.
+#[derive(Debug, Clone, Keyable)]
+pub struct DashPattern {
+    pub lengths: Vec<f32>,
+    pub offset: f32,
+}
+
+impl DashPattern {
+    pub fn new(lengths: impl Into<Vec<f32>>, offset: f32) -> Self {
+        Self {
+            lengths: lengths.into(),
+            offset,
+        }
+    }
+
+    /// `lengths`, doubled if its length is odd (SVG's `stroke-dasharray`
+    /// rule) so the result always alternates on/off. `None` if the pattern
+    /// cannot draw any dashes: empty, containing a negative run length, or
+    /// summing to zero.
+    pub fn normalized_lengths(&self) -> Option<Vec<f32>> {
+        if self.lengths.is_empty() || self.lengths.iter().any(|&len| len < 0.0) {
+            return None;
+        }
+        let total: f32 = self.lengths.iter().sum();
+        if total <= 0.0 {
+            return None;
+        }
+        if self.lengths.len() % 2 == 0 {
+            Some(self.lengths.clone())
+        } else {
+            let mut doubled = self.lengths.clone();
+            doubled.extend_from_slice(&self.lengths);
+            Some(doubled)
+        }
     }
 }
 
@@ -405,7 +459,11 @@ impl From<Color> for Option<Fill> {
 impl From<Paint> for Stroke {
     fn from(paint: Paint) -> Self {
         // Default stroke width mirrors SVG's `stroke-width="1"`.
-        Self { paint, width: 1.0 }
+        Self {
+            paint,
+            width: 1.0,
+            dash: None,
+        }
     }
 }
 
@@ -461,6 +519,7 @@ mod tests {
             Some(Stroke {
                 paint: Paint::Solid(color),
                 width: 1.0,
+                dash: None,
             })
         );
     }
@@ -601,5 +660,59 @@ mod tests {
         };
         assert!(path.fill.is_none());
         assert!(path.stroke.is_some());
+    }
+
+    #[test]
+    fn stroke_new_has_no_dash() {
+        let stroke = Stroke::new(Color::rgb_u8(0, 0, 0), 2.0);
+        assert_eq!(stroke.dash, None);
+
+        let dashed = stroke.with_dash(DashPattern::new(vec![4.0, 2.0], 0.0));
+        assert!(dashed.dash.is_some());
+    }
+
+    #[test]
+    fn even_length_dash_pattern_is_unchanged() {
+        let dash = DashPattern::new(vec![4.0, 2.0, 1.0, 2.0], 0.0);
+        assert_eq!(dash.normalized_lengths(), Some(vec![4.0, 2.0, 1.0, 2.0]));
+    }
+
+    #[test]
+    fn odd_length_dash_pattern_is_doubled() {
+        // SVG's `stroke-dasharray` rule: an odd count is conceptually
+        // repeated once so the pattern still alternates on/off.
+        let dash = DashPattern::new(vec![18.0], 0.0);
+        assert_eq!(dash.normalized_lengths(), Some(vec![18.0, 18.0]));
+
+        let dash = DashPattern::new(vec![10.0, 5.0, 3.0], 0.0);
+        assert_eq!(
+            dash.normalized_lengths(),
+            Some(vec![10.0, 5.0, 3.0, 10.0, 5.0, 3.0])
+        );
+    }
+
+    #[test]
+    fn degenerate_dash_patterns_normalize_to_none() {
+        assert_eq!(DashPattern::new(vec![], 0.0).normalized_lengths(), None);
+        assert_eq!(
+            DashPattern::new(vec![0.0, 0.0], 0.0).normalized_lengths(),
+            None
+        );
+        assert_eq!(
+            DashPattern::new(vec![-1.0, 2.0], 0.0).normalized_lengths(),
+            None
+        );
+    }
+
+    #[test]
+    fn strokes_with_different_dash_patterns_compare_unequal() {
+        let solid = Stroke::new(Color::rgb_u8(0, 0, 0), 2.0);
+        let dashed = solid
+            .clone()
+            .with_dash(DashPattern::new(vec![4.0, 2.0], 0.0));
+        assert_ne!(solid, dashed);
+
+        let same_dash = solid.with_dash(DashPattern::new(vec![4.0, 2.0], 0.0));
+        assert_eq!(dashed, same_dash);
     }
 }

--- a/tellur-live/examples/demo_scene/overture.rs
+++ b/tellur-live/examples/demo_scene/overture.rs
@@ -135,6 +135,7 @@ pub fn Overture(time: LocalTime, palette: Palette) -> impl VectorComponent {
                 .stroke(Stroke {
                     paint: p.pink.with_alpha(hero_life * 0.82).into(),
                     width: 3.0,
+                    dash: None,
                 })
                 .transform_around(
                     Anchor::CENTER,

--- a/tellur-live/examples/timeline_showcase.rs
+++ b/tellur-live/examples/timeline_showcase.rs
@@ -125,6 +125,7 @@ fn stroke_rect(cx: f32, cy: f32, w: f32, h: f32, c: Color, width: f32) -> Positi
         .stroke(Stroke {
             paint: Paint::Solid(c),
             width,
+            dash: None,
         })
         .place_at(Vec2(cx - w * 0.5, cy - h * 0.5))
 }
@@ -144,6 +145,7 @@ fn stroke_circle(cx: f32, cy: f32, r: f32, c: Color, width: f32) -> Positioned {
         .stroke(Stroke {
             paint: Paint::Solid(c),
             width,
+            dash: None,
         })
         .place_at(Vec2(cx - r, cy - r))
 }

--- a/tellur-macros/src/keyable.rs
+++ b/tellur-macros/src/keyable.rs
@@ -301,7 +301,7 @@ fn eq_for(ty: &Type, a: &TokenStream2, b: &TokenStream2) -> TokenStream2 {
         return quote!( #a == #b );
     }
     match classify(ty) {
-        Shape::Float(_) => quote!( #a.to_bits() == #b.to_bits() ),
+        Shape::Float(_) => quote!( (#a).to_bits() == (#b).to_bits() ),
         Shape::Opt(inner) => {
             let inner = eq_for(inner, &quote!(__a), &quote!(__b));
             quote!(
@@ -314,9 +314,15 @@ fn eq_for(ty: &Type, a: &TokenStream2, b: &TokenStream2) -> TokenStream2 {
         }
         Shape::Seq(inner) => {
             let inner = eq_for(inner, &quote!(__a), &quote!(__b));
+            // `a`/`b` may themselves be a `&expr` token stream (e.g. the
+            // struct-level `&self.field`), so parenthesize before chaining a
+            // method call — an unparenthesized `#a.iter()` splices to
+            // `&self.field.iter()`, which parses as `&(self.field.iter())`
+            // (method calls bind tighter than a prefix `&`) instead of
+            // `(&self.field).iter()`.
             quote!(
-                #a.len() == #b.len()
-                    && #a.iter().zip(#b.iter()).all(|(__a, __b)| #inner)
+                (#a).len() == (#b).len()
+                    && (#a).iter().zip((#b).iter()).all(|(__a, __b)| #inner)
             )
         }
         Shape::Tuple(elems) => {
@@ -359,9 +365,13 @@ fn hash_for(ty: &Type, v: &TokenStream2, state: &TokenStream2) -> TokenStream2 {
         }
         Shape::Seq(inner) => {
             let inner = hash_for(inner, &quote!(__v), state);
+            // See the matching note in `eq_for`'s `Shape::Seq` arm: `v` must
+            // be parenthesized before `.len()`/`.iter()` or an unparenthesized
+            // `&self.field.iter()` parses as `&(self.field.iter())` — a
+            // reference to an iterator, which is not itself an `Iterator`.
             quote!(
-                ::core::hash::Hash::hash(&#v.len(), #state);
-                for __v in #v.iter() { #inner }
+                ::core::hash::Hash::hash(&(#v).len(), #state);
+                for __v in (#v).iter() { #inner }
             )
         }
         Shape::Tuple(elems) => {

--- a/tellur-renderer/src/gpu.rs
+++ b/tellur-renderer/src/gpu.rs
@@ -14,7 +14,8 @@ use tellur_core::render_context::{
     CompositeInput, DropShadowInput, GpuRasterBackend, OutlineInput,
 };
 use tellur_core::vector::{
-    ClipGroup as TellurClipGroup, Node, Paint, Path as TellurPath, PathCommand, VectorGraphic,
+    ClipGroup as TellurClipGroup, DashPattern, Node, Paint, Path as TellurPath, PathCommand,
+    VectorGraphic,
 };
 use vello::kurbo::{Affine, BezPath, Rect as VelloRect, Stroke as VelloStroke};
 use wgpu::util::DeviceExt;
@@ -1417,18 +1418,28 @@ fn encode_vello_path(
     if let Some(stroke) = &path.stroke {
         if stroke.width > 0.0 {
             if let Some(paint) = to_vello_color(&stroke.paint, opacity) {
-                scene.stroke(
-                    &VelloStroke::new(stroke.width as f64),
-                    transform,
-                    paint,
-                    None,
-                    &vello_path,
-                );
+                let vello_stroke =
+                    apply_dash(VelloStroke::new(stroke.width as f64), stroke.dash.as_ref());
+                scene.stroke(&vello_stroke, transform, paint, None, &vello_path);
             }
         }
     }
 
     Some(())
+}
+
+/// Applies a [`DashPattern`] to a [`VelloStroke`], mirroring
+/// `rasterize.rs`'s `to_skia_dash` so the GPU (vello) and CPU (tiny-skia)
+/// backends draw identical dashes. `None`/an unusable pattern (see
+/// [`DashPattern::normalized_lengths`]) leaves the stroke solid.
+fn apply_dash(stroke: VelloStroke, dash: Option<&DashPattern>) -> VelloStroke {
+    let Some(dash) = dash else {
+        return stroke;
+    };
+    let Some(lengths) = dash.normalized_lengths() else {
+        return stroke;
+    };
+    stroke.with_dashes(dash.offset as f64, lengths.into_iter().map(f64::from))
 }
 
 fn build_vello_path(commands: &[PathCommand]) -> Option<BezPath> {
@@ -2459,6 +2470,7 @@ mod tests {
                                 stroke: Some(Stroke {
                                     paint: Paint::Solid(Color::rgba_u8(0, 0, 0, 255)),
                                     width: 4.0,
+                                    dash: None,
                                 }),
                                 transform: Transform::IDENTITY,
                             })),

--- a/tellur-renderer/src/rasterize.rs
+++ b/tellur-renderer/src/rasterize.rs
@@ -4,7 +4,9 @@ use tellur_core::color::Color;
 use tellur_core::geometry::{Constraints, Rect, Transform, Vec2};
 use tellur_core::raster::{PixelFormat, RasterComponent, RasterImage, Resolution};
 use tellur_core::render_context::RenderContext;
-use tellur_core::vector::{Node, Paint, Path, PathCommand, VectorComponent, VectorGraphic};
+use tellur_core::vector::{
+    DashPattern, Node, Paint, Path, PathCommand, VectorComponent, VectorGraphic,
+};
 
 /// A `RasterComponent` that rasterizes a `VectorComponent`. The layout
 /// protocol forwards to the wrapped vector: layout / paint_bounds /
@@ -224,10 +226,20 @@ fn render_path(pixmap: &mut tiny_skia::Pixmap, path: &Path, xform: tiny_skia::Tr
         apply_paint(&mut paint, &stroke.paint);
         let skia_stroke = tiny_skia::Stroke {
             width: stroke.width,
+            dash: to_skia_dash(stroke.dash.as_ref()),
             ..Default::default()
         };
         pixmap.stroke_path(&skia_path, &paint, &skia_stroke, xform, None);
     }
+}
+
+/// Converts a [`DashPattern`] to tiny-skia's stroke-time dashing. `None` both
+/// when there is no pattern and when the pattern cannot draw any dashes (see
+/// [`DashPattern::normalized_lengths`]) — either way the stroke draws solid.
+fn to_skia_dash(dash: Option<&DashPattern>) -> Option<tiny_skia::StrokeDash> {
+    let dash = dash?;
+    let lengths = dash.normalized_lengths()?;
+    tiny_skia::StrokeDash::new(lengths, dash.offset)
 }
 
 fn build_skia_path(commands: &[PathCommand]) -> Option<tiny_skia::Path> {
@@ -271,3 +283,102 @@ fn to_skia_transform(t: &Transform) -> tiny_skia::Transform {
 
 // The compile-time dyn-safety guarantee for `Rasterize` is covered by the
 // `const _: Option<&dyn RasterComponent> = None;` assertion in `RasterComponent`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tellur_core::geometry::Rect;
+
+    fn alpha_at(image: &RasterImage, x: u32, y: u32, width: u32) -> u8 {
+        let cpu = image
+            .as_cpu()
+            .expect("rasterize() always returns a CPU image");
+        cpu.pixels[((y * width + x) * 4 + 3) as usize]
+    }
+
+    #[test]
+    fn to_skia_dash_is_none_without_a_pattern() {
+        assert!(to_skia_dash(None).is_none());
+    }
+
+    #[test]
+    fn to_skia_dash_is_none_for_a_degenerate_pattern() {
+        let dash = DashPattern::new(vec![0.0, 0.0], 0.0);
+        assert!(to_skia_dash(Some(&dash)).is_none());
+    }
+
+    #[test]
+    fn to_skia_dash_builds_from_a_valid_pattern() {
+        let dash = DashPattern::new(vec![4.0, 4.0], 0.0);
+        assert!(to_skia_dash(Some(&dash)).is_some());
+    }
+
+    #[test]
+    fn dashed_stroke_leaves_gaps_along_the_line() {
+        // 4-on/4-off dashes along a horizontal line spanning the full
+        // 20x10 view box (1 logical unit == 1 pixel, so sampled x positions
+        // land squarely inside a dash or a gap).
+        let stroke = tellur_core::vector::Stroke {
+            paint: Paint::Solid(Color::rgba_u8(0, 0, 0, 255)),
+            width: 2.0,
+            dash: Some(DashPattern::new(vec![4.0, 4.0], 0.0)),
+        };
+        let graphic = VectorGraphic {
+            view_box: Rect {
+                origin: Vec2::ZERO,
+                size: Vec2(20.0, 10.0),
+            },
+            root: Node::Path(Path {
+                commands: vec![
+                    PathCommand::MoveTo(Vec2(0.0, 5.0)),
+                    PathCommand::LineTo(Vec2(20.0, 5.0)),
+                ],
+                fill: None,
+                stroke: Some(stroke),
+                transform: Transform::IDENTITY,
+            }),
+        };
+
+        let image = rasterize(&graphic, 20, 10);
+        assert!(
+            alpha_at(&image, 2, 5, 20) > 0,
+            "x=2 sits inside the first dash (0..4)"
+        );
+        assert_eq!(
+            alpha_at(&image, 6, 5, 20),
+            0,
+            "x=6 sits inside the first gap (4..8)"
+        );
+        assert!(
+            alpha_at(&image, 10, 5, 20) > 0,
+            "x=10 sits inside the second dash (8..12)"
+        );
+    }
+
+    #[test]
+    fn undashed_stroke_paints_the_whole_line() {
+        let stroke = tellur_core::vector::Stroke {
+            paint: Paint::Solid(Color::rgba_u8(0, 0, 0, 255)),
+            width: 2.0,
+            dash: None,
+        };
+        let graphic = VectorGraphic {
+            view_box: Rect {
+                origin: Vec2::ZERO,
+                size: Vec2(20.0, 10.0),
+            },
+            root: Node::Path(Path {
+                commands: vec![
+                    PathCommand::MoveTo(Vec2(0.0, 5.0)),
+                    PathCommand::LineTo(Vec2(20.0, 5.0)),
+                ],
+                fill: None,
+                stroke: Some(stroke),
+                transform: Transform::IDENTITY,
+            }),
+        };
+
+        let image = rasterize(&graphic, 20, 10);
+        assert!(alpha_at(&image, 6, 5, 20) > 0, "a solid stroke has no gaps");
+    }
+}


### PR DESCRIPTION
Adds the drawing vocabulary the shorts videos had been hand-rolling: `Arc`, `RegularPolygon`, and `PathShape` shapes, a `Clip` container, and dash patterns on `Stroke`, plus a latent `Keyable` derive fix they exposed. 10 files (+1042 / -15) across `tellur-core`, `tellur-macros`, `tellur-renderer`, and `tellur-live`.

## Shapes and clipping
- Add `Arc` (Bezier-approximated, write-on compatible) and `RegularPolygon` (circumradius/apothem via `PolygonRadius`).
- Add `PathShape` for arbitrary `PathCommand` lists with an explicit view box.
- Add `Clip`, wrapping its child in a `Node::ClipGroup` (rect or path region).

## Dashed strokes
- Add `DashPattern` on `Stroke` (SVG `stroke-dasharray`/`stroke-dashoffset` semantics, odd-length doubling).
- Apply dashes natively in both backends (tiny-skia `StrokeDash`, vello `with_dashes`), after write-on trimming.

## Keyable macro fix
- Parenthesize spliced field access in seq codegen so `Vec<f32>` fields compile.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p tellur-core` / `cargo test -p tellur-renderer --lib`
- `cargo check --workspace`
