### PR TITLE
feat(core): add event windows, cubic-bezier easing, and time box

### DIFF
--- a/tellur-core/src/easing.rs
+++ b/tellur-core/src/easing.rs
@@ -24,7 +24,12 @@ use crate::window::Window;
 /// An easing curve as a value. Each variant names one of the
 /// [`PhaseEasing`] methods; [`Easing::factor`] evaluates the raw curve and
 /// [`Phase::eased`] applies it within the unit interval.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// Derives [`crate::Keyable`] rather than the stock `PartialEq`/`Eq`/`Hash`:
+/// [`Easing::CubicBezier`] carries `f32` control points, and floats implement
+/// neither trait (`NaN != NaN`), so the derive compares/hashes every variant
+/// by bit pattern instead (the same treatment `Window` and `TriggerKind` get).
+#[derive(Debug, Clone, Copy, crate::Keyable)]
 pub enum Easing {
     /// No curve — the identity.
     Linear,
@@ -42,6 +47,14 @@ pub enum Easing {
     InBack,
     /// Elastic ease-out. Overshoots above `1.0` for "spring snap" motion.
     OutElastic,
+    /// A CSS-style `cubic-bezier(x1, y1, x2, y2)` curve: the cubic Bézier
+    /// through `(0, 0)`, `(x1, y1)`, `(x2, y2)`, `(1, 1)`, sampled by solving
+    /// for the Bézier parameter at the given `x` (Newton's method with a
+    /// bisection fallback). `x1`/`x2` are expected in `[0.0, 1.0]` so the
+    /// curve is a function of `x` (monotonic on that axis); `y1`/`y2` are
+    /// unconstrained, so, like [`Easing::InBack`] / [`Easing::OutElastic`],
+    /// this curve can overshoot `[0.0, 1.0]` when they fall outside it.
+    CubicBezier { x1: f32, y1: f32, x2: f32, y2: f32 },
 }
 
 impl Easing {
@@ -89,8 +102,82 @@ impl Easing {
                     2.0_f32.powf(-10.0 * x) * ((x * 10.0 - 0.75) * c4).sin() + 1.0
                 }
             }
+            Easing::CubicBezier { x1, y1, x2, y2 } => cubic_bezier(x, x1, y1, x2, y2),
         }
     }
+}
+
+/// Samples a CSS-style `cubic-bezier(x1, y1, x2, y2)` curve at `x`: solves
+/// the Bézier parameter `t` such that `bezier_axis(t, x1, x2) == x`, then
+/// evaluates the Y axis at that `t`. `x` is clamped to `[0.0, 1.0]` first, so
+/// the search always has a root (`x1`/`x2` are expected in that range, which
+/// keeps the X axis monotonic in `t`).
+///
+/// The root-find is 8 rounds of Newton's method — fast, but it can jump
+/// outside the current bracket for a flat slope — falling back to 12 rounds
+/// of bisection using whichever bracket Newton narrowed to, exactly the
+/// ported approach (same iteration counts and the same `1e-6` thresholds).
+fn cubic_bezier(x: f32, x1: f32, y1: f32, x2: f32, y2: f32) -> f32 {
+    let x = x.clamp(0.0, 1.0);
+    if x == 0.0 || x == 1.0 {
+        return x;
+    }
+
+    let mut lower = 0.0;
+    let mut upper = 1.0;
+    let mut t = x;
+
+    for _ in 0..8 {
+        let curve_x = cubic_bezier_axis(t, x1, x2);
+        if curve_x < x {
+            lower = t;
+        } else {
+            upper = t;
+        }
+
+        let slope = cubic_bezier_axis_derivative(t, x1, x2);
+        if slope.abs() < 1e-6 {
+            break;
+        }
+
+        let next = t - (curve_x - x) / slope;
+        if next <= lower || next >= upper {
+            break;
+        }
+
+        t = next;
+    }
+
+    for _ in 0..12 {
+        let curve_x = cubic_bezier_axis(t, x1, x2);
+        if (curve_x - x).abs() < 1e-6 {
+            break;
+        }
+
+        if curve_x < x {
+            lower = t;
+        } else {
+            upper = t;
+        }
+        t = (lower + upper) * 0.5;
+    }
+
+    cubic_bezier_axis(t, y1, y2)
+}
+
+/// One axis of the cubic Bézier through `(0, 0)`, `(p1, p2)` control points
+/// tied to a shared parameter `t`, `(1, 1)` — the standard cubic Bézier
+/// formula specialized to endpoints pinned at `0` and `1`.
+fn cubic_bezier_axis(t: f32, p1: f32, p2: f32) -> f32 {
+    let inv = 1.0 - t;
+    3.0 * inv * inv * t * p1 + 3.0 * inv * t * t * p2 + t * t * t
+}
+
+/// Derivative of [`cubic_bezier_axis`] with respect to `t`, driving the
+/// Newton step in [`cubic_bezier`].
+fn cubic_bezier_axis_derivative(t: f32, p1: f32, p2: f32) -> f32 {
+    let inv = 1.0 - t;
+    3.0 * inv * inv * p1 + 6.0 * inv * t * (p2 - p1) + 3.0 * t * t * (1.0 - p2)
 }
 
 impl Phase {
@@ -106,6 +193,22 @@ impl Phase {
     /// [`PhaseEasing::ease_out_elastic`]).
     pub fn eased(self, easing: Easing) -> Phase {
         Phase::saturating(easing.factor(self))
+    }
+
+    /// Eases through a CSS-style `cubic-bezier(x1, y1, x2, y2)` curve
+    /// straight into the `(from, to)` value range — the direct-range twin of
+    /// [`Easing::CubicBezier`], preserving overshoot the same way
+    /// [`PhaseEasing::ease_out_elastic`] does (an out-of-range `y1`/`y2` is
+    /// not clamped).
+    ///
+    /// Not a [`PhaseEasing`] method: every method there shares the
+    /// `(self, from, to)` shape because each names one fully-fixed curve: a
+    /// cubic-bezier curve additionally needs its four control points from
+    /// the caller, which does not fit that uniform shape. This lives on
+    /// `Phase` directly instead of forcing a mismatched arity onto the
+    /// trait.
+    pub fn ease_bezier(self, x1: f32, y1: f32, x2: f32, y2: f32, from: f32, to: f32) -> f32 {
+        lerp_unbounded(from, to, cubic_bezier(self.get(), x1, y1, x2, y2))
     }
 }
 
@@ -314,5 +417,116 @@ mod tests {
         let v = Vec2(0.0, 0.0).interpolate(Vec2(10.0, 20.0), p);
         assert_near(v.0, 8.75);
         assert_near(v.1, 17.5);
+    }
+
+    #[test]
+    fn cubic_bezier_hits_endpoints() {
+        let curve = Easing::CubicBezier {
+            x1: 0.25,
+            y1: 0.1,
+            x2: 0.25,
+            y2: 1.0,
+        };
+        assert_near(curve.factor(Phase::ZERO), 0.0);
+        assert_near(curve.factor(Phase::ONE), 1.0);
+    }
+
+    #[test]
+    fn cubic_bezier_identity_control_points_are_linear() {
+        // cubic-bezier(0, 0, 1, 1) traces the diagonal, i.e. the identity.
+        let curve = Easing::CubicBezier {
+            x1: 0.0,
+            y1: 0.0,
+            x2: 1.0,
+            y2: 1.0,
+        };
+        for x in [0.0, 0.2, 0.5, 0.75, 1.0] {
+            let p = Phase::new(x).unwrap();
+            assert_near(curve.factor(p), x);
+        }
+    }
+
+    #[test]
+    fn cubic_bezier_matches_ported_reference_curve() {
+        // `summon_ease` from the ported source
+        // (movies/202606/shorts_sqrt2_plus_sqrt3/src/explanation.rs) is
+        // `cubic_bezier(progress, 0.76, 0.0, 0.0, 0.93)`; this pins the port
+        // to a value computed independently from that same formula.
+        let curve = Easing::CubicBezier {
+            x1: 0.76,
+            y1: 0.0,
+            x2: 0.0,
+            y2: 0.93,
+        };
+        assert_near(curve.factor(Phase::HALF), 0.775_318_4);
+    }
+
+    #[test]
+    fn cubic_bezier_can_overshoot_like_back_and_elastic() {
+        // A back-style bezier (control points borrowed from the common
+        // "easeInOutBack" approximation) dips below 0 before rising, the
+        // same overshoot shape as `Easing::InBack`.
+        let curve = Easing::CubicBezier {
+            x1: 0.68,
+            y1: -0.55,
+            x2: 0.265,
+            y2: 1.55,
+        };
+        assert!(curve.factor(Phase::new(0.1).unwrap()) < 0.0);
+    }
+
+    #[test]
+    fn ease_bezier_preserves_overshoot_into_the_value_range() {
+        let p = Phase::new(0.1).unwrap();
+        assert!(p.ease_bezier(0.68, -0.55, 0.265, 1.55, 0.0, 1.0) < 0.0);
+        assert!(p.ease_bezier(0.68, -0.55, 0.265, 1.55, 80.0, 300.0) < 80.0);
+    }
+
+    #[test]
+    fn eased_cubic_bezier_saturates_overshoot() {
+        // Mirrors `eased_saturates_overshoot_curves`: the raw factor dips
+        // below 0, but `Phase::eased` clamps it back into the unit interval.
+        let curve = Easing::CubicBezier {
+            x1: 0.68,
+            y1: -0.55,
+            x2: 0.265,
+            y2: 1.55,
+        };
+        let p = Phase::new(0.1).unwrap();
+        assert!(curve.factor(p) < 0.0);
+        assert_eq!(p.eased(curve).get(), 0.0);
+    }
+
+    #[test]
+    fn cubic_bezier_variants_are_keyable_by_bit_pattern() {
+        let a = Easing::CubicBezier {
+            x1: 0.25,
+            y1: 0.1,
+            x2: 0.25,
+            y2: 1.0,
+        };
+        let b = a;
+        assert_eq!(a, b);
+
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let hash_of = |e: Easing| {
+            let mut s = DefaultHasher::new();
+            e.hash(&mut s);
+            s.finish()
+        };
+        assert_eq!(hash_of(a), hash_of(b));
+
+        let different = Easing::CubicBezier {
+            x1: 0.26,
+            y1: 0.1,
+            x2: 0.25,
+            y2: 1.0,
+        };
+        assert_ne!(a, different);
+
+        // Distinct variants (same underlying discriminant-free shape as
+        // enums without payload) must still compare unequal.
+        assert_ne!(a, Easing::Linear);
     }
 }

--- a/tellur-core/src/interpolate.rs
+++ b/tellur-core/src/interpolate.rs
@@ -13,6 +13,7 @@
 //! ease a typed interpolation, reshape the Phase first via
 //! [`Phase::eased`]: `a.interpolate(b, p.eased(Easing::OutCubic))`.
 
+use crate::color::Color;
 use crate::geometry::{Anchor, Vec2};
 use crate::phase::Phase;
 
@@ -45,6 +46,23 @@ impl Interpolate for Anchor {
             self.rx.interpolate(other.rx, p),
             self.ry.interpolate(other.ry, p),
         )
+    }
+}
+
+/// Straight per-channel lerp in sRGB space (the same numbers [`Color`]
+/// already stores) — NOT a linear-light blend. Mixing in sRGB is what a
+/// hand-rolled `r + (other.r - r) * t` lerp does, so this matches every
+/// existing manual color lerp in the codebase byte-for-byte; it does not
+/// convert to linear light and back the way a "physically correct" color
+/// mix would.
+impl Interpolate for Color {
+    fn interpolate(self, other: Self, p: Phase) -> Self {
+        Color {
+            r: self.r.interpolate(other.r, p),
+            g: self.g.interpolate(other.g, p),
+            b: self.b.interpolate(other.b, p),
+            a: self.a.interpolate(other.a, p),
+        }
     }
 }
 
@@ -98,5 +116,53 @@ mod tests {
         // Halfway between left-center and right-center should be CENTER.
         let mid = Anchor::CENTER_LEFT.interpolate(Anchor::CENTER_RIGHT, Phase::HALF);
         assert_eq!(mid, Anchor::CENTER);
+    }
+
+    #[test]
+    fn color_endpoints() {
+        let a = Color::rgba_u8(0, 0, 0, 0);
+        let b = Color::rgba_u8(255, 255, 255, 255);
+        assert_eq!(a.interpolate(b, Phase::ZERO), a);
+        assert_eq!(a.interpolate(b, Phase::ONE), b);
+    }
+
+    #[test]
+    fn color_componentwise_midpoint_includes_alpha() {
+        let a = Color {
+            r: 0.0,
+            g: 0.2,
+            b: 1.0,
+            a: 0.0,
+        };
+        let b = Color {
+            r: 1.0,
+            g: 0.8,
+            b: 0.0,
+            a: 1.0,
+        };
+        let mid = a.interpolate(b, Phase::HALF);
+        assert_eq!(mid.r, 0.5);
+        assert_eq!(mid.g, 0.5);
+        assert_eq!(mid.b, 0.5);
+        assert_eq!(mid.a, 0.5);
+    }
+
+    #[test]
+    fn color_matches_a_hand_rolled_srgb_lerp() {
+        // The exact shape the ported source (`PersistentPiScene::pi_color` in
+        // movies/202606/shorts_sqrt2_plus_sqrt3/src/explanation.rs) computed
+        // by hand: independent per-channel `a + (b - a) * t`.
+        let ink = Color::rgb_u8(24, 28, 36);
+        let muted = Color::rgb_u8(112, 121, 132);
+        let t = 0.3;
+        let p = Phase::new(t).unwrap();
+
+        let expected = Color {
+            r: ink.r + (muted.r - ink.r) * t,
+            g: ink.g + (muted.g - ink.g) * t,
+            b: ink.b + (muted.b - ink.b) * t,
+            a: ink.a + (muted.a - ink.a) * t,
+        };
+        assert_eq!(ink.interpolate(muted, p), expected);
     }
 }

--- a/tellur-core/src/timeline_component/tests.rs
+++ b/tellur-core/src/timeline_component/tests.rs
@@ -318,6 +318,78 @@ fn unfired_event_elapsed_is_zero() {
 }
 
 #[test]
+fn event_window_unfired_reports_the_before_state_with_a_stable_key() {
+    let e = Event::new();
+    let table = TriggerTable::new();
+    let early = Clock::new(TimelineTime::new(3.0), LocalTime::new(3.0), &table);
+    let late = Clock::new(TimelineTime::new(50.0), LocalTime::new(50.0), &table);
+
+    let w_early = e.window(&early, 0.2..0.9);
+    let w_late = e.window(&late, 0.2..0.9);
+
+    // An unfired (+∞) trigger cannot be shifted into absolute seconds, so the
+    // window reports the same "before it opens" snapshot regardless of `now`
+    // — otherwise it could not be a stable cache-key term (`.sketch/02 §11`).
+    assert_eq!(w_early, w_late);
+    assert_eq!(w_early.phase().get(), 0.0);
+    assert_eq!(w_early.envelope(0.1, 0.1).get(), 0.0);
+}
+
+#[test]
+fn event_window_before_the_trigger_is_clamped_to_start() {
+    let e = Event::new();
+    let mut table = TriggerTable::new();
+    table.record(e, 5.0);
+    // Trigger at 5.0 ⇒ window [5.5, 6.5); `now` = 4.0 is before it opens.
+    let clock = Clock::new(TimelineTime::new(4.0), LocalTime::new(0.0), &table);
+
+    let w = e.window(&clock, 0.5..1.5);
+    assert_eq!(w.phase().get(), 0.0);
+    assert_eq!(w.envelope(0.2, 0.2).get(), 0.0);
+}
+
+#[test]
+fn event_window_inside_tracks_the_trigger_relative_cursor() {
+    let e = Event::new();
+    let mut table = TriggerTable::new();
+    table.record(e, 5.0);
+    // Window [trigger + 0.5, trigger + 1.5) = [5.5, 6.5); `now` = 6.0 is
+    // halfway through.
+    let clock = Clock::new(TimelineTime::new(6.0), LocalTime::new(0.0), &table);
+
+    let w = e.window(&clock, 0.5..1.5);
+    assert!((w.phase().get() - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn event_window_after_is_clamped_to_end_with_a_stable_key() {
+    let e = Event::new();
+    let mut table = TriggerTable::new();
+    table.record(e, 5.0);
+
+    let just_after = Clock::new(TimelineTime::new(7.0), LocalTime::new(0.0), &table);
+    let long_after = Clock::new(TimelineTime::new(500.0), LocalTime::new(0.0), &table);
+
+    let w_just_after = e.window(&just_after, 0.5..1.5);
+    let w_long_after = e.window(&long_after, 0.5..1.5);
+
+    // Both are past the window's close (6.5); the clamped snapshot is
+    // identical however far past, matching `Window::clamped`'s own guarantee
+    // (`clamped_freezes_outside_the_window` in `window.rs`).
+    assert_eq!(w_just_after, w_long_after);
+    assert_eq!(w_just_after.phase().get(), 1.0);
+}
+
+#[test]
+#[should_panic(expected = "Event::window requires a finite range with end > start")]
+fn event_window_rejects_empty_range() {
+    let e = Event::new();
+    let table = TriggerTable::new();
+    let clock = Clock::new(TimelineTime::new(0.0), LocalTime::new(0.0), &table);
+    let _ = e.window(&clock, 1.0..1.0);
+}
+
+#[test]
 fn triggered_resolve_records_start_time() {
     let e = Event::new();
     let triggered = Dot.trigger_at_start(e);

--- a/tellur-core/src/timeline_component/trigger.rs
+++ b/tellur-core/src/timeline_component/trigger.rs
@@ -3,6 +3,7 @@
 //! (stamps the authoring call site onto the arrangement).
 
 use std::hash::Hash;
+use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::geometry::Vec2;
@@ -10,6 +11,7 @@ use crate::phase::Phase;
 use crate::raster::{RasterImage, Resolution};
 use crate::render_context::RenderContext;
 use crate::time::Time;
+use crate::window::Window;
 
 use super::*;
 
@@ -115,6 +117,42 @@ impl Event {
             return 0.0;
         }
         (clock.global().seconds() - trigger).max(0.0)
+    }
+
+    /// A [`Window`] over `[trigger + range.start, trigger + range.end)`,
+    /// already [`clamped`](Window::clamped) — the event-relative twin of
+    /// [`crate::time::Time::window`], for staggering sub-events
+    /// ([`Window::sub_secs`]) or reading elapsed/remaining seconds off a
+    /// single trigger-anchored interval instead of composing them from
+    /// [`Event::phase`] / [`Event::elapsed`] by hand.
+    ///
+    /// Returning the clamped snapshot (not the live cursor) directly is what
+    /// makes this safe to store in a component field: like
+    /// [`Window::clamped`], the snapshot is constant at `(start, end, start)`
+    /// before the window opens and constant at `(start, end, end)` once it
+    /// closes, so it is a frame-stable cache-key term the same way a
+    /// saturating [`Phase`] is (`.sketch/02 §11`).
+    ///
+    /// An unfired event (trigger at `+∞`) cannot be shifted into absolute
+    /// seconds, so it reports the "before the window" snapshot directly —
+    /// `range.start` doubling as its own anchor, cursor pinned to
+    /// `range.start` (phase `0`, matching [`Event::phase`]'s `+∞` short
+    /// circuit) — rather than propagating `+∞`/`NaN` or panicking. That
+    /// snapshot does not depend on the current time, so it stays stable
+    /// across every frame the event remains unfired, exactly like the
+    /// post-close snapshot stays stable across every frame after firing.
+    pub fn window(&self, clock: &Clock<'_>, range: Range<f32>) -> Window {
+        assert!(
+            range.start.is_finite() && range.end.is_finite() && range.end > range.start,
+            "Event::window requires a finite range with end > start"
+        );
+        let trigger = clock.trigger_of(*self).seconds();
+        if trigger.is_infinite() {
+            return Window::new(range.start, range.end, range.start);
+        }
+        let start = trigger + range.start;
+        let end = trigger + range.end;
+        Window::new(start, end, clock.global().seconds()).clamped()
     }
 }
 

--- a/tellur-core/src/timeline_container/leaves.rs
+++ b/tellur-core/src/timeline_container/leaves.rs
@@ -331,6 +331,41 @@ fn audio_fade_gain(local_time: f32, clip_duration: f32, fade_in: f32, fade_out: 
     rise.min(fall)
 }
 
+/// An invisible, silent placeholder with an explicit `duration` and no
+/// visual, audio, or subtitle output of its own — the timeline twin of the
+/// layout side's [`SizedBox`](crate::layout::SizedBox). Built with
+/// `TimeBox::builder().duration(1.5)`.
+///
+/// Useful anywhere a `Timeline`/`Sequence` needs an explicit length to hang
+/// triggers on or to reserve a beat, without authoring a stub media file
+/// just to give a clip a duration (the role
+/// `DialogueDuration` played ad hoc before this leaf existed).
+#[crate::component(timeline)]
+#[derive(Clone, Copy, crate::Keyable)]
+pub struct TimeBox {
+    pub duration: f32,
+}
+
+impl TimelineComponent for TimeBox {
+    fn duration(&self) -> Option<f32> {
+        Some(self.duration)
+    }
+
+    fn arrangement(&self, offset: f32) -> Arrangement {
+        Arrangement {
+            kind: NodeKind::Timeline,
+            label: "time box".to_owned(),
+            name: None,
+            source: None,
+            start: offset,
+            end: offset + self.duration,
+            trim: None,
+            triggers: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
 /// 字幕 — the subtitle channel only (written to .srt/.vtt, NOT a burned-in
 /// telop, which is a visual). Built with `Subtitle::builder().text("…")`.
 ///

--- a/tellur-core/src/timeline_container/tests.rs
+++ b/tellur-core/src/timeline_container/tests.rs
@@ -333,6 +333,51 @@ fn media_leaf_probe_seam_is_injectable() {
     assert_eq!(Subtitle::builder().text("t").build().duration(), None);
 }
 
+// `TimeBox` — the timeless-side `SizedBox`'s temporal twin: a leaf with no
+// output of its own, just an explicit `duration`.
+#[test]
+fn time_box_reports_the_given_duration() {
+    let time_box = TimeBox::builder().duration(2.5).build();
+    assert_eq!(time_box.duration(), Some(2.5));
+    assert_eq!(time_box.measure(), Some(2.5));
+}
+
+#[test]
+fn time_box_arrangement_spans_its_duration_from_the_offset() {
+    let node = TimeBox::builder().duration(1.5).build().arrangement(10.0);
+    assert_eq!(node.kind, NodeKind::Timeline);
+    assert_eq!(node.start, 10.0);
+    assert_eq!(node.end, 11.5);
+    assert!(node.children.is_empty());
+}
+
+// A `TimeBox` gives a `Timeline` an explicit length exactly the way
+// `DialogueDuration` did in the ported source (`.sketch`-style: a non-fill
+// child with no media/visual of its own, just to set the container span).
+#[test]
+fn time_box_gives_a_timeline_an_explicit_length() {
+    let tl = Timeline::builder()
+        .child(TimeBox::builder().duration(4.0).build().at(0.0))
+        .build();
+    assert_eq!(tl.measure(), Some(4.0));
+    let resolved = resolve(tl).expect("windowed, not timeless");
+    assert_eq!(resolved.duration(), 4.0);
+}
+
+// A `TimeBox` is an ordinary `TimelineComponent`, so it can anchor a
+// `.trigger_at_end(..)` like any other clip a `Sequence` positions.
+#[test]
+fn time_box_can_carry_a_trigger() {
+    use crate::timeline_component::{Event, Triggers};
+
+    let e = Event::new();
+    let triggered = TimeBox::builder().duration(3.0).build().trigger_at_end(e);
+    let mut ctx = ResolveCtx::new();
+    triggered.resolve(2.0, &mut ctx);
+    let table = ctx.into_triggers();
+    assert_eq!(table.get(e.id()).seconds(), 5.0);
+}
+
 // The complete builders satisfy `TimelineBuilder` (the marker bound), so the
 // buildless `.child(..)` / `.at(..)` / `.fill()` paths work.
 #[test]


### PR DESCRIPTION
Adds the time-authoring vocabulary ported from the shorts refactor: CSS cubic-bezier easing, sRGB color interpolation, event-anchored clamped windows, and an explicit-duration timeline leaf. 6 files (+471 / -1) in `tellur-core`.

## Easing and interpolation
- Add `Easing::CubicBezier { x1, y1, x2, y2 }` (Newton + bisection solver) and `Phase::ease_bezier` for overshoot-preserving lerps.
- Switch `Easing` to `Keyable`-style bit-pattern equality (the new variant carries `f32`).
- Implement `Interpolate for Color` as a straight per-channel sRGB lerp.

## Event windows and time box
- Add `Event::window(&clock, range)`: a clamped, cache-stable `Window` anchored at the trigger; unfired events report the before-the-window state.
- Add `TimeBox`, an invisible fixed-duration leaf — the timeline twin of `SizedBox`.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p tellur-core --lib`
- `cargo check --workspace`
