### PR TITLE
fix(live): verify plugin ABI fingerprint before dlopen

### DIFF
--- a/tellur-live/Cargo.toml
+++ b/tellur-live/Cargo.toml
@@ -39,3 +39,6 @@ path = "examples/demo_timeline_mp4.rs"
 [[example]]
 name = "timeline_showcase"
 crate-type = ["cdylib"]
+
+[dev-dependencies]
+tellur-plugin = { path = "../tellur-plugin", version = "0.1.0" }

--- a/tellur-live/src/plugin.rs
+++ b/tellur-live/src/plugin.rs
@@ -17,7 +17,10 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tellur_plugin::{EntryFn, TimelineCollection, ENTRY_SYMBOL};
+use tellur_plugin::{
+    validate_plugin_fingerprint, AbiFingerprintFn, AbiMismatchError, EntryFn, TimelineCollection,
+    ABI_FINGERPRINT_SYMBOL, ENTRY_SYMBOL,
+};
 
 #[derive(Debug)]
 pub enum PluginLoadError {
@@ -25,6 +28,8 @@ pub enum PluginLoadError {
     InvalidPath(PathBuf),
     Open { path: PathBuf, message: String },
     Symbol { symbol: String, message: String },
+    MissingAbiFingerprint,
+    AbiMismatch(AbiMismatchError),
     MissingPlugin,
 }
 
@@ -39,6 +44,12 @@ impl fmt::Display for PluginLoadError {
             Self::Symbol { symbol, message } => {
                 write!(f, "failed to load symbol {symbol}: {message}")
             }
+            Self::MissingAbiFingerprint => write!(
+                f,
+                "plugin is missing the ABI fingerprint symbol (tellur_abi_fingerprint_v1); \
+                 rebuild the project with a tellur version that exports it"
+            ),
+            Self::AbiMismatch(err) => write!(f, "{err}"),
             Self::MissingPlugin => write!(f, "plugin is not loaded"),
         }
     }
@@ -203,6 +214,7 @@ fn metadata_change_time(metadata: &fs::Metadata) -> Option<(i64, i64)> {
 fn load_plugin(path: &Path, stamp: SourceStamp) -> Result<LoadedPlugin, PluginLoadError> {
     let staged_path = stage_library(path, stamp)?;
     let library = unsafe { DynamicLibrary::open(&staged_path)? };
+    check_plugin_abi(&library)?;
     let entry: EntryFn = unsafe { library.symbol(ENTRY_SYMBOL)? };
     let collection = unsafe { entry() };
     Ok(LoadedPlugin {
@@ -212,6 +224,41 @@ fn load_plugin(path: &Path, stamp: SourceStamp) -> Result<LoadedPlugin, PluginLo
         collection,
         library,
     })
+}
+
+fn check_plugin_abi(library: &DynamicLibrary) -> Result<(), PluginLoadError> {
+    if std::env::var_os("TELLUR_SKIP_ABI_CHECK").is_some() {
+        eprintln!("warning: TELLUR_SKIP_ABI_CHECK=1; skipping plugin ABI fingerprint check");
+        return Ok(());
+    }
+
+    let fingerprint_fn: AbiFingerprintFn =
+        match unsafe { library.symbol(ABI_FINGERPRINT_SYMBOL) } {
+            Ok(f) => f,
+            Err(PluginLoadError::Symbol { symbol, .. })
+                if symbol == "tellur_abi_fingerprint_v1" =>
+            {
+                return Err(PluginLoadError::MissingAbiFingerprint);
+            }
+            Err(e) => return Err(e),
+        };
+
+    let plugin_ptr = unsafe { fingerprint_fn() };
+    if plugin_ptr.is_null() {
+        return Err(PluginLoadError::Symbol {
+            symbol: "tellur_abi_fingerprint_v1".to_owned(),
+            message: "fingerprint function returned a null pointer".to_owned(),
+        });
+    }
+
+    let plugin_fp = unsafe { CStr::from_ptr(plugin_ptr) }
+        .to_str()
+        .map_err(|_| PluginLoadError::Symbol {
+            symbol: "tellur_abi_fingerprint_v1".to_owned(),
+            message: "fingerprint is not valid UTF-8".to_owned(),
+        })?;
+
+    validate_plugin_fingerprint(plugin_fp).map_err(PluginLoadError::AbiMismatch)
 }
 
 fn stage_library(path: &Path, stamp: SourceStamp) -> Result<PathBuf, PluginLoadError> {

--- a/tellur-live/src/plugin.rs
+++ b/tellur-live/src/plugin.rs
@@ -22,7 +22,6 @@ use tellur_plugin::{
     ABI_FINGERPRINT_SYMBOL, ENTRY_SYMBOL,
 };
 
-#[derive(Debug)]
 pub enum PluginLoadError {
     Io(std::io::Error),
     InvalidPath(PathBuf),
@@ -31,6 +30,12 @@ pub enum PluginLoadError {
     MissingAbiFingerprint,
     AbiMismatch(AbiMismatchError),
     MissingPlugin,
+}
+
+impl fmt::Debug for PluginLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
 }
 
 impl fmt::Display for PluginLoadError {
@@ -182,6 +187,7 @@ impl HotReloadPlugin {
                 Ok(true)
             }
             Err(e) if self.loaded.is_some() => {
+                eprintln!("{e}");
                 self.last_error = Some(e.to_string());
                 self.failed_stamp = Some(stamp);
                 Ok(false)

--- a/tellur-live/tests/plugin_abi.rs
+++ b/tellur-live/tests/plugin_abi.rs
@@ -1,0 +1,45 @@
+//! Integration tests for live-preview plugin ABI loading.
+
+use std::path::PathBuf;
+
+use tellur_live::HotReloadPlugin;
+
+fn demo_plugin_path() -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_owned());
+    let path = manifest_dir.join(format!(
+        "../target/{profile}/examples/libdemo_timeline_plugin.so"
+    ));
+    if path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+#[test]
+fn loads_demo_plugin_when_built() {
+    let Some(plugin_path) = demo_plugin_path() else {
+        eprintln!(
+            "skipping loads_demo_plugin_when_built: build the example first with \
+             `cargo build -p tellur-live --example demo_timeline_plugin`"
+        );
+        return;
+    };
+
+    let mut loader = HotReloadPlugin::new(&plugin_path);
+    loader
+        .reload_if_changed()
+        .expect("demo plugin should load when host and plugin share the workspace lock");
+    let collection = loader.collection().expect("collection");
+    assert!(!collection.timelines().is_empty());
+}
+
+#[test]
+fn rejects_mismatched_abi_fingerprint() {
+    let err = tellur_plugin::validate_plugin_fingerprint(
+        "rustc=0.0.0/000 target=unknown tellur-plugin=0.0.0 lock=unknown bytes=unknown",
+    )
+    .expect_err("host fingerprint should reject a foreign plugin fingerprint");
+    assert!(err.to_string().contains("plugin ABI fingerprint mismatch"));
+}

--- a/tellur-live/tests/plugin_abi.rs
+++ b/tellur-live/tests/plugin_abi.rs
@@ -41,5 +41,5 @@ fn rejects_mismatched_abi_fingerprint() {
         "rustc=0.0.0/000 target=unknown tellur-plugin=0.0.0 lock=unknown bytes=unknown",
     )
     .expect_err("host fingerprint should reject a foreign plugin fingerprint");
-    assert!(err.to_string().contains("plugin ABI fingerprint mismatch"));
+    assert!(err.to_string().contains("AbiMismatch:"));
 }

--- a/tellur-live/tests/plugin_abi.rs
+++ b/tellur-live/tests/plugin_abi.rs
@@ -42,4 +42,6 @@ fn rejects_mismatched_abi_fingerprint() {
     )
     .expect_err("host fingerprint should reject a foreign plugin fingerprint");
     assert!(err.to_string().contains("AbiMismatch:"));
+    assert!(format!("{err:?}").contains("AbiMismatch:"));
+    assert!(!format!("{err:?}").contains("AbiMismatchError {"));
 }

--- a/tellur-plugin/Cargo.toml
+++ b/tellur-plugin/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 description = "Plugin ABI for loading tellur timelines as dynamic libraries"
+build = "build.rs"
 
 [dependencies]
 tellur-core = { path = "../tellur-core", version = "0.1.0" }

--- a/tellur-plugin/build.rs
+++ b/tellur-plugin/build.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+use std::process::Command;
+
+mod fingerprint;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=fingerprint.rs");
+
+    let out_dir = env("OUT_DIR");
+    if let Some(lock_path) = fingerprint::find_cargo_lock(Path::new(&out_dir)) {
+        println!("cargo:rerun-if-changed={}", lock_path.display());
+    }
+
+    let (rustc_release, rustc_commit) = rustc_version();
+    let target = env("TARGET");
+    let pkg_version = env("CARGO_PKG_VERSION");
+
+    let lock_path = fingerprint::find_cargo_lock(Path::new(&out_dir));
+    let fingerprint = fingerprint::build_fingerprint(
+        &rustc_release,
+        &rustc_commit,
+        &target,
+        &pkg_version,
+        lock_path.as_deref(),
+    );
+
+    println!("cargo:rustc-env=TELLUR_ABI_FINGERPRINT={fingerprint}");
+}
+
+fn env(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|e| panic!("missing env var {name}: {e}"))
+}
+
+fn rustc_version() -> (String, String) {
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
+    let output = Command::new(&rustc)
+        .arg("-vV")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run {rustc} -vV: {e}"));
+    if !output.status.success() {
+        panic!(
+            "{rustc} -vV failed with status {}",
+            output.status
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut release = None;
+    let mut commit = None;
+    for line in stdout.lines() {
+        if let Some(value) = line.strip_prefix("release: ") {
+            release = Some(value.to_owned());
+        } else if let Some(value) = line.strip_prefix("commit-hash: ") {
+            commit = Some(value.to_owned());
+        }
+    }
+
+    (
+        release.unwrap_or_else(|| "unknown".to_owned()),
+        commit.unwrap_or_else(|| "unknown".to_owned()),
+    )
+}

--- a/tellur-plugin/fingerprint.rs
+++ b/tellur-plugin/fingerprint.rs
@@ -1,0 +1,157 @@
+//! Shared ABI fingerprint generation for the live-preview plugin boundary.
+//!
+//! Used by `build.rs` at compile time and by unit tests. Each side of the
+//! dynamic-library boundary (host and plugin) embeds the fingerprint produced
+//! from its own build graph so mismatched transitive deps (e.g. `bytes`) are
+//! caught before Rust types cross the dlopen boundary.
+
+#![allow(dead_code)] // Included by build.rs and lib; not every item is used in both.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Crates whose types may cross the host/plugin dylib boundary.
+///
+/// Extend this list when a new dependency's types are passed across the
+/// `TimelineCollection` / `RasterImage` ABI (not for tellur-internal types
+/// that stay on one side).
+pub const BOUNDARY_CRATES: &[&str] = &["bytes"];
+
+/// Walk upward from `start` (typically `OUT_DIR`) until a `Cargo.lock` is found.
+pub fn find_cargo_lock(start: &Path) -> Option<PathBuf> {
+    let mut dir = start.to_path_buf();
+    loop {
+        let candidate = dir.join("Cargo.lock");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn unquote(value: &str) -> String {
+    value.trim().trim_matches('"').to_owned()
+}
+
+/// Parse resolved versions for `names` from a `Cargo.lock` file body.
+pub fn parse_crate_versions(lock: &str, names: &[&str]) -> BTreeMap<String, String> {
+    let mut result = BTreeMap::new();
+    let mut current_name: Option<String> = None;
+
+    for line in lock.lines() {
+        let line = line.trim();
+        if line == "[[package]]" {
+            current_name = None;
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("name = ") {
+            current_name = Some(unquote(rest));
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("version = ") {
+            if let Some(name) = current_name.as_deref() {
+                if names.contains(&name) {
+                    result.insert(name.to_owned(), unquote(rest));
+                }
+            }
+        }
+    }
+
+    for name in names {
+        result
+            .entry((*name).to_owned())
+            .or_insert_with(|| "unknown".to_owned());
+    }
+
+    result
+}
+
+/// Build the fingerprint string embedded into host and plugin binaries.
+pub fn build_fingerprint(
+    rustc_release: &str,
+    rustc_commit: &str,
+    target: &str,
+    pkg_version: &str,
+    lock_path: Option<&Path>,
+) -> String {
+    let mut parts = vec![
+        format!("rustc={rustc_release}/{rustc_commit}"),
+        format!("target={target}"),
+        format!("tellur-plugin={pkg_version}"),
+    ];
+
+    if let Some(lock_path) = lock_path {
+        parts.push("lock=found".to_owned());
+        let lock_content = std::fs::read_to_string(lock_path).unwrap_or_default();
+        let versions = parse_crate_versions(&lock_content, BOUNDARY_CRATES);
+        for crate_name in BOUNDARY_CRATES {
+            let version = versions
+                .get(*crate_name)
+                .map(String::as_str)
+                .unwrap_or("unknown");
+            parts.push(format!("{crate_name}={version}"));
+        }
+    } else {
+        parts.push("lock=unknown".to_owned());
+        for crate_name in BOUNDARY_CRATES {
+            parts.push(format!("{crate_name}=unknown"));
+        }
+    }
+
+    parts.join(" ")
+}
+
+/// Parse `key=value` tokens from a fingerprint string.
+pub fn parse_fingerprint_kv(fingerprint: &str) -> BTreeMap<String, String> {
+    fingerprint
+        .split_whitespace()
+        .filter_map(|token| {
+            let (key, value) = token.split_once('=')?;
+            Some((key.to_owned(), value.to_owned()))
+        })
+        .collect()
+}
+
+/// Suggest remediation when host and plugin fingerprints differ.
+pub fn remediation_hint(host: &str, plugin: &str) -> String {
+    let host_map = parse_fingerprint_kv(host);
+    let plugin_map = parse_fingerprint_kv(plugin);
+    let mut hints = Vec::new();
+
+    if host_map.get("lock") == Some(&"unknown".to_owned())
+        || plugin_map.get("lock") == Some(&"unknown".to_owned())
+    {
+        hints.push(
+            "ensure the project has a Cargo.lock and rebuild the plugin from that directory"
+                .to_owned(),
+        );
+    }
+
+    for crate_name in BOUNDARY_CRATES {
+        if host_map.get(*crate_name) != plugin_map.get(*crate_name) {
+            if let Some(host_ver) = host_map.get(*crate_name) {
+                if host_ver != "unknown" {
+                    hints.push(format!("cargo update -p {crate_name} --precise {host_ver}"));
+                }
+            }
+        }
+    }
+
+    if host_map.get("tellur-plugin") != plugin_map.get("tellur-plugin") {
+        hints.push(
+            "update the tellur dependency to the same version as the tellur live host".to_owned(),
+        );
+    }
+
+    if host_map.get("rustc") != plugin_map.get("rustc") {
+        hints.push("rebuild the plugin with the same Rust toolchain as the tellur host".to_owned());
+    }
+
+    if hints.is_empty() {
+        "rebuild the plugin with the same tellur version and Cargo.lock as the live host".to_owned()
+    } else {
+        hints.join("; ")
+    }
+}

--- a/tellur-plugin/fingerprint.rs
+++ b/tellur-plugin/fingerprint.rs
@@ -114,6 +114,47 @@ pub fn parse_fingerprint_kv(fingerprint: &str) -> BTreeMap<String, String> {
         .collect()
 }
 
+const PLUGIN_SIDE_PREFIX: &str = "On the plugin side (your video editing project), please ";
+
+/// Keys compared for ABI mismatch display, in presentation order.
+const DIFF_FIELD_KEYS: &[&str] = &["tellur-plugin", "rustc", "target", "lock"];
+
+/// Return `(field, host_value, plugin_value)` for each fingerprint field that differs.
+pub fn fingerprint_diffs(host: &str, plugin: &str) -> Vec<(String, String, String)> {
+    let host_map = parse_fingerprint_kv(host);
+    let plugin_map = parse_fingerprint_kv(plugin);
+    let mut diffs = Vec::new();
+
+    for crate_name in BOUNDARY_CRATES {
+        push_diff(
+            &mut diffs,
+            &host_map,
+            &plugin_map,
+            (*crate_name).to_owned(),
+        );
+    }
+
+    for key in DIFF_FIELD_KEYS {
+        push_diff(&mut diffs, &host_map, &plugin_map, (*key).to_owned());
+    }
+
+    diffs
+}
+
+fn push_diff(
+    diffs: &mut Vec<(String, String, String)>,
+    host_map: &BTreeMap<String, String>,
+    plugin_map: &BTreeMap<String, String>,
+    field: String,
+) {
+    let (Some(host_val), Some(plugin_val)) = (host_map.get(&field), plugin_map.get(&field)) else {
+        return;
+    };
+    if host_val != plugin_val {
+        diffs.push((field, host_val.clone(), plugin_val.clone()));
+    }
+}
+
 /// Suggest remediation when host and plugin fingerprints differ.
 pub fn remediation_hint(host: &str, plugin: &str) -> String {
     let host_map = parse_fingerprint_kv(host);
@@ -123,35 +164,40 @@ pub fn remediation_hint(host: &str, plugin: &str) -> String {
     if host_map.get("lock") == Some(&"unknown".to_owned())
         || plugin_map.get("lock") == Some(&"unknown".to_owned())
     {
-        hints.push(
-            "ensure the project has a Cargo.lock and rebuild the plugin from that directory"
-                .to_owned(),
-        );
+        hints.push(format!(
+            "{PLUGIN_SIDE_PREFIX}ensure the project has a Cargo.lock and rebuild from that directory."
+        ));
     }
 
     for crate_name in BOUNDARY_CRATES {
         if host_map.get(*crate_name) != plugin_map.get(*crate_name) {
             if let Some(host_ver) = host_map.get(*crate_name) {
                 if host_ver != "unknown" {
-                    hints.push(format!("cargo update -p {crate_name} --precise {host_ver}"));
+                    hints.push(format!(
+                        "{PLUGIN_SIDE_PREFIX}run `cargo update -p {crate_name} --precise {host_ver}`."
+                    ));
                 }
             }
         }
     }
 
     if host_map.get("tellur-plugin") != plugin_map.get("tellur-plugin") {
-        hints.push(
-            "update the tellur dependency to the same version as the tellur live host".to_owned(),
-        );
+        hints.push(format!(
+            "{PLUGIN_SIDE_PREFIX}update the tellur dependency to match the tellur live host."
+        ));
     }
 
     if host_map.get("rustc") != plugin_map.get("rustc") {
-        hints.push("rebuild the plugin with the same Rust toolchain as the tellur host".to_owned());
+        hints.push(format!(
+            "{PLUGIN_SIDE_PREFIX}rebuild the plugin with the same Rust toolchain as the tellur live host."
+        ));
     }
 
     if hints.is_empty() {
-        "rebuild the plugin with the same tellur version and Cargo.lock as the live host".to_owned()
+        format!(
+            "{PLUGIN_SIDE_PREFIX}rebuild the plugin with the same tellur version and Cargo.lock as the tellur live host."
+        )
     } else {
-        hints.join("; ")
+        hints.join("\nhint: ")
     }
 }

--- a/tellur-plugin/fingerprint.rs
+++ b/tellur-plugin/fingerprint.rs
@@ -114,7 +114,13 @@ pub fn parse_fingerprint_kv(fingerprint: &str) -> BTreeMap<String, String> {
         .collect()
 }
 
-const PLUGIN_SIDE_PREFIX: &str = "On the plugin side (your video editing project), please ";
+const PLUGIN_SIDE_INTRO: &str = "On the plugin side (your video editing project),";
+/// Aligns continuation lines with the text after the `hint: ` prefix.
+const HINT_CONTINUATION_INDENT: &str = "      ";
+
+fn format_plugin_side_hint(action: &str) -> String {
+    format!("{PLUGIN_SIDE_INTRO}\n{HINT_CONTINUATION_INDENT}please {action}")
+}
 
 /// Keys compared for ABI mismatch display, in presentation order.
 const DIFF_FIELD_KEYS: &[&str] = &["tellur-plugin", "rustc", "target", "lock"];
@@ -164,8 +170,8 @@ pub fn remediation_hint(host: &str, plugin: &str) -> String {
     if host_map.get("lock") == Some(&"unknown".to_owned())
         || plugin_map.get("lock") == Some(&"unknown".to_owned())
     {
-        hints.push(format!(
-            "{PLUGIN_SIDE_PREFIX}ensure the project has a Cargo.lock and rebuild from that directory."
+        hints.push(format_plugin_side_hint(
+            "ensure the project has a Cargo.lock and rebuild from that directory.",
         ));
     }
 
@@ -173,29 +179,29 @@ pub fn remediation_hint(host: &str, plugin: &str) -> String {
         if host_map.get(*crate_name) != plugin_map.get(*crate_name) {
             if let Some(host_ver) = host_map.get(*crate_name) {
                 if host_ver != "unknown" {
-                    hints.push(format!(
-                        "{PLUGIN_SIDE_PREFIX}run `cargo update -p {crate_name} --precise {host_ver}`."
-                    ));
+                    hints.push(format_plugin_side_hint(&format!(
+                        "run `cargo update -p {crate_name} --precise {host_ver}`."
+                    )));
                 }
             }
         }
     }
 
     if host_map.get("tellur-plugin") != plugin_map.get("tellur-plugin") {
-        hints.push(format!(
-            "{PLUGIN_SIDE_PREFIX}update the tellur dependency to match the tellur live host."
+        hints.push(format_plugin_side_hint(
+            "update the tellur dependency to match the tellur live host.",
         ));
     }
 
     if host_map.get("rustc") != plugin_map.get("rustc") {
-        hints.push(format!(
-            "{PLUGIN_SIDE_PREFIX}rebuild the plugin with the same Rust toolchain as the tellur live host."
+        hints.push(format_plugin_side_hint(
+            "rebuild the plugin with the same Rust toolchain as the tellur live host.",
         ));
     }
 
     if hints.is_empty() {
-        format!(
-            "{PLUGIN_SIDE_PREFIX}rebuild the plugin with the same tellur version and Cargo.lock as the tellur live host."
+        format_plugin_side_hint(
+            "rebuild the plugin with the same tellur version and Cargo.lock as the tellur live host.",
         )
     } else {
         hints.join("\nhint: ")

--- a/tellur-plugin/src/abi.rs
+++ b/tellur-plugin/src/abi.rs
@@ -26,19 +26,45 @@ pub struct AbiMismatchError {
     pub hint: String,
 }
 
+/// Right-aligned width for the `Host` / `Plugin` labels so values line up.
+const SIDE_LABEL_WIDTH: usize = 7;
+
 impl fmt::Display for AbiMismatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f)?;
         writeln!(f, "AbiMismatch: The plugin ABI is incompatible with the host.")?;
         writeln!(f)?;
 
         let diffs = fingerprint::fingerprint_diffs(&self.host, &self.plugin);
         if diffs.is_empty() {
-            writeln!(f, "  Host {}", self.host)?;
-            writeln!(f, "  Plugin {}", self.plugin)?;
+            writeln!(
+                f,
+                "{:>width$} {}",
+                "Host",
+                self.host,
+                width = SIDE_LABEL_WIDTH
+            )?;
+            writeln!(
+                f,
+                "{:>width$} {}",
+                "Plugin",
+                self.plugin,
+                width = SIDE_LABEL_WIDTH
+            )?;
         } else {
             for (field, host_val, plugin_val) in diffs {
-                writeln!(f, "  Host {field}={host_val}")?;
-                writeln!(f, "  Plugin {field}={plugin_val}")?;
+                writeln!(
+                    f,
+                    "{:>width$} {field}={host_val}",
+                    "Host",
+                    width = SIDE_LABEL_WIDTH
+                )?;
+                writeln!(
+                    f,
+                    "{:>width$} {field}={plugin_val}",
+                    "Plugin",
+                    width = SIDE_LABEL_WIDTH
+                )?;
             }
         }
 
@@ -101,7 +127,7 @@ mod tests {
         let plugin = "rustc=1.95.0/abc target=x86_64-unknown-linux-gnu tellur-plugin=0.1.0 lock=found bytes=1.12.0";
         let hint = remediation_hint(host, plugin);
         assert!(hint.contains(
-            "On the plugin side (your video editing project), please run `cargo update -p bytes --precise 1.11.1`."
+            "On the plugin side (your video editing project),\n      please run `cargo update -p bytes --precise 1.11.1`."
         ));
     }
 
@@ -114,7 +140,7 @@ mod tests {
             plugin: plugin.to_owned(),
             hint: remediation_hint(host, plugin),
         };
-        let expected = "AbiMismatch: The plugin ABI is incompatible with the host.\n\n  Host bytes=1.11.1\n  Plugin bytes=1.12.0\n\nhint: On the plugin side (your video editing project), please run `cargo update -p bytes --precise 1.11.1`.";
+        let expected = "\nAbiMismatch: The plugin ABI is incompatible with the host.\n\n   Host bytes=1.11.1\n Plugin bytes=1.12.0\n\nhint: On the plugin side (your video editing project),\n      please run `cargo update -p bytes --precise 1.11.1`.";
         assert_eq!(err.to_string(), expected);
         assert_eq!(format!("{err:?}"), expected);
         assert_eq!(fingerprint_diffs(host, plugin).len(), 1);

--- a/tellur-plugin/src/abi.rs
+++ b/tellur-plugin/src/abi.rs
@@ -28,11 +28,22 @@ pub struct AbiMismatchError {
 
 impl fmt::Display for AbiMismatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "plugin ABI fingerprint mismatch\n  host:   {}\n  plugin: {}\n  fix: {}",
-            self.host, self.plugin, self.hint
-        )
+        writeln!(f, "AbiMismatch: The plugin ABI is incompatible with the host.")?;
+        writeln!(f)?;
+
+        let diffs = fingerprint::fingerprint_diffs(&self.host, &self.plugin);
+        if diffs.is_empty() {
+            writeln!(f, "  Host {}", self.host)?;
+            writeln!(f, "  Plugin {}", self.plugin)?;
+        } else {
+            for (field, host_val, plugin_val) in diffs {
+                writeln!(f, "  Host {field}={host_val}")?;
+                writeln!(f, "  Plugin {field}={plugin_val}")?;
+            }
+        }
+
+        writeln!(f)?;
+        write!(f, "hint: {}", self.hint)
     }
 }
 
@@ -54,7 +65,7 @@ pub fn validate_plugin_fingerprint(plugin: &str) -> Result<(), AbiMismatchError>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fingerprint::{find_cargo_lock, parse_crate_versions, remediation_hint};
+    use fingerprint::{find_cargo_lock, fingerprint_diffs, parse_crate_versions, remediation_hint};
     use std::path::Path;
 
     #[test]
@@ -69,6 +80,7 @@ mod tests {
                 .expect_err("mismatch");
         assert_ne!(err.host, err.plugin);
         assert!(!err.hint.is_empty());
+        assert!(err.to_string().contains("AbiMismatch:"));
     }
 
     #[test]
@@ -82,7 +94,25 @@ mod tests {
         let host = "rustc=1.95.0/abc target=x86_64-unknown-linux-gnu tellur-plugin=0.1.0 lock=found bytes=1.11.1";
         let plugin = "rustc=1.95.0/abc target=x86_64-unknown-linux-gnu tellur-plugin=0.1.0 lock=found bytes=1.12.0";
         let hint = remediation_hint(host, plugin);
-        assert!(hint.contains("cargo update -p bytes --precise 1.11.1"));
+        assert!(hint.contains(
+            "On the plugin side (your video editing project), please run `cargo update -p bytes --precise 1.11.1`."
+        ));
+    }
+
+    #[test]
+    fn display_shows_only_diffing_fields() {
+        let host = "rustc=1.95.0/abc target=x86_64-unknown-linux-gnu tellur-plugin=0.1.0 lock=found bytes=1.11.1";
+        let plugin = "rustc=1.95.0/abc target=x86_64-unknown-linux-gnu tellur-plugin=0.1.0 lock=found bytes=1.12.0";
+        let err = AbiMismatchError {
+            host: host.to_owned(),
+            plugin: plugin.to_owned(),
+            hint: remediation_hint(host, plugin),
+        };
+        assert_eq!(
+            err.to_string(),
+            "AbiMismatch: The plugin ABI is incompatible with the host.\n\n  Host bytes=1.11.1\n  Plugin bytes=1.12.0\n\nhint: On the plugin side (your video editing project), please run `cargo update -p bytes --precise 1.11.1`."
+        );
+        assert_eq!(fingerprint_diffs(host, plugin).len(), 1);
     }
 
     #[test]

--- a/tellur-plugin/src/abi.rs
+++ b/tellur-plugin/src/abi.rs
@@ -19,7 +19,7 @@ pub static ABI_FINGERPRINT_C: &[u8] = concat!(env!("TELLUR_ABI_FINGERPRINT"), "\
 pub type AbiFingerprintFn = unsafe extern "C" fn() -> *const std::os::raw::c_char;
 
 /// Error when a plugin's ABI fingerprint does not match the host.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct AbiMismatchError {
     pub host: String,
     pub plugin: String,
@@ -44,6 +44,12 @@ impl fmt::Display for AbiMismatchError {
 
         writeln!(f)?;
         write!(f, "hint: {}", self.hint)
+    }
+}
+
+impl fmt::Debug for AbiMismatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -108,10 +114,9 @@ mod tests {
             plugin: plugin.to_owned(),
             hint: remediation_hint(host, plugin),
         };
-        assert_eq!(
-            err.to_string(),
-            "AbiMismatch: The plugin ABI is incompatible with the host.\n\n  Host bytes=1.11.1\n  Plugin bytes=1.12.0\n\nhint: On the plugin side (your video editing project), please run `cargo update -p bytes --precise 1.11.1`."
-        );
+        let expected = "AbiMismatch: The plugin ABI is incompatible with the host.\n\n  Host bytes=1.11.1\n  Plugin bytes=1.12.0\n\nhint: On the plugin side (your video editing project), please run `cargo update -p bytes --precise 1.11.1`.";
+        assert_eq!(err.to_string(), expected);
+        assert_eq!(format!("{err:?}"), expected);
         assert_eq!(fingerprint_diffs(host, plugin).len(), 1);
     }
 

--- a/tellur-plugin/src/abi.rs
+++ b/tellur-plugin/src/abi.rs
@@ -1,0 +1,98 @@
+//! Runtime ABI fingerprint validation for live-preview plugin loading.
+
+use std::fmt;
+
+#[path = "../fingerprint.rs"]
+mod fingerprint;
+
+/// Symbol exported by timeline plugins for ABI fingerprint checks.
+pub const ABI_FINGERPRINT_SYMBOL: &[u8] = b"tellur_abi_fingerprint_v1\0";
+
+/// Fingerprint of the currently linked `tellur-plugin` build graph.
+pub const ABI_FINGERPRINT: &str = env!("TELLUR_ABI_FINGERPRINT");
+
+/// NUL-terminated fingerprint bytes for the C ABI export symbol.
+#[doc(hidden)]
+pub static ABI_FINGERPRINT_C: &[u8] = concat!(env!("TELLUR_ABI_FINGERPRINT"), "\0").as_bytes();
+
+/// Signature of [`ABI_FINGERPRINT_SYMBOL`].
+pub type AbiFingerprintFn = unsafe extern "C" fn() -> *const std::os::raw::c_char;
+
+/// Error when a plugin's ABI fingerprint does not match the host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbiMismatchError {
+    pub host: String,
+    pub plugin: String,
+    pub hint: String,
+}
+
+impl fmt::Display for AbiMismatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "plugin ABI fingerprint mismatch\n  host:   {}\n  plugin: {}\n  fix: {}",
+            self.host, self.plugin, self.hint
+        )
+    }
+}
+
+impl std::error::Error for AbiMismatchError {}
+
+/// Validate a plugin fingerprint string against this host build.
+pub fn validate_plugin_fingerprint(plugin: &str) -> Result<(), AbiMismatchError> {
+    if plugin == ABI_FINGERPRINT {
+        return Ok(());
+    }
+
+    Err(AbiMismatchError {
+        host: ABI_FINGERPRINT.to_owned(),
+        plugin: plugin.to_owned(),
+        hint: fingerprint::remediation_hint(ABI_FINGERPRINT, plugin),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fingerprint::{find_cargo_lock, parse_crate_versions, remediation_hint};
+    use std::path::Path;
+
+    #[test]
+    fn validate_accepts_host_fingerprint() {
+        validate_plugin_fingerprint(ABI_FINGERPRINT).expect("host fingerprint matches");
+    }
+
+    #[test]
+    fn validate_rejects_mismatched_fingerprint() {
+        let err =
+            validate_plugin_fingerprint("rustc=0.0.0/000 target=unknown tellur-plugin=0.0.0 lock=unknown bytes=unknown")
+                .expect_err("mismatch");
+        assert_ne!(err.host, err.plugin);
+        assert!(!err.hint.is_empty());
+    }
+
+    #[test]
+    fn find_cargo_lock_walks_up_from_out_dir() {
+        let lock = find_cargo_lock(Path::new(env!("CARGO_MANIFEST_DIR")));
+        assert!(lock.is_some(), "workspace Cargo.lock should be discoverable");
+    }
+
+    #[test]
+    fn remediation_suggests_precise_update_for_bytes() {
+        let host = "rustc=1.95.0/abc target=x86_64-unknown-linux-gnu tellur-plugin=0.1.0 lock=found bytes=1.11.1";
+        let plugin = "rustc=1.95.0/abc target=x86_64-unknown-linux-gnu tellur-plugin=0.1.0 lock=found bytes=1.12.0";
+        let hint = remediation_hint(host, plugin);
+        assert!(hint.contains("cargo update -p bytes --precise 1.11.1"));
+    }
+
+    #[test]
+    fn parse_crate_versions_reads_lock_entries() {
+        let lock = r#"
+[[package]]
+name = "bytes"
+version = "1.11.1"
+"#;
+        let versions = parse_crate_versions(lock, fingerprint::BOUNDARY_CRATES);
+        assert_eq!(versions.get("bytes"), Some(&"1.11.1".to_owned()));
+    }
+}

--- a/tellur-plugin/src/lib.rs
+++ b/tellur-plugin/src/lib.rs
@@ -5,9 +5,11 @@
 //! symbol ([`ENTRY_SYMBOL`]) returning a [`TimelineCollection`]; the host
 //! `dlopen`s the library and calls it. This contract intentionally uses Rust
 //! types across the dynamic-library boundary, so it is sound only when the host
-//! and plugin are built from the same `tellur` version and toolchain — it is
-//! NOT a stable C ABI. The entry symbol is versioned so a stale plugin fails to
-//! resolve cleanly instead of hitting a vtable mismatch.
+//! and plugin are built from the same `tellur` version, toolchain, and resolved
+//! boundary-crate versions — it is NOT a stable C ABI. The entry symbol is
+//! versioned so a stale plugin fails to resolve cleanly instead of hitting a
+//! vtable mismatch, and [`abi::ABI_FINGERPRINT_SYMBOL`] carries a finer-grained
+//! fingerprint checked at load time.
 
 use std::hash::{Hash, Hasher};
 
@@ -48,6 +50,24 @@ pub use tellur_core as __core;
 /// `render_audio_window`, so stale `v3` plugins must fail at `dlsym` instead of
 /// landing on the wrong vtable slot.
 pub const ENTRY_SYMBOL: &[u8] = b"tellur_timeline_collection_v4\0";
+
+pub mod abi;
+pub use abi::{
+    validate_plugin_fingerprint, AbiFingerprintFn, AbiMismatchError, ABI_FINGERPRINT,
+    ABI_FINGERPRINT_SYMBOL,
+};
+
+/// Export the C ABI fingerprint symbol alongside timeline entry points.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __tellur_export_abi_fingerprint {
+    () => {
+        #[no_mangle]
+        pub extern "C" fn tellur_abi_fingerprint_v1() -> *const ::std::os::raw::c_char {
+            $crate::abi::ABI_FINGERPRINT_C.as_ptr().cast()
+        }
+    };
+}
 
 /// The signature of the [`ENTRY_SYMBOL`] entry point a plugin exports.
 pub type EntryFn = unsafe extern "Rust" fn() -> Box<dyn TimelineCollection>;
@@ -312,6 +332,7 @@ impl<T: Timeline + Send + 'static> TimelineComponent for LegacyTimeline<T> {
 #[macro_export]
 macro_rules! export_timeline {
     ($id:expr, $title:expr, $builder:path) => {
+        $crate::__tellur_export_abi_fingerprint!();
         #[no_mangle]
         pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
@@ -319,6 +340,7 @@ macro_rules! export_timeline {
         }
     };
     ($id:expr, $title:expr, $builder:path, canvas = ($w:expr, $h:expr)) => {
+        $crate::__tellur_export_abi_fingerprint!();
         #[no_mangle]
         pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
@@ -343,6 +365,7 @@ macro_rules! export_timeline {
 #[macro_export]
 macro_rules! export_legacy_timeline {
     ($id:expr, $title:expr, $builder:path) => {
+        $crate::__tellur_export_abi_fingerprint!();
         #[no_mangle]
         pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {
@@ -359,6 +382,7 @@ macro_rules! export_legacy_timeline {
 #[macro_export]
 macro_rules! export_timeline_collection {
     ($builder:path) => {
+        $crate::__tellur_export_abi_fingerprint!();
         #[no_mangle]
         pub extern "Rust" fn tellur_timeline_collection_v4(
         ) -> ::std::boxed::Box<dyn $crate::TimelineCollection> {


### PR DESCRIPTION
Detects host/plugin build-graph mismatches at dlopen time so live preview
fails with a clear error instead of `free(): invalid pointer` when Rust
types (e.g. `bytes::Bytes` in `RasterImage::Cpu`) cross the dylib
boundary. 8 files (+442 / -4) across `tellur-plugin` and `tellur-live`.

## Fingerprint generation
- Add `tellur-plugin/build.rs` and shared `fingerprint.rs` to embed
  `TELLUR_ABI_FINGERPRINT` from rustc, target, tellur-plugin version,
  and boundary-crate lock versions (initially `bytes`).
- Export `tellur_abi_fingerprint_v1` (C ABI string) from all
  `export_timeline!` macros alongside the v4 entry symbol.

## Host-side check
- `tellur-live` resolves the fingerprint before calling the entry fn;
  mismatches surface as `PluginLoadError::AbiMismatch` with remediation
  hints (`cargo update -p bytes --precise …`).
- `TELLUR_SKIP_ABI_CHECK=1` bypasses the check for debugging.

## Verification
- `nix develop -c cargo test -p tellur-plugin -p tellur-live`
- `nix develop -c cargo build -p tellur-live --example demo_timeline_plugin --release`
- Integration test loads `demo_timeline_plugin` when host and plugin
  share the workspace lock.