### PR TITLE
fix(live): register timeline wheel listener as non-passive

### DIFF
--- a/tellur-live/web/src/components/Timeline.tsx
+++ b/tellur-live/web/src/components/Timeline.tsx
@@ -756,9 +756,11 @@ export function Timeline(props: TimelineProps) {
   }, []);
 
   const handleWheel = useCallback(
-    (e: React.WheelEvent<HTMLDivElement>) => {
+    (e: WheelEvent) => {
       if (!e.shiftKey) return;
-      const rect = e.currentTarget.getBoundingClientRect();
+      const body = bodyRef.current;
+      if (!body) return;
+      const rect = body.getBoundingClientRect();
       if (rect.width <= 0) return;
 
       e.preventDefault();
@@ -805,6 +807,13 @@ export function Timeline(props: TimelineProps) {
     },
     [duration, onViewportChange],
   );
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    if (!body) return;
+    body.addEventListener("wheel", handleWheel, { passive: false });
+    return () => body.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
 
   // Motion transitions for the expand/collapse choreography. Snappy but clean:
   // position/size/scaleY ride an ease-out tween (easeOutQuint) that decelerates
@@ -901,7 +910,6 @@ export function Timeline(props: TimelineProps) {
             : "timeline__body"
         }
         ref={bodyRef}
-        onWheel={handleWheel}
         onPointerDown={handleSeekPointerDown}
         onPointerMove={handleSeekPointerMove}
         onPointerUp={endSeekDrag}
@@ -1229,10 +1237,7 @@ export function Timeline(props: TimelineProps) {
   );
 }
 
-function normalizeWheelDelta(
-  e: React.WheelEvent<HTMLDivElement>,
-  pageSize: number,
-): number {
+function normalizeWheelDelta(e: WheelEvent, pageSize: number): number {
   const rawDelta =
     Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
 


### PR DESCRIPTION
Stops the recurring console warning when shift-wheel panning or zooming the timeline. 1 file (+12 / -7) in `tellur-live/web`.

## Cause
React 17+ registers `onWheel` as a passive listener, so `preventDefault()` in the timeline handler logged "Unable to preventDefault inside passive event listener invocation" and could not block page scroll during shift-wheel gestures.

## Fix
- Replace React `onWheel` with a native `wheel` listener on the timeline body via `addEventListener(..., { passive: false })`.
- Type `handleWheel` / `normalizeWheelDelta` against native `WheelEvent`.

## Verification
- `nix develop -c bash -c "cd tellur-live/web && npm run build"`
- Shift+wheel on the timeline: no console warning; pan/zoom still works.