### PR TITLE
chore: release v0.2.1

### DIFF
--- a/.changeset/cache_font_unit_metrics.md
+++ b/.changeset/cache_font_unit_metrics.md
@@ -1,8 +1,0 @@
----
-default: patch
----
-
-# Cache font unit metrics at construction
-
-`Font::vertical_metrics` reparsed the entire `rustybuzz::Face` on every call, even on shape-cache hits, making text-heavy renders CPU-bound.  
-The metrics are face constants, so they are now read once when the font is constructed and only scaled per call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to tellur are documented in this file.
 Versions are lockstep across the workspace.
 
+## 0.2.1 (2026-07-10)
+
+### Fixes
+
+- **Cache font unit metrics at construction**
+
+  `Font::vertical_metrics` reparsed the entire `rustybuzz::Face` on every call, even on shape-cache hits, making text-heavy renders CPU-bound.  
+  The metrics are face constants, so they are now read once when the font is constructed and only scaled per call.
+
+
 ## 0.2.0 (2026-07-09)
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "tellur"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "tellur-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ab_glyph",
  "bon",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "tellur-live"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "lru",
  "png",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "tellur-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2071,14 +2071,14 @@ dependencies = [
 
 [[package]]
 name = "tellur-plugin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "tellur-core",
 ]
 
 [[package]]
 name = "tellur-renderer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytemuck",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["tools/release-notes"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/tellur-core/Cargo.toml
+++ b/tellur-core/Cargo.toml
@@ -39,7 +39,7 @@ rustybuzz = "0.20"
 # full Symphonia feature set so users can import common audio containers/codecs
 # such as WAV/AIFF, FLAC, Ogg/Vorbis, MP3, and MP4 AAC/ALAC.
 symphonia = { version = "0.5.4", default-features = false, features = ["all"] }
-tellur-macros = { path = "../tellur-macros", version = "0.2.0" }
+tellur-macros = { path = "../tellur-macros", version = "0.2.1" }
 thiserror = "2.0.18"
 
 # LaTeX math layout (RaTeX), gated behind the `latex` feature. `ratex-layout`

--- a/tellur-live/Cargo.toml
+++ b/tellur-live/Cargo.toml
@@ -24,9 +24,9 @@ include = [
 [dependencies]
 lru = "0.12.5"
 png = "0.18.1"
-tellur-core = { path = "../tellur-core", version = "0.2.0" }
-tellur-plugin = { path = "../tellur-plugin", version = "0.2.0" }
-tellur-renderer = { path = "../tellur-renderer", version = "0.2.0" }
+tellur-core = { path = "../tellur-core", version = "0.2.1" }
+tellur-plugin = { path = "../tellur-plugin", version = "0.2.1" }
+tellur-renderer = { path = "../tellur-renderer", version = "0.2.1" }
 
 [[example]]
 name = "demo_timeline_plugin"
@@ -41,4 +41,4 @@ name = "timeline_showcase"
 crate-type = ["cdylib"]
 
 [dev-dependencies]
-tellur-plugin = { path = "../tellur-plugin", version = "0.2.0" }
+tellur-plugin = { path = "../tellur-plugin", version = "0.2.1" }

--- a/tellur-plugin/Cargo.toml
+++ b/tellur-plugin/Cargo.toml
@@ -9,4 +9,4 @@ description = "Plugin ABI for loading tellur timelines as dynamic libraries"
 build = "build.rs"
 
 [dependencies]
-tellur-core = { path = "../tellur-core", version = "0.2.0" }
+tellur-core = { path = "../tellur-core", version = "0.2.1" }

--- a/tellur-renderer/Cargo.toml
+++ b/tellur-renderer/Cargo.toml
@@ -36,7 +36,7 @@ lru = "0.12"
 pollster = "0.3"
 rustc-hash = "1.1.0"
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
-tellur-core = { path = "../tellur-core", version = "0.2.0" }
+tellur-core = { path = "../tellur-core", version = "0.2.1" }
 thiserror = "2.0.18"
 tiny-skia = "0.12.0"
 vello = "0.2.1"

--- a/tellur/Cargo.toml
+++ b/tellur/Cargo.toml
@@ -25,10 +25,10 @@ latex = ["tellur-core/latex", "tellur-renderer?/latex"]
 cli = ["dep:clap", "dep:cargo_metadata", "dep:toml_edit", "dep:tellur-live", "renderer"]
 
 [dependencies]
-tellur-core = { path = "../tellur-core", version = "0.2.0" }
-tellur-plugin = { path = "../tellur-plugin", version = "0.2.0" }
-tellur-renderer = { path = "../tellur-renderer", version = "0.2.0", optional = true }
-tellur-live = { path = "../tellur-live", version = "0.2.0", optional = true }
+tellur-core = { path = "../tellur-core", version = "0.2.1" }
+tellur-plugin = { path = "../tellur-plugin", version = "0.2.1" }
+tellur-renderer = { path = "../tellur-renderer", version = "0.2.1", optional = true }
+tellur-live = { path = "../tellur-live", version = "0.2.1", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 cargo_metadata = { version = "0.18", optional = true }
 toml_edit = { version = "0.22", optional = true }


### PR DESCRIPTION
This PR was created by Knope. Merging it will tag `v0.2.1`, create a GitHub Release, and publish all workspace crates to crates.io.

Review the updated `CHANGELOG.md` in this PR for release notes (sections are derived from each changeset's `default` bump).
