### PR TITLE
fix(core): resolve clippy and rustfmt violations on main

### DIFF
--- a/tellur-core/src/raster.rs
+++ b/tellur-core/src/raster.rs
@@ -543,8 +543,14 @@ mod tests {
         };
         let mut ctx = PassThrough;
 
-        let over = solid.opacity(2.0).render(Vec2(2.0, 2.0), Resolution::new(2, 2), &mut ctx);
-        assert_eq!(over.as_cpu().unwrap().pixels[3], 200, "opacity > 1 clamps to 1 (no-op)");
+        let over = solid
+            .opacity(2.0)
+            .render(Vec2(2.0, 2.0), Resolution::new(2, 2), &mut ctx);
+        assert_eq!(
+            over.as_cpu().unwrap().pixels[3],
+            200,
+            "opacity > 1 clamps to 1 (no-op)"
+        );
 
         let solid = SolidAlpha {
             rgba: [1, 2, 3, 200],
@@ -552,7 +558,11 @@ mod tests {
         let nan = solid
             .opacity(f32::NAN)
             .render(Vec2(2.0, 2.0), Resolution::new(2, 2), &mut ctx);
-        assert_eq!(nan.as_cpu().unwrap().pixels[3], 0, "NaN opacity clamps to 0");
+        assert_eq!(
+            nan.as_cpu().unwrap().pixels[3],
+            0,
+            "NaN opacity clamps to 0"
+        );
     }
 
     /// A `RenderContext` stub that always answers `render` with a GPU-tagged

--- a/tellur-core/src/vector.rs
+++ b/tellur-core/src/vector.rs
@@ -392,7 +392,7 @@ impl DashPattern {
         if total <= 0.0 {
             return None;
         }
-        if self.lengths.len() % 2 == 0 {
+        if self.lengths.len().is_multiple_of(2) {
             Some(self.lengths.clone())
         } else {
             let mut doubled = self.lengths.clone();


### PR DESCRIPTION
Restores a green main: #53 landed a `manual_is_multiple_of` clippy violation (`DashPattern::normalized_lengths`) and #55 landed rustfmt violations in the `Opacity` tests, so the Clippy (tellur-core / tellur-renderer) and Rustfmt (tellur-core) jobs currently fail on main. 2 files (+13 / -6) in `tellur-core`.

## Cleanups
- Replace `len() % 2 == 0` with `len().is_multiple_of(2)` in dash pattern normalization.
- Apply `cargo fmt --all` (reflows two `Opacity` test assertions).

## Verification
- `nix develop -c cargo clippy --locked -p tellur-core -p tellur-renderer -p tellur-macros --all-targets -- -D warnings`
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test -p tellur-core --lib`
