### PR TITLE
chore: add crates.io metadata to workspace manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,9 @@ members = [
     "tellur-renderer",
 ]
 resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/comnipl/tellur"

--- a/tellur-core/Cargo.toml
+++ b/tellur-core/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "tellur-core"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Core component model for tellur: vector/raster/timeline components, layout, easing, and events"
+keywords = ["video", "animation", "graphics", "declarative"]
+categories = ["multimedia::video", "graphics", "rendering"]
+
+[package.metadata.docs.rs]
+features = ["latex"]
 
 [features]
 # Inline LaTeX math spans (`MathSpan`). Pulls in the RaTeX math-layout

--- a/tellur-live/Cargo.toml
+++ b/tellur-live/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "tellur-live"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Live-preview server for tellur projects with hot rebuild"
 build = "build.rs"
 # `web/dist` (the Vite bundle build.rs embeds) is gitignored, so by default it is
 # left out of the published crate — consumers would then have to run npm at build
@@ -19,9 +22,9 @@ include = [
 [dependencies]
 lru = "0.12.5"
 png = "0.18.1"
-tellur-core = { path = "../tellur-core" }
-tellur-plugin = { path = "../tellur-plugin" }
-tellur-renderer = { path = "../tellur-renderer" }
+tellur-core = { path = "../tellur-core", version = "0.1.0" }
+tellur-plugin = { path = "../tellur-plugin", version = "0.1.0" }
+tellur-renderer = { path = "../tellur-renderer", version = "0.1.0" }
 
 [[example]]
 name = "demo_timeline_plugin"

--- a/tellur-macros/Cargo.toml
+++ b/tellur-macros/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "tellur-macros"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Procedural macros for tellur: #[component] and #[derive(Keyable)]"
 
 [lib]
 proc-macro = true

--- a/tellur-plugin/Cargo.toml
+++ b/tellur-plugin/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "tellur-plugin"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Plugin ABI for loading tellur timelines as dynamic libraries"
 
 [dependencies]
-tellur-core = { path = "../tellur-core" }
+tellur-core = { path = "../tellur-core", version = "0.1.0" }

--- a/tellur-renderer/Cargo.toml
+++ b/tellur-renderer/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "tellur-renderer"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "GPU (wgpu/vello) and CPU rasterization plus ffmpeg encoding for tellur"
+
+[package.metadata.docs.rs]
+features = ["latex"]
 
 [features]
 # Forwards to `tellur-core/latex` so examples (and downstream renderers) can
@@ -29,7 +35,7 @@ lru = "0.12"
 pollster = "0.3"
 rustc-hash = "1.1.0"
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
-tellur-core = { path = "../tellur-core" }
+tellur-core = { path = "../tellur-core", version = "0.1.0" }
 thiserror = "2.0.18"
 tiny-skia = "0.12.0"
 vello = "0.2.1"

--- a/tellur/Cargo.toml
+++ b/tellur/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "tellur"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Declarative video authoring in Rust: vector, raster, and timeline components with GPU rendering"
+keywords = ["video", "animation", "graphics", "declarative"]
+categories = ["multimedia::video", "graphics", "rendering"]
+
+[package.metadata.docs.rs]
+features = ["latex"]
 
 [features]
 default = ["renderer"]
@@ -16,10 +24,10 @@ latex = ["tellur-core/latex", "tellur-renderer?/latex"]
 cli = ["dep:clap", "dep:cargo_metadata", "dep:toml_edit", "dep:tellur-live", "renderer"]
 
 [dependencies]
-tellur-core = { path = "../tellur-core" }
-tellur-plugin = { path = "../tellur-plugin" }
-tellur-renderer = { path = "../tellur-renderer", optional = true }
-tellur-live = { path = "../tellur-live", optional = true }
+tellur-core = { path = "../tellur-core", version = "0.1.0" }
+tellur-plugin = { path = "../tellur-plugin", version = "0.1.0" }
+tellur-renderer = { path = "../tellur-renderer", version = "0.1.0", optional = true }
+tellur-live = { path = "../tellur-live", version = "0.1.0", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 cargo_metadata = { version = "0.18", optional = true }
 toml_edit = { version = "0.22", optional = true }


### PR DESCRIPTION
Prepares the workspace for publishing to crates.io: every manifest now carries the registry-required metadata, and all inter-crate path dependencies specify a version so `cargo package` succeeds. 7 files (+58 / -21), manifests only — no code changes.

## Workspace metadata
- Add `[workspace.package]` (version / edition / license / repository) and switch all six crates to workspace inheritance.
- Add a per-crate `description`; `keywords` / `categories` on the `tellur` facade and `tellur-core`.
- Add `[package.metadata.docs.rs] features = ["latex"]` to `tellur`, `tellur-core`, and `tellur-renderer` so docs.rs renders the math API.

## Path dependencies
- Add `version = "0.1.0"` to all nine inter-crate `path` dependencies (cargo rejects packaging without it; `tellur-core → tellur-macros` already had one).

## Verification
- `cargo package -p <each of the six crates> --no-verify`: no missing-version errors, no missing-metadata warnings.
- `cargo check --workspace`