### PR TITLE
fix(live): clear sticky Failed to fetch after reconnect

### DIFF
--- a/tellur-live/web/src/App.tsx
+++ b/tellur-live/web/src/App.tsx
@@ -94,11 +94,21 @@ export function App() {
   const fpsCounterRef = useRef({ frames: 0, last: performance.now() });
   const previewSettingsProjectRef = useRef<string | null>(null);
   const userChangedPreviewSettingsRef = useRef(false);
+  const reconnectInfoRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let source: EventSource | null = null;
+    let polling = false;
+
+    const stopPolling = () => {
+      if (timer != null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      polling = false;
+    };
 
     const applyInfo = (next: ServerInfo) => {
       if (cancelled) return;
@@ -121,21 +131,15 @@ export function App() {
       setLoadError(null);
     };
 
-    const tick = async () => {
-      try {
-        applyInfo(await fetchInfo());
-      } catch (e) {
-        if (!cancelled) setLoadError(String(e));
-      } finally {
-        if (!cancelled) timer = setTimeout(tick, INFO_FALLBACK_POLL_MS);
-      }
-    };
-
-    if ("EventSource" in window) {
+    const connectEvents = () => {
+      if (cancelled || !("EventSource" in window)) return;
+      if (source && source.readyState !== EventSource.CLOSED) return;
+      source?.close();
       source = new EventSource("/api/events");
       source.addEventListener("info", (event: MessageEvent) => {
         try {
           applyInfo(JSON.parse(event.data) as ServerInfo);
+          stopPolling();
         } catch (e) {
           if (!cancelled) setLoadError(String(e));
         }
@@ -144,16 +148,58 @@ export function App() {
         if (cancelled) return;
         source?.close();
         source = null;
-        tick();
+        startPolling();
       };
+    };
+
+    const tick = async () => {
+      if (cancelled) return;
+      polling = true;
+      try {
+        applyInfo(await fetchInfo());
+        if (!cancelled && source == null && "EventSource" in window) {
+          connectEvents();
+        }
+      } catch (e) {
+        if (!cancelled) setLoadError(String(e));
+      } finally {
+        if (!cancelled && polling) {
+          timer = setTimeout(tick, INFO_FALLBACK_POLL_MS);
+        }
+      }
+    };
+
+    const startPolling = () => {
+      if (polling || cancelled) return;
+      stopPolling();
+      void tick();
+    };
+
+    reconnectInfoRef.current = () => {
+      if (cancelled) return;
+      void fetchInfo()
+        .then((next) => {
+          applyInfo(next);
+          if (!cancelled && source == null && "EventSource" in window) {
+            connectEvents();
+          }
+        })
+        .catch((e) => {
+          if (!cancelled) setLoadError(String(e));
+        });
+    };
+
+    if ("EventSource" in window) {
+      connectEvents();
     } else {
-      tick();
+      startPolling();
     }
 
     return () => {
       cancelled = true;
-      if (timer) clearTimeout(timer);
+      stopPolling();
       source?.close();
+      reconnectInfoRef.current = null;
     };
   }, []);
 
@@ -176,6 +222,22 @@ export function App() {
     fps,
     motionBlur,
   });
+
+  useEffect(() => {
+    const recover = () => {
+      reconnectInfoRef.current?.();
+      preview.recoverFromNetwork();
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") recover();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("online", recover);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("online", recover);
+    };
+  }, [preview.recoverFromNetwork]);
 
   useEffect(() => {
     // Only suppress the global shortcuts when focus is in a GENUINE text-entry

--- a/tellur-live/web/src/preview/TimelinePlayer.ts
+++ b/tellur-live/web/src/preview/TimelinePlayer.ts
@@ -254,6 +254,7 @@ export class TimelinePlayer {
 
   seek(seconds: number): void {
     if (this.disposed) return;
+    this.clearError();
     const target = clamp(seconds, 0, this.config.duration);
     this.position = target;
     this.fillGen++;
@@ -319,6 +320,7 @@ export class TimelinePlayer {
   // Must be called inside the user gesture so unmuted playback satisfies autoplay policy.
   play(): void {
     if (this.disposed) return;
+    this.clearError();
     // Apply the user's audio state synchronously within the gesture.
     // React does not re-apply the `muted` attribute after mount, so set the property.
     this.video.muted = this.config.isMuted();
@@ -353,6 +355,17 @@ export class TimelinePlayer {
   setMuted(muted: boolean): void {
     if (this.disposed) return;
     this.video.muted = muted;
+  }
+
+  // Wake / online recovery: drop a hung stream, clear transient errors, and retry fill.
+  recoverFromNetwork(): void {
+    if (this.disposed) return;
+    this.clearError();
+    this.streamBlockedUntil = 0;
+    if (this.inflight) {
+      this.abortInflight();
+    }
+    this.kickFill();
   }
 
   pause(): void {
@@ -735,6 +748,7 @@ export class TimelinePlayer {
       }
       reached = persistedEnd;
       this.streamBlockedUntil = 0;
+      this.clearError();
       const blob = new Blob(inflight.received, { type: "video/mp4" });
       const ok = await this.config.cache.putSegment(
         this.config.groupKey,
@@ -776,6 +790,8 @@ export class TimelinePlayer {
         if (this.appendFailureCount >= APPEND_FAILURES_BEFORE_ERROR) {
           this.events.onError?.(String(e));
         }
+      } else if (isTransientNetworkError(e)) {
+        this.events.onError?.(String(e));
       } else {
         this.events.onError?.(String(e));
       }
@@ -1005,8 +1021,11 @@ export class TimelinePlayer {
   }
 
   private noteAppendSuccess(): void {
-    if (this.appendFailureCount === 0) return;
     this.appendFailureCount = 0;
+    this.clearError();
+  }
+
+  private clearError(): void {
     this.events.onError?.(null);
   }
 
@@ -1560,6 +1579,18 @@ function mergeRanges(ranges: CacheRange[]): CacheRange[] {
 
 function isAbortError(e: unknown): boolean {
   return e instanceof DOMException && e.name === "AbortError";
+}
+
+function isTransientNetworkError(e: unknown): boolean {
+  if (e instanceof TypeError) return true;
+  const message = e instanceof Error ? e.message : String(e);
+  if (/Failed to fetch|NetworkError|Load failed/i.test(message)) return true;
+  const statusMatch = /failed:\s*(\d{3})\b/.exec(message);
+  if (statusMatch) {
+    const status = Number(statusMatch[1]);
+    return status >= 500 && status <= 599;
+  }
+  return false;
 }
 
 class SourceBufferAppendError extends Error {

--- a/tellur-live/web/src/preview/usePreview.ts
+++ b/tellur-live/web/src/preview/usePreview.ts
@@ -36,6 +36,7 @@ export interface PreviewControls {
   toggleMute: () => void;
   stepFrame: (delta: number) => void;
   rewindToStart: () => void;
+  recoverFromNetwork: () => void;
 }
 
 export interface PreviewSettings {
@@ -372,6 +373,10 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
 
   const rewindToStart = useCallback(() => seekTo(0), [seekTo]);
 
+  const recoverFromNetwork = useCallback(() => {
+    playerRef.current?.recoverFromNetwork();
+  }, []);
+
   return {
     state: {
       seconds,
@@ -390,6 +395,7 @@ export function usePreview(settings: PreviewSettings): PreviewControls {
     toggleMute,
     stepFrame,
     rewindToStart,
+    recoverFromNetwork,
   };
 }
 


### PR DESCRIPTION
After sleep or a brief server outage, tellur-live playback could recover
while the preview overlay kept showing `TypeError: Failed to fetch`.
3 files (+114 / -15) in `tellur-live/web`.

## Cause
- `TimelinePlayer.streamSegment` surfaced fetch failures via `onError`,
  but success never called `onError(null)` unless a SourceBuffer append
  had previously failed.
- SSE disconnected permanently after the first error: the client fell
  back to `/api/info` polling and never reopened `/api/events`.
- Wake/online had no hook to retry hung streams or reconnect info.

## Fix
- Clear preview errors on stream success, append success, play/seek,
  and via new `recoverFromNetwork()`.
- Classify transient network errors (`Failed to fetch`, 5xx) separately
  from append/MSE failures.
- Reopen EventSource after a successful poll; stop polling once SSE
  delivers `info` again.
- On `visibilitychange` (visible) and `online`, reconnect info and retry
  the fill loop.

## Verification
- `nix develop -c bash -c "cd tellur-live/web && npm run build"`
- `nix develop -c cargo build -p tellur-live`
- Stop/restart the live server while playing: overlay clears once the
  stream resumes; Header returns to Compiled and SSE reconnects.