### PR TITLE
perf(core): cache font unit metrics instead of reparsing face per call

### DIFF
--- a/.changeset/cache_font_unit_metrics.md
+++ b/.changeset/cache_font_unit_metrics.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+# Cache font unit metrics at construction
+
+`Font::vertical_metrics` reparsed the entire `rustybuzz::Face` on every call, even on shape-cache hits, making text-heavy renders CPU-bound.  
+The metrics are face constants, so they are now read once when the font is constructed and only scaled per call.

--- a/tellur-core/src/text.rs
+++ b/tellur-core/src/text.rs
@@ -139,6 +139,17 @@ pub struct FontMetrics {
     pub line_gap: f32,
 }
 
+/// A font's vertical metrics in design units, read once at construction.
+/// These are face constants (independent of rendering size), so caching
+/// them lets [`Font::vertical_metrics`] scale directly instead of
+/// reparsing the face on every call.
+struct FontUnitMetrics {
+    units_per_em: f32,
+    ascender: f32,
+    descender: f32,
+    line_gap: f32,
+}
+
 /// An owned font, cheaply shareable via `Arc<Font>` across components.
 ///
 /// The byte buffer is reference-counted. Shaping a run — building a
@@ -153,6 +164,7 @@ pub struct FontMetrics {
 pub struct Font {
     data: Arc<Vec<u8>>,
     face_index: u32,
+    unit_metrics: FontUnitMetrics,
     shape_cache: Mutex<LruCache<ShapeKey, Arc<ShapedGlyphs>>>,
 }
 
@@ -172,10 +184,18 @@ impl Font {
         face_index: u32,
     ) -> Result<Self, FontError> {
         let data: Arc<Vec<u8>> = bytes.into();
-        rustybuzz::Face::from_slice(data.as_ref(), face_index).ok_or(FontError::Parse)?;
+        let face =
+            rustybuzz::Face::from_slice(data.as_ref(), face_index).ok_or(FontError::Parse)?;
+        let unit_metrics = FontUnitMetrics {
+            units_per_em: face.units_per_em() as f32,
+            ascender: face.ascender() as f32,
+            descender: face.descender() as f32,
+            line_gap: face.line_gap() as f32,
+        };
         Ok(Self {
             data,
             face_index,
+            unit_metrics,
             shape_cache: Mutex::new(LruCache::new(
                 NonZeroUsize::new(SHAPE_CACHE_CAPACITY).expect("cache capacity is non-zero"),
             )),
@@ -274,14 +294,12 @@ impl Font {
 
     /// This font's vertical metrics at `size`.
     pub fn vertical_metrics(&self, size: f32) -> FontMetrics {
-        let face = self.face();
-        let upem = face.units_per_em() as f32;
-        let scale = size / upem;
-        let ascent = face.ascender() as f32 * scale;
+        let scale = size / self.unit_metrics.units_per_em;
+        let ascent = self.unit_metrics.ascender * scale;
         // `descender` is conventionally negative (below baseline); flip it
         // to a non-negative depth.
-        let descent = -(face.descender() as f32) * scale;
-        let line_gap = face.line_gap() as f32 * scale;
+        let descent = -self.unit_metrics.descender * scale;
+        let line_gap = self.unit_metrics.line_gap * scale;
         FontMetrics {
             ascent: ascent.max(0.0),
             descent: descent.max(0.0),


### PR DESCRIPTION
`Font::vertical_metrics` rebuilt the entire `rustybuzz::Face` — including GSUB/GPOS lookup parsing — on every call, making text-heavy renders CPU-bound with the GPU mostly idle. 2 files (+33 / -7) in `tellur-core` and `.changeset/`.

## Cause
- `TextSpan::shape` calls `Font::vertical_metrics` unconditionally, even on shape-cache hits, and every call ran `rustybuzz::Face::from_slice`.
- Face construction eagerly parses GSUB/GPOS lookups and collects coverage set digests, which costs milliseconds per call on CJK fonts. A perf profile of a 2877-frame export showed ~78% of all CPU cycles under `vertical_metrics`.

## Fix
- Add `FontUnitMetrics` (`units_per_em` / `ascender` / `descender` / `line_gap` in design units), read once in `Font::from_bytes_indexed` from the Face it already builds for validation.
- `vertical_metrics` now scales the stored constants. Behavior is unchanged: these are face constants, and the previous code never applied variations before reading them.

## Verification
- `write-window-verify` (deterministic CPU render, 477 sampled frames): bit-identical output before/after.
- `render-baseline` (GPU export, 2877 frames): build time 193.5s → 40.7s (~4.7×) with identical op and cache counts.